### PR TITLE
feat(state): 预订 saga 状态机具名化(booking_saga_fsm.v1,issue #17 采纳)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,9 @@
 **异步终态合同(Issue #19,2026-08-29)**:`gotry_async_terminal.v1` 将 4/4 映射为 `succeeded`/ledger `settled`/exit 0,将非 4/4 映射为 `failed`/ledger `failed`/exit 2;终态复诵返回同一结构化结果与退出码且零重算。
 
 
+**预订 saga 状态机具名化(2026-08-29,issue #17 采纳)**:「多 Agent 协同用 FSM 显式建模」提议的处置——机理全有归宿(共享态/原子更新=账本;检查点=events+fold;防重复副作用=workflow_steps exactly-once+idem_key;HITL=pending 持久挂起+ApprovalSeam),LangGraph 编排不引入;本次落地**词汇层** `ts/src/booking-saga.ts`(booking_saga_fsm.v1,纯函数):状态字母表与 pending_writes CHECK 逐字一致、四条边全函数边表(12 格含结构化拒绝闭集,吸收态无出边)、审计链校验器(合法路径四条/空 receipt 抓出),run-all §36 物理对账 25 断言锁定「词汇层=账本 saga 基座语义,分叉即红」。ADR-17 三口径:①企业审批=pending 持久挂起+外部事件沿边恢复,复用 ApprovalSeam;②合规检查恒为 deterministic-edge(Z3 命名约束/unsat core),永不做成 LLM Agent 节点;③M5 启封增量(空 receipt 物理 CHECK/booking seam 词汇/L2 L4 接线)仍是 M5 Entry 交付物(M4 exit + 供应链协议开闸),本词汇层不构成里程碑证据。设计文档 `booking-saga-fsm.md`。
+
+
 **产物面最小切片(Issue #25,2026-08-29)**:`gotry_artifacts_list/read`(第 19/20 工具)——账本 workflow_runs 交付 + dsh 工作目录顶层 md 在 dsh 内可发现、可读(dsh read 卡行号文件视图,工单 id 直读 + offset/limit 翻页);只读能力层 `capabilities/artifacts.ts`(路径白名单 = stateRoot+工作目录、排除 node_modules/.git;扩展名白名单 = 文本类),smoke §13。面板第二切片(同日,founder 指令「看 dsh-market 成熟组件」):自建零依赖 webui 因 UI 品质不达产品级撤回,改走宿主组件 **dsh-better-sidebar**(dshmarket.com #1 UI,18.9 万周装,v0.17.1 双形态兼容)——`gotry setup` 宿主层安装(dsh plugin → ~/.dsh/profiles/web,不进 gotry 依赖),dsh web 右侧工作台(文件树/Markdown/Mermaid/PDF 预览)直接浏览工作区产物;账本感知产物 Tab(better-sidebar registerTab,需 client-half 插件面)列下一阶段。
 
 ## 2. 总体架构:五层与现状
@@ -80,7 +83,8 @@ L5 治理:loopx(objective/gate/evidence/quota,验证后才花费)
 | `ts/capabilities/flyai.ts` | **FlyAI 官方通道**:飞猪 8 只读工具的管道层(search-flight/train 先接),证据链 `[实时API:flyai@ts]` | ✅ run-all §24-F |
 | `ts/capabilities/session-search.ts` + `session/` | **会话检索面**(RFC P1):transport(puppeteer-core 专用 profile)/ReadGuard(写请求物理拦截+审计,fail-closed)/携程机票适配器(batchSearch 嗅探)/action-cache 自愈层(变量化key+指纹被动失效+miss回写);节律闸;`[会话:*]` 证据链 | ✅ run-all §24/§25 |
 | `ts/capabilities/artifacts.ts` | **产物面**(issue #25 最小切片):产物发现(账本 workflow_runs 权威 + 无账本回退 async 目录视图 + dsh 工作目录顶层 md)+ 行号窗口读取(dsh read 卡);只读,路径/扩展名白名单 | ✅ smoke §13 |
-| `ts/src/state-ledger.ts` | **事务化状态账本**(ADR-15):SQLite 单文件唯一权威(events append-only+语义幂等键/投影表 fold 可重建/workflow_steps durable 工单/pending_writes saga);`gotry_async_terminal.v1` 固化 4/4/非 4/4 终态、退出码与零重算复诵;守门纯函数复用为写路径与 fold 处理器;读路径带旧文件回退;首写自动 one-shot 迁移+快照 | ✅ run-all §28 |
+| `ts/src/state-ledger.ts` | **事务化状态账本**(ADR-15):SQLite 单文件唯一权威(events append-only+语义幂等键/投影表 fold 可重建/workflow_steps durable 工单/pending_writes saga)；`gotry_async_terminal.v1` 固化 4/4/非 4/4 终态、退出码与零重算复诵;守门纯函数复用为写路径与 fold 处理器;读路径带旧文件回退;首写自动 one-shot 迁移+快照 | ✅ run-all §28 |
+| `ts/src/booking-saga.ts` `ts/scripts/booking-saga-tests.ts` | **预订 saga 状态机词汇层**(booking_saga_fsm.v1,issue #17 采纳/ADR-17):状态字母表+四条边全函数边表+结构化拒绝闭集+审计链校验;§36 与账本 saga 基座逐格物理对账 | ✅ run-all §36(纯函数,零写路径接线) |
 | `ts/scripts/state-cli.ts` | **账本操作面**(ADR-15):migrate/export(视图单向)/log/stats/rebuild/rewind/forget(物理硬删带审计)/tick(回收 pending 工单)/whatif(VACUUM INTO 分叉)/pw-*(WriteGate saga CLI 面) | ✅ run-all §29 |
 | `ts/scripts/product-metrics.ts` `ts/data/product-metrics-fixture.json` + `ts/scripts/nightly-evidence.ts` `ts/data/m3-nightly-prompts.json` `ts/data/llm-price-table.json` | **M3 cohort 证据评分面 + nightly 证据生产器(Issue #22)**:阈值冻结 manifest + 脱敏 cohort/nightly schema + 定稿率/NPS/POI 幻觉率 scorer；fixture 与真实证据分流，未知字段 fail-closed；nightly 生产器封存 prompt 集与价表(peak 保守上界,未知模型 fail-closed)、无凭证 waiting/backoff/no-spend、超预算退 3,记录写入前必过消费方 parseNightlyRun | ✅ run-all §33/§35；真实 cohort 待收集,nightly 真跑记录待凭证环境执行 |
 | `ts/scripts/time-eval-tests.ts` `data/time-slot-eval.json` | 时间感评测(25 题):确定性部分进 CI,`--real` 真模型巡检(只读报告) | ✅ 真模型 25/25 |
@@ -142,6 +146,7 @@ Option      = { id, move(services×transfers×缓冲×红眼×tz), stay?(晚数/
 | 14 | 记忆效用 sidecar(RFC S2/S3,post-outcome-memory 映射):recalled/applied/verified_outcome 三类事件 append-only(`gotry-state/memory-utility.jsonl`),归因只认 owner 确认(attribution 只能在 confirm-outcome 由用户明说落盘,模型不许自评「有用」);wish 稳定 `wish_id` + muted(休眠不删除);召回 0..1/轮(`gotry_wish_pool_list` 条件评分,muted 永不召回,无命中不硬推)——M4 北极星「下一次出发率」的度量底座 | 召回即记「有用」(自称用了≠让结果变好)/wish 删除制(憧憬不被拒绝) | 多用户 AaaS 账本化(RFC §6.5)或出现第二个效用消费方时复审 | `memory-utility.ts`;`index.ts gotry_wish_pool_list`;smoke §10 |
 | 15 | 事务化状态基座(RFC `transactional-state-rfc`,业界 durable-execution 五件套收敛):单文件 SQLite 账本(better-sqlite3,WAL)= 唯一权威——events append-only(语义幂等键 UNIQUE 物理化,wish_id 语义派生)+ 投影表 fold 可重建(纯函数守门原样复用,语义层零改造)+ 红线进事务(evidence/conditions 拒绝即回滚)+ durable 工单(workflow_steps intent-before-execute,崩溃恢复 exactly-once)+ pending_writes saga(WriteGate L2/L3 基座:幂等键/receipt/补偿)+ what-if 分叉(VACUUM INTO);旧 JSON/JSONL 降级单向导出视图(红线 6);one-shot 迁移(首写自动+快照 `pre-ledger-backup/`) | Postgres/DBOS/Temporal/Restate 平台(单用户本地产品不需要服务端;SQLite durable 学派「一文件即控制面」)/纯文件加固 tmp+rename(修不了跨文件分叉与并发)/node:sqlite(零依赖但较新,D1 落选备选) | 多用户 AaaS 化(RFC §6.5 claim/CAS 实装)或需要多写者/多端复制(cr-sqlite/Litestream,触发式=D-15)时复审 | `state-ledger.ts`;run-all §28/§29 |
 | 16 | 双形态架构冻结(本地+Web,通用 agent 产品形态):**一套账本语义,两种宿主绑定**——本地=better-sqlite3 直读文件,Web=同一 schema 跑在每用户 SQLite 文件(或 Postgres,schema 同构);**tenant_id 从第一天就是一等字段**(events/投影/工单/pending_writes 全部带租户列,单用户期恒为 `'local'`,主键空间化防跨用户撞);**同步=账本事件的复制而非状态的翻译**(events 行带 tenant_id+幂等键,双端合并天然幂等);写必经账本、读必带租户上下文进不变量表 | 本地与 Web 各长一套逻辑(多用户期合并不动,推倒重来)/云端为权威本地为缓存(违反红线 6 本地优先)/同步投影而非事件(投影是派生态,合并会分叉) | 永不复审(双形态是产品形态基座);同步协议实装(Litestream/cr-sqlite/自建 API)与 claim/CAS 实装仍按触发器后置 | `state-ledger.ts` schema v2;run-all §28 双形态断言 |
+| 17 | 预订 saga 状态机具名化(issue #17 采纳,2026-08-29):预订/支付/退改的 saga **不引入编排框架(LangGraph 等)**,FSM 落为账本 pending_writes 的具名字母表+四条边全函数边表(`booking_saga_fsm.v1`,纯函数零接线);三种边型入词汇——deterministic-edge(合规/政策判定恒为代码层 Z3 命名约束/unsat core,永不做成 LLM Agent 节点)/gate-edge(用户选择题)/external-event-edge(HITL 审批=pending 持久挂起+外部账本事件恢复,复用 ApprovalSeam);M5 Entry 后任何 booking seam 只许走该边表 | LangGraph/Temporal 式 FSM 框架(第二运行时,违反 harness 基线与复用矩阵)/状态散落 SQL 字符串(边语义漂移无词表)/多 Agent 提示词协同(隐式依赖,ADR-9/10 教训) | M5 拍板 WriteGate 时复审(启封增量的 schema CHECK/seam 词汇/L4 自动类);若出现需要并行多写者的预订流,复审 keyed 单写者形态 | `ts/src/booking-saga.ts`;`docs/booking-saga-fsm.md`;run-all §36 |
 
 ## 9. 演进(时间线唯一来源= `roadmap.md` 的 M0-M6;此处只保留原则与现状)
 
@@ -160,6 +165,8 @@ Option      = { id, move(services×transfers×缓冲×红眼×tz), stay?(晚数/
 - **dsh runtime 跟进上游 alpha.1(2026-08-29,issue #15)**:上游 `dsh-v0.1.2-alpha.1` 只挂 GitHub 不发 npm(rc.2 后 1079 commits),「等 publish」改「源码跟进」——vendored runtime 换装 alpha.1 全量 241 包 tarball 解包(`vendor/` + pnpm workspace),免等上游发版;npm 公共面仍 rc.2,上游 publish 后可整体回到 npm 依赖形态。详见 §1 尾注与 `vendor/README.md`。
 
 - **OTA 平铺 + 账号授权闸(2026-08-29 第二批,founder 口径「OTA 这些都是工具,不要区分主路径/降级路径;用用户账号必须跟用户确认」)**:①酒店接入官方只读通道——flyai `search-hotel` 实测(大理:结构化 name/star/打码价 ¥7xx/detailUrl;解析契约 `FlyaiHotelOption`,打码价保 priceRaw 原值、数字价恒 0,防「¥7xx 截成 7 伪装真价」),`gotry_flyai_search` kind=flight|train|hotel 三形态,参数闸 per-kind;②OTA 工具面平铺——工具描述与 persona (19) 去「主链路/交叉验证/三级路由」层级话术(数据层 L4 证据链逐源标注照旧,拍平的是路由优先级不是标注纪律);③账号授权闸(v2,当日二迭代):`session-consent.ts` 挂 `tools/pre-execute`,**每会话每站点首次调用**弹审批卡→会话内记住,**拒绝=本会话吊销**(不再弹卡不再执行;首版逐次弹卡被 founder 实测否决——「每次都要弹,经常无法点击」),sessionAccess `ask|allow|off` 三态,无审批通道/headless fail-closed;授权状态存 Weak<agent> 绝不跨会话延续;④**登录态 seam 落地**:`scripts/session-login.ts`(cdp attach→开登录入口→人登录→只读轮询票据名)替代「跑脚本」空指引;⑤测试纪律:session-tests live 节默认 SKIP,`GOTRY_SESSION_LIVE=1` 显式开启——**例行回归永不自动开用户浏览器窗口**。run-all §24(session-tests §H/§I)+ smoke §12-13;全栈回归全绿。
+
+- **预订 saga 状态机具名化(2026-08-29 第二批,issue #17 采纳)**:针对「多 Agent 协同用 FSM 显式建模副作用传递」提议,逐机理勾稽(共享态/检查点/防重复副作用/HITL 在账本与 durable 工单已物理存在)后,落地词汇层 `booking-saga.ts` + 设计文档 `booking-saga-fsm.md` + ADR-17;LangGraph 编排不引入,合规恒为 deterministic-edge,HITL 审批 = pending 挂起 + 外部事件恢复;run-all §36 物理对账 25 断言。
 
 - **产物面(2026-08-29,issue #25,两步)**:①dsh 内查看——`gotry_artifacts_list/read` 把账本工单交付与工作目录 md 变为可发现、可读对象(read 卡);②成熟面板——dsh-market 调研(dshmarket.com,2495 插件)选型 **dsh-better-sidebar**(★3083/18.9 万周装,#1 UI 组件;自建零依赖 webui 因品质不达产品级当日撤回),`gotry setup` 宿主层安装(GOTRY_SETUP_SIDEBAR=0 可跳,幂等/失败降级路①),dsh web 侧栏工作台浏览+渲染工作区产物;产物 Tab(registerTab client-half)为下一阶段。
 
@@ -191,6 +198,7 @@ Option      = { id, move(services×transfers×缓冲×红眼×tz), stay?(晚数/
 | D-19 M4 真实 repeat cohort 缺口 | **证据合同已落地 2026-08-29**:Issue #20 fixture scorer 固定 paired/active-planning/reflux/溯源/P4 口径,synthetic fixture 不得充当 Exit。赎回条件=私有 `observed_private` cohort 达 N≥5 并产出脱敏 summary;无真实样本时 waiting/backoff/no-spend,不扩 schema 假装进展。 |
 | D-20 六状态面里程碑口径漂移 | **已清偿 2026-08-29(Issue #19)**:六状态面统一为「M3 真实 evidence 未收口；M4 为 founder 授权并行，不是 M3 Exit 证明；M5/M6 仅受各自 Entry gate 开闸」。后续不得把工程交付、发布或并行切片等同于里程碑退出证据。 |
 | D-21 async 非 4/4 被误结算为成功 | **已清偿 2026-08-29(Issue #19)**:`collectDeepPlanning` 产出 `gotry_async_terminal.v1`；collector 仅在 4/4 时写 `succeeded`/ledger `settled`/exit 0，任一未达写 `failed`/ledger `failed`/exit 2；账本保存结构化结果，终态复诵零重算且保持同一退出码。隔离 `stateRoot` 回归见 run-all §28。 |
+| D-22 pending_writes 空 receipt 无物理 CHECK(booking_saga_fsm.v1 已知边界) | 词汇层审计链已兜住(`sagaTraceViolations` 对空 receipt 报违例,run-all §36);**赎回时机 = M5 Entry 拍板**:pending_writes 随 schema 升版加 `receipt 非空 CHECK` + 具名 seam 词汇冻结(`booking-saga-fsm.md` §4),未到 M5 Entry 不动写路径 |
 
 ## 11. 保鲜机制(文档与现实的同步纪律)
 
@@ -228,3 +236,4 @@ Option      = { id, move(services×transfers×缓冲×红眼×tz), stay?(晚数/
 | `memory-design.md` | **记忆域设计**:C 端六层重设计(M1-M6 现状映射/P1-P4 分期增量/铁律与验收),M4 交付「六层框架重设计」的正式文档 |
 | `loopx-inspired-upgrades-rfc.md` | **RFC(accepted 2026-08-27)**:loopx 13 篇架构 RFC 的映射升级——四道接缝(S1 工具 packet 纪律/S2 记忆效用 sidecar/S3 wish 触达 0..1 纪律/S4 WriteGate L0-L4 词汇) |
 | `transactional-state-rfc.md` | **RFC(accepted 2026-08-28,ADR-15)**:事务化状态基座——业界 durable-execution 调研收敛五件套 + GoTry 落地架构 + TS-0..TS-5 执行计划与决策记录(D1-D5) |
+| `booking-saga-fsm.md` | **预订 saga 状态机设计(issue #17 采纳,ADR-17)**:booking_saga_fsm.v1 字母表/边表/拒绝闭集 + 三种边型词汇(deterministic/gate/external-event)+ HITL 审批的挂起-恢复形态 + M5 启封增量与不引入编排框架的判定记录 |

--- a/docs/booking-saga-fsm.md
+++ b/docs/booking-saga-fsm.md
@@ -1,0 +1,81 @@
+# 预订 saga 状态机(booking_saga_fsm.v1)——issue #17 采纳面的设计正式化
+
+> 状态:**accepted**(2026-08-29 founder 指令「现在就推进」,对 issue #17 评估中「真正值取的三点」的执行)
+> 上游权威:`architecture.md`(技术权威面/ADR-15/ADR-16/ADR-17)、`transactional-state-rfc.md`(§4.3 WriteGate 基座)、`gotry-master-outline.md` §2(复用矩阵)、`roadmap.md`(M5 Entry gate)
+> 执行锚点:`ts/src/booking-saga.ts`(纯函数词汇层)+ `ts/scripts/booking-saga-tests.ts`(run-all §36,25 断言)
+> 纪律:单一文件承载单一关注点;版本历史归 git;**本交付是 M5 的设计基座具名化,不是交易闭环的实现,不构成 M3/M5 Exit 证据**(D-20 纪律)
+
+## 0. 一句话主张
+
+M5 的预订/支付/退改**不需要引入编排框架**(LangGraph/Temporal 类):预订流程状态机在 TS-4 事务化基座里**已经物理存在**——`pending_writes` 的三态 CHECK + 幂等键 + saga 三方法就是它。issue #17 提议的三个机理全部有既有归宿,欠缺的只是「具名」:本设计把状态、边、事件、拒绝理由收敛为一个显式词汇层(`booking-saga.ts`),并约定 M5 启封时任何 booking seam 只许走这张边表。
+
+## 1. 状态字母表与边表(代码即权威:`ts/src/booking-saga.ts`)
+
+- **状态字母表**(与 `state-ledger.ts` pending_writes.status CHECK 逐字一致):`pending | confirmed | compensated`;补 `none`(∅,主体未登记)为起点。
+- **触发器**:`propose`(L2,只登记不执行)/ `confirm`(L3 具名 seam 确认,携 receipt)/ `compensate`(saga 补偿)。
+- **边表**(全函数,12 格 = 4 边 + 8 拒,无空洞无第三态):
+
+```
+∅ --propose--> pending --confirm--> confirmed
+                  │                    │
+                  └---- compensate ----┴--> compensated   (吸收态,无出边)
+```
+
+| from | trigger | to | 账本事件 | 守卫 |
+|---|---|---|---|---|
+| none | propose | pending | `write.pending` | L2 只登记不执行;idem_key UNIQUE,重复提议 = no-op |
+| pending | confirm | confirmed | `write.confirmed` | L3 具名 seam 确认,必携 receipt;已确认不可再确认 |
+| pending | compensate | compensated | `write.compensated` | 外部写未发生,取消即终态(零补偿动作) |
+| confirmed | compensate | compensated | `write.compensated` | 已发生副作用的 saga 补偿(退改),receipt 保留(COALESCE) |
+
+拒绝理由闭集:`missing-subject / idem-exists / already-confirmed / absorbed-compensated / already-compensated`——结构化拒绝,**拒绝即不动**(与账本 `changes=0` 同义)。compensated 为吸收态;receipt 在 confirmed 后不可变;幂等键保证「同一预订确认不可能下两次」。
+
+- **审计链**(`sagaTraceViolations`):单 idem_key 的 `write.*` 事件序列必须恰好走出边表的一条合法路径;`write.confirmed` 空 receipt 即违例。词汇层校验物理账本的真实事件流——**词汇层与账本不分叉,分叉即回归红**(§36 物理对账 25 断言)。
+- **已知边界(诚实面)**:账本物理层暂不挡空 receipt(词汇层审计已兜住);物理 CHECK 随 M5 拍板入 schema。
+
+## 2. 边型词汇(把 issue #17 的「边」落成 GoTry 词汇)
+
+多 Agent 流程图里的「边」,在 GoTry 里只有三种,全部有现有承载:
+
+| 边型 | 语义 | 现有承载 | 例 |
+|---|---|---|---|
+| **deterministic-edge** | 代码层判定,无 LLM 参与 | Z3 命名约束 + unsat core(`unified.ts`);gate 守卫;validateSpec 闸 | 合规检查(差标/工作窗口/红眼)= 求解前确定性排除,violation 带理由入 exclusions——**violation 的候选不给下游**,比「合规 Agent 返回布尔再路由」更强 |
+| **gate-edge** | 用户决策点,唯一交互形态 | L1 gates 消息内选择题(D1 契约;`loop.ts`) | 「加 ¥300 升舱吗」式 trade-off 选择 |
+| **external-event-edge** | 外部世界事件恢复流程(审批/回票/超时) | durable 工单(`workflow_steps` 挂起恢复)+ pending_writes saga + ApprovalSeam(`session-consent.ts`,已在生产) | 主管审批结果 = 一次账本事件,pending → confirmed/compensated |
+
+**推论(HITL 不需要新框架)**:「等待审批 24h」不是 pause/resume 机制,而是 **pending 状态的持久挂起**——账本即挂起态,进程可死可重启(ADR-15 崩溃安全),外部事件到达即沿边恢复;审批通道复用 dsh ApprovalSeam(会话闸已是生产形态,headless fail-closed)。
+
+## 3. issue #17 三机理的归宿(映射表)
+
+| issue #17 提议 | 归宿 | 状态 |
+|---|---|---|
+| 共享 State + 原子更新 | 账本单事务(events+投影同生) | ✅ ADR-15 |
+| Checkpointers | events append-only + 投影 fold 重建 | ✅ |
+| 长事务跨重启、防重复副作用 | workflow_steps exactly-once + `gotry_async_terminal.v1` + idem_key UNIQUE | ✅(D-21) |
+| HITL 暂停-恢复 | durable 工单挂起恢复 + ApprovalSeam 审批卡 | ✅ 生产中(会话闸);企业审批为 M5 的 seam 接线 |
+| 合规 Agent 条件边 | **deterministic-edge**:Z3 命名约束/unsat core,合规永不做成 LLM Agent 节点 | ✅ 已是架构纪律(不变量表 L2「LLM 不做算术判定」) |
+| 状态机显式化(StateGraph 形态) | `booking_saga_fsm.v1`:字母表+边表+解析器+审计链校验,纯函数 | ✅ 本次落地 |
+| LangGraph 框架引入 | 拒绝(ADR-4 被拒备选=自研状态机控制平面;复用矩阵外;RFC(transactional-state)§2.1 已扫) | 不采纳 |
+
+## 4. M5 启封增量(触发 = M5 Entry:M4 exit + 供应链协议;未触发前零实现)
+
+1. booking seam 落地:具名 seam 登记词汇 `<domain>-<action>-confirm`(如 `flight-order-confirm`;词汇表 M5 拍板冻结);
+2. 空 receipt 物理闸:pending_writes 加 `receipt 非空(CHECK)`,随 schema 升版;
+3. L2/L4 接线:建议态(只登记)与自动类(L4)的授权词汇按 RFC(loopx)S4 分级,每级可回滚;
+4. 审批等待状态:企业审批(外部事件)若需跨会话可见,扩 `waiting-approval` no-spend 词汇(session-double-source 系 waiting-* 同族,不花费)。
+
+**以上任何一项落地都改变系统形态,须走状态面六处同步 + 全栈回归;它们是 M5 的交付物,不是本文的兑现**。
+
+## 5. 明确不做(边界)
+
+- 不引入 LangGraph/Temporal/编排框架或任何新运行时(ADR-4 / 总纲刚性约束 1 / RFC §1.3);
+- 不动 dsh harness 会话层、不新增 Python 面;
+- 合规/政策检查**永不做成 LLM Agent 节点**(确定性归代码,violation 必须带 unsat core 或规则理由);
+- 本状态机不含业务预订流程图(段序/审批人路由等)——那是 M5 交付时的 seam 设计,字母表只管 saga 状态推进。
+
+## 6. 判定记录(为何此形态而非 LangGraph 形态)
+
+1. ADR-4 的被拒备选即「自研状态机」控制平面——本状态机是**账本 saga 的词汇层**,不是控制平面,不动 L2 编排(loop.ts/dsh);
+2. 复用矩阵:LangGraph 不在矩阵;引入外部编排框架先修总纲;
+3. M5 Entry gate(M4 exit + 供应链协议)未开,交易闭环不做倒推实现(D-20);
+4. 决定性机理(挂起恢复/幂等/补偿/审计)单 SQLite 账本已物理完备(RFC transactional-state §2/§4),LangGraph checkpointer 是同一学派的服务端形态。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,7 +77,7 @@ rc 序列总览(细节见 release-notes.md,版本历史归 git):
 - **Exit**:回访用户规划时长较首访降 ≥50%;经验回流率有基线。
 
 ### M5:交易闭环
-- **Entry**:M4 exit + 供应链协议。**交付**:WriteGate 生产化——写权按 L0-L4 渐进授权(L2 建议/L3 具名 seam 确认带 receipt/L4 自动类),每级可回滚(RFC S4);预订/支付/退改;佣金披露(红线随行)。
+- **Entry**:M4 exit + 供应链协议。**交付**:WriteGate 生产化——写权按 L0-L4 渐进授权(L2 建议/L3 具名 seam 确认带 receipt/L4 自动类),每级可回滚(RFC S4);预订/支付/退改;佣金披露(红线随行)。**设计基座已备(2026-08-29,issue #17 采纳/ADR-17)**:预订 saga 状态机词汇层(`booking_saga_fsm.v1`,`ts/src/booking-saga.ts` + `docs/booking-saga-fsm.md`)——字母表/四条边全函数边表/拒绝闭集/审计链校验,run-all §36 与账本物理对账;启封时任何 booking seam 只许走该边表;空 receipt 物理 CHECK、seam 命名词汇、L2/L4 接线与审批等待态为 M5 交付物。
 - **Exit**:预订零误操作事故;单位经济实测(对齐 D1 §8)。
 
 ### M6:B2B 包裹

--- a/docs/transactional-state-rfc.md
+++ b/docs/transactional-state-rfc.md
@@ -126,6 +126,7 @@ async-collect 从「读 JSON 工单」升级为「恢复一个 journaled run」;
 - `idem_key` 唯一 = 「同一预订确认不可能下两次」的物理保证(产品红线:三步确认+幂等键)。
 - what-if 预演 = 复制 DB(`VACUUM INTO`)后在副本上 fold,确认后才在正本走 saga——LoopX「先只读投影后执行」的物理化。
 - ReadGuard 维持现状:检索态物理只读,与 pending_writes 互不相交。
+- **增补(2026-08-29,issue #17 采纳/ADR-17)**:saga 状态推进词汇已显式化为 `booking_saga_fsm.v1`(`ts/src/booking-saga.ts` + `docs/booking-saga-fsm.md`;run-all §36 物理对账)——M5 启封时 booking seam 只许走该边表;已知边界「空 receipt 无物理 CHECK」= D-22。
 
 ### 4.4 选型
 

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -309,6 +309,10 @@ else
 fi
 
 echo
+echo "=== 36. 预订 saga 状态机(booking_saga_fsm.v1,issue #17 采纳:字母表/边表封闭性 + 主路径/吸收态 + 审计链校验 + 与账本 saga 基座物理对账/多租户,纯函数) ==="
+(cd ts && npx tsx scripts/booking-saga-tests.ts | tail -1) || FAIL=1
+
+echo
 if [ "$FAIL" -ne 0 ]; then
   echo "REGRESSION FAILED"
   exit 1

--- a/ts/scripts/booking-saga-tests.ts
+++ b/ts/scripts/booking-saga-tests.ts
@@ -1,0 +1,148 @@
+/**
+ * 预订 saga 状态机回归(booking_saga_fsm.v1,issue #17 采纳锚点,run-all §36):
+ *  1 字母表/边表封闭性:12 个 (origin,trigger) 组合恰好一边或一拒,无空洞无重复;事件命名收敛
+ *  2 触发解析:主路径可达;二次确认与吸收态推进结构化拒绝;解析器与边表/拒绝表十二格全一致
+ *  3 审计链校验器:合法路径零违例;缺起点/双确认/补偿后再推进/空 receipt 均被抓出
+ *  4 物理对账:真账本(pending_writes 行 + write.* 审计事件)与状态机逐格同归宿——
+ *    状态机不是新机器,是 TS-4 saga 基座的具名化(词汇层与物理层分叉即本节红)
+ *  5 多租户:saga 键以 tenant_id 为一等字段,跨租户互不可见(ADR-16)
+ * 运行(在 ts/ 下):npx tsx scripts/booking-saga-tests.ts
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  BOOKING_SAGA_SCHEMA,
+  SAGA_EDGES,
+  SAGA_REJECTIONS,
+  SAGA_STATUSES,
+  SAGA_TRIGGER_EVENT,
+  resolveSagaTrigger,
+  sagaLegalPaths,
+  sagaTraceViolations,
+  type SagaAuditEvent,
+} from '../src/booking-saga.ts'
+import { ensureLedger, type StateLedger } from '../src/state-ledger.ts'
+
+let pass = 0
+let fail = 0
+function assert(cond: boolean, msg: string): void {
+  if (cond) {
+    pass++
+    console.log(`  ok - ${msg}`)
+  } else {
+    fail++
+    console.error(`  FAIL - ${msg}`)
+  }
+}
+
+function parseReceipt(payload: string): string | undefined {
+  try {
+    const doc = JSON.parse(payload) as { receipt?: unknown }
+    return typeof doc.receipt === 'string' && doc.receipt !== '' ? doc.receipt : undefined
+  } catch {
+    return undefined
+  }
+}
+
+// ---- 1:字母表与边表封闭性 --------------------------------------------------------
+
+const TRIGGERS = ['propose', 'confirm', 'compensate'] as const
+const ORIGINS = ['none', ...SAGA_STATUSES] as const
+const COMBOS = ORIGINS.flatMap(from => TRIGGERS.map(trigger => `${from}:${trigger}` as const))
+const edgeKeys = new Set(SAGA_EDGES.map(e => `${e.from}:${e.trigger}` as const))
+const rejectKeys = new Set(SAGA_REJECTIONS.map(e => `${e.from}:${e.trigger}` as const))
+
+assert(BOOKING_SAGA_SCHEMA === 'booking_saga_fsm.v1' && SAGA_STATUSES.join(',') === 'pending,confirmed,compensated', 'schema 词唯一;状态字母表与 pending_writes CHECK 逐字一致')
+assert(COMBOS.length === 12 && new Set(COMBOS).size === 12 && edgeKeys.size === SAGA_EDGES.length && rejectKeys.size === SAGA_REJECTIONS.length, '12 个 (origin,trigger) 组合;边表与拒绝表内部无重复')
+assert(COMBOS.every(k => edgeKeys.has(k) !== rejectKeys.has(k)), '每格恰为一条合法边或一条结构化拒绝(全函数,无空洞无第三态)')
+assert(SAGA_EDGES.every(e => (SAGA_STATUSES as readonly string[]).includes(e.to) && e.event === SAGA_TRIGGER_EVENT[e.trigger] && e.guard.length > 0), '合法边:终点在字母表内、事件 kind 与触发器一一对应、守卫语义齐全')
+
+const allConsistent = ORIGINS.every(from => TRIGGERS.every(trigger => {
+  const v = resolveSagaTrigger(from, trigger)
+  const edge = SAGA_EDGES.find(e => e.from === from && e.trigger === trigger)
+  if (edge) return v.ok && v.to === edge.to && v.event === edge.event
+  return !v.ok && v.reason === SAGA_REJECTIONS.find(x => x.from === from && x.trigger === trigger)!.reason
+}))
+assert(allConsistent, 'resolveSagaTrigger 十二格与边表/拒绝表全一致(解析器无平行第二逻辑)')
+
+// ---- 2:主路径、吸收态与审计链校验(纯函数) --------------------------------------
+
+{
+  const vProp = resolveSagaTrigger('none', 'propose')
+  const vConf = resolveSagaTrigger('pending', 'confirm')
+  const vComp = resolveSagaTrigger('confirmed', 'compensate')
+  assert(vProp.ok && vProp.to === 'pending' && vConf.ok && vConf.to === 'confirmed' && vComp.ok && vComp.to === 'compensated', '主路径 ∅→pending→confirmed→compensated 连通(L2 登记只不执行 / L3 确认携 receipt / saga 补偿)')
+  const vDouble = resolveSagaTrigger('confirmed', 'confirm')
+  assert(!vDouble.ok && vDouble.reason === 'already-confirmed', '二次确认结构化拒绝(already-confirmed)')
+  const vIdem = resolveSagaTrigger('compensated', 'propose')
+  const vRevive = resolveSagaTrigger('compensated', 'confirm')
+  const vReComp = resolveSagaTrigger('compensated', 'compensate')
+  assert(!vIdem.ok && vIdem.reason === 'idem-exists' && !vRevive.ok && vRevive.reason === 'absorbed-compensated' && !vReComp.ok && vReComp.reason === 'already-compensated', 'compensated 吸收态:propose=幂等存在,confirm/compensate 拒绝(无复活路径)')
+
+  assert(sagaLegalPaths().length === 4, '合法路径恰四条(主路径及其真前缀)')
+  const legalClean = sagaLegalPaths().every(path => {
+    const events: SagaAuditEvent[] = path.map((trigger, i) => ({ seq: i + 1, kind: SAGA_TRIGGER_EVENT[trigger], receipt: trigger === 'confirm' ? 'PNR-X' : undefined }))
+    return sagaTraceViolations(events).length === 0
+  })
+  assert(legalClean, '四条合法路径的审计链均零违例')
+  const flagOf = (events: SagaAuditEvent[]): string | undefined => sagaTraceViolations(events)[0]
+  assert(flagOf([{ kind: 'write.confirmed', receipt: 'PNR-A' }]) !== undefined, '缺 pending 起点的 confirm 被审计链抓出')
+  assert(flagOf([{ kind: 'write.pending' }, { kind: 'write.confirmed', receipt: 'PNR-A' }, { kind: 'write.confirmed', receipt: 'PNR-B' }]) !== undefined, '双确认被审计链抓出(每键至多确认一次)')
+  assert(flagOf([{ kind: 'write.pending' }, { kind: 'write.compensated' }, { kind: 'write.confirmed', receipt: 'X' }]) !== undefined, 'compensated 之后不得再有 saga 事件(吸收态)')
+  assert((flagOf([{ kind: 'write.pending' }, { kind: 'write.confirmed' }]) ?? '').includes('receipt'), 'write.confirmed 空 receipt 被抓(L3 必携外部回执)')
+}
+
+// ---- 3:物理对账(状态机 = 账本 saga 基座的词汇层,分叉即红) ---------------------
+
+const root = mkdtempSync(join(tmpdir(), 'gotry-booking-saga-'))
+try {
+  const ledger = ensureLedger(root)
+  const sagaEventsOf = (l: StateLedger, key: string): SagaAuditEvent[] => {
+    const rows = l.db.prepare(`SELECT seq, kind, payload FROM events WHERE tenant_id = ? AND subject_id = ? AND kind IN ('write.pending','write.confirmed','write.compensated') ORDER BY seq`).all(l.tenant, key) as Array<{ seq: number; kind: string; payload: string }>
+    return rows.map(r => ({ seq: r.seq, kind: r.kind, receipt: parseReceipt(r.payload) }))
+  }
+
+  const K1 = 'booking:K1'
+  const proposed = ledger.requestPendingWrite({ idemKey: K1, seam: 'flight-order-confirm', payload: { flight: 'MU123' } })
+  assert(proposed.created === true && proposed.status === 'pending' && resolveSagaTrigger('none', 'propose').to === 'pending', '物理提议 ∅→pending 与状态机同归宿(L2 只登记不执行)')
+
+  const dup = ledger.requestPendingWrite({ idemKey: K1, seam: 'flight-order-confirm', payload: { flight: 'MU123' } })
+  assert(dup.created === false && dup.status === 'pending' && resolveSagaTrigger('pending', 'propose').reason === 'idem-exists', '同幂等键重复提议:账本 no-op = 状态机 idem-exists')
+
+  const confirmed = ledger.confirmPendingWrite(K1, 'PNR-A')
+  assert(confirmed.ok === true && confirmed.status === 'confirmed' && resolveSagaTrigger('pending', 'confirm').to === 'confirmed', 'L3 具名确认 pending→confirmed(携 receipt)')
+  const reConfirmed = ledger.confirmPendingWrite(K1, 'PNR-SHOULD-IGNORE')
+  assert(reConfirmed.ok === false && (ledger.listPendingWrites().find(w => w.idem_key === K1)?.receipt ?? null) === 'PNR-A' && resolveSagaTrigger('confirmed', 'confirm').reason === 'already-confirmed', '二次确认被账本守卫拒绝且 receipt 不可变(仍为 PNR-A)')
+
+  const compensated = ledger.compensatePendingWrite(K1, '用户改签退款')
+  assert(compensated.ok === true && ledger.listPendingWrites().find(w => w.idem_key === K1)?.status === 'compensated', '已确认副作用可 saga 补偿(pending|confirmed → compensated)')
+
+  const afterConfirm = ledger.confirmPendingWrite(K1, 'PNR-POST')
+  const afterCompensate = ledger.compensatePendingWrite(K1, '重复补偿')
+  const afterPropose = ledger.requestPendingWrite({ idemKey: K1, seam: 'flight-order-confirm', payload: {} })
+  assert(afterConfirm.ok === false && afterCompensate.ok === false && afterPropose.created === false, '吸收态:compensated 后 confirm/compensate/propose 全拒,零复活')
+
+  const audit = sagaEventsOf(ledger, K1)
+  assert(audit.map(e => e.kind).join(',') === 'write.pending,write.confirmed,write.compensated', '审计事件链与边表路径同构(被拒调用零事件)')
+  assert(sagaTraceViolations(audit).length === 0, '真实账本审计链过词汇层校验零违例')
+
+  const K3 = 'booking:K3'
+  ledger.requestPendingWrite({ idemKey: K3, seam: 'hotel-order-confirm', payload: {} })
+  const emptyReceipt = ledger.confirmPendingWrite(K3, '')
+  assert(emptyReceipt.ok === true && sagaTraceViolations(sagaEventsOf(ledger, K3)).some(v => v.includes('receipt')), '已知边界:账本物理层暂不挡空 receipt,词汇层审计链抓出(物理 CHECK 随 M5 拍板入 schema)')
+
+  const other = ensureLedger(root, 'tenant-b')
+  const crossProp = other.requestPendingWrite({ idemKey: K1, seam: 'flight-order-confirm', payload: {} })
+  assert(crossProp.created === true, '同 idem_key 跨租户互不可见:tenant-b 可建自己的 K1(tenant_id 一等字段,ADR-16)')
+  const LOCAL_ONLY = 'booking:local-only'
+  ledger.requestPendingWrite({ idemKey: LOCAL_ONLY, seam: 'flight-order-confirm', payload: {} })
+  const crossMissing = other.confirmPendingWrite(LOCAL_ONLY, 'PNR-CROSS')
+  assert(crossMissing.ok === false && crossMissing.status === 'missing', 'tenant-b 看不到 local 的 saga 键(拒绝 missing)')
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+console.log(`\nBOOKING SAGA TESTS: ${pass} ok, ${fail} fail`)
+if (fail > 0) process.exit(1)

--- a/ts/src/booking-saga.ts
+++ b/ts/src/booking-saga.ts
@@ -1,0 +1,133 @@
+/**
+ * 预订 saga 状态机(booking_saga_fsm.v1)——issue #17 采纳三点的具名化落点。
+ *
+ * 立场(docs/booking-saga-fsm.md / ADR-17):不引入编排框架;预订 saga 的状态字母表与边表
+ * 就是账本 pending_writes(status CHECK:pending|confirmed|compensated)的显式化。
+ * 本模块是纯函数词汇层,零依赖、零行为、不接线任何 seam——M5 拍板 WriteGate 生产化时
+ * 以此为唯一状态推进词汇(具名化 = 状态与边不再散落在 SQL 字符串里)。
+ *
+ * 物理对账目标(state-ledger.ts,TS-4 基座):
+ *  - propose  = requestPendingWrite(∅ → pending,L2 只登记不执行;idem_key UNIQUE,重复提议 no-op)
+ *  - confirm  = confirmPendingWrite(pending → confirmed,L3 具名 seam 确认,携 receipt;无 receipt 则视为缺省空串)
+ *  - compensate = compensatePendingWrite(pending|confirmed → compensated,吸收态,无出边)
+ *  - 审计事件 kind:write.pending / write.confirmed / write.compensated
+ */
+
+export const BOOKING_SAGA_SCHEMA = 'booking_saga_fsm.v1'
+
+export type SagaStatus = 'pending' | 'confirmed' | 'compensated'
+export type SagaOrigin = 'none' | SagaStatus
+export type SagaTrigger = 'propose' | 'confirm' | 'compensate'
+export type SagaLedgerEvent = 'write.pending' | 'write.confirmed' | 'write.compensated'
+
+/** 状态字母表(与 pending_writes.status CHECK 约束逐字一致) */
+export const SAGA_STATUSES = ['pending', 'confirmed', 'compensated'] as const satisfies readonly SagaStatus[]
+
+export interface SagaEdge {
+  from: SagaOrigin
+  trigger: SagaTrigger
+  to: SagaStatus
+  event: SagaLedgerEvent
+  /** 边的守卫说明;物理执行在账本事务内(UNIQUE 守卫/CHECK),此处为语义面 */
+  guard: string
+}
+
+/**
+ * 边表(预订流程 FSM 的全部合法转移):
+ *  ∅ --propose--> pending --confirm--> confirmed
+ *        │             │
+ *        └---(任何状态) --compensate--> compensated(吸收态,无出边)
+ */
+export const SAGA_EDGES: ReadonlyArray<SagaEdge> = [
+  { from: 'none', trigger: 'propose', to: 'pending', event: 'write.pending', guard: 'L2 只登记不执行;idem_key UNIQUE(重复提议 no-op)' },
+  { from: 'pending', trigger: 'confirm', to: 'confirmed', event: 'write.confirmed', guard: 'L3 具名 seam 确认,必携 receipt;已确认不可再确认' },
+  { from: 'pending', trigger: 'compensate', to: 'compensated', event: 'write.compensated', guard: '外部写未发生,取消即终态(无补偿动作)' },
+  { from: 'confirmed', trigger: 'compensate', to: 'compensated', event: 'write.compensated', guard: '已发生副作用的 saga 补偿(退改),receipt 保留(COALESCE)' },
+]
+
+export type SagaRejection =
+  | 'missing-subject'
+  | 'idem-exists'
+  | 'already-confirmed'
+  | 'absorbed-compensated'
+  | 'already-compensated'
+
+/** 非边组合的拒绝理由(结构化,拒绝即不动——与账本 changes=0 同义) */
+export const SAGA_REJECTIONS: ReadonlyArray<{ from: SagaOrigin; trigger: SagaTrigger; reason: SagaRejection }> = [
+  { from: 'none', trigger: 'confirm', reason: 'missing-subject' },
+  { from: 'none', trigger: 'compensate', reason: 'missing-subject' },
+  { from: 'pending', trigger: 'propose', reason: 'idem-exists' },
+  { from: 'confirmed', trigger: 'propose', reason: 'idem-exists' },
+  { from: 'confirmed', trigger: 'confirm', reason: 'already-confirmed' },
+  { from: 'compensated', trigger: 'propose', reason: 'idem-exists' },
+  { from: 'compensated', trigger: 'confirm', reason: 'absorbed-compensated' },
+  { from: 'compensated', trigger: 'compensate', reason: 'already-compensated' },
+]
+
+export type SagaVerdict =
+  | { ok: true; from: SagaOrigin; trigger: SagaTrigger; to: SagaStatus; event: SagaLedgerEvent; guard: string; reason: null }
+  | { ok: false; from: SagaOrigin; trigger: SagaTrigger; to: null; event: null; guard: null; reason: SagaRejection }
+
+/** 触发解析:唯一归宿或结构化拒绝(预订 seam 的状态推进只许走这张表的边) */
+export function resolveSagaTrigger(origin: SagaOrigin, trigger: SagaTrigger): SagaVerdict {
+  const edge = SAGA_EDGES.find(e => e.from === origin && e.trigger === trigger)
+  if (edge) return { ok: true, from: origin, trigger, to: edge.to, event: edge.event, guard: edge.guard, reason: null }
+  const rejection = SAGA_REJECTIONS.find(e => e.from === origin && e.trigger === trigger)
+  return { ok: false, from: origin, trigger, to: null, event: null, guard: null, reason: rejection!.reason }
+}
+
+/** 触发器 → 账本事件 kind 的唯一映射(写入侧命名不再各处硬编码) */
+export const SAGA_TRIGGER_EVENT: Record<SagaTrigger, SagaLedgerEvent> = {
+  propose: 'write.pending',
+  confirm: 'write.confirmed',
+  compensate: 'write.compensated',
+}
+
+/** 账本事件 kind → 触发器(读取/审计侧);非 saga 事件返回 null */
+export function triggerOfEventKind(kind: string): SagaTrigger | null {
+  if (kind === 'write.pending') return 'propose'
+  if (kind === 'write.confirmed') return 'confirm'
+  if (kind === 'write.compensated') return 'compensate'
+  return null
+}
+
+export interface SagaAuditEvent {
+  seq?: number
+  kind: string
+  /** write.confirmed 携带的外部回执(payload.receipt) */
+  receipt?: string | null
+}
+
+/**
+ * 审计链校验(单 idem_key 的 write.* 事件序列):必须恰好走出边表的一条合法路径。
+ *  - 链以 write.pending 开头;
+ *  - confirm/compensate 至多各一次;
+ *  - compensated 之后不允许任何 saga 事件(吸收态);
+ *  - write.confirmed 的 receipt 为空(缺省/空串)即违例——L3 具名确认必携外部回执;
+ *  - 非 write.* 事件(其他域审计)穿插不计。
+ * 返回违例清单(空数组 = 链合法)。
+ */
+export function sagaTraceViolations(events: ReadonlyArray<SagaAuditEvent>): string[] {
+  const violations: string[] = []
+  let stage: SagaOrigin = 'none'
+  for (const ev of events) {
+    const trigger = triggerOfEventKind(ev.kind)
+    if (!trigger) continue
+    const verdict = resolveSagaTrigger(stage, trigger)
+    const at = `seq=${ev.seq ?? '?'} ${ev.kind}`
+    if (!verdict.ok) {
+      violations.push(`${at}: 非法(${stage} --${trigger}--> 拒绝 ${verdict.reason})`)
+      continue
+    }
+    stage = verdict.to
+    if (trigger === 'confirm' && (ev.receipt === undefined || ev.receipt === null || ev.receipt === '')) {
+      violations.push(`${at}: receipt 为空(L3 具名确认必携外部回执)`)
+    }
+  }
+  return violations
+}
+
+/** 完整合法路径集合(文档/测试共用):∅→pending→confirmed→compensated 与其前缀 */
+export function sagaLegalPaths(): ReadonlyArray<ReadonlyArray<SagaTrigger>> {
+  return [['propose'], ['propose', 'compensate'], ['propose', 'confirm'], ['propose', 'confirm', 'compensate']]
+}


### PR DESCRIPTION
Closes #17(采纳部分)/ Refs #17

## 为什么
issue #17 提议以 LangGraph FSM 显式建模多 Agent 副作用传递。逐机理勾稽:提议的机理全部有 accepted 归宿(ADR-15/16 事务化状态基座),本次不引入编排框架,而是补上唯一缺口——**具名**:把预订 saga 的状态/边/事件/拒绝理由从账本事务里的字符串约束升格为显式词汇层;并立三条口径(ADR-17)。

## 交付
- `ts/src/booking-saga.ts`(booking_saga_fsm.v1,纯函数):状态字母表(与 pending_writes CHECK 逐字一致)、四条边全函数边表(12 格 = 4 边 + 8 结构化拒绝,compensated 吸收态)、审计链校验器;零依赖、零写路径接线。
- `ts/scripts/booking-saga-tests.ts`(run-all §36,25 断言):封闭性 + 主路径/吸收态 + 审计链校验 + **与账本逐格物理对账**(词汇层与账本语义永不分叉,分叉即红)+ 多租户。
- `docs/booking-saga-fsm.md`:三点正式化设计文档(状态机词汇层 / HITL 审批边 / 合规确定性边)+ 机理归宿映射 + M5 启封增量。

## 边型词汇(回应 issue 的「边」)
- **deterministic-edge**:合规/政策判定 = 代码层 Z3 命名约束 + unsat core,永不做成 LLM Agent 节点;
- **gate-edge**:用户选择题(L1 gates,唯一交互形态);
- **external-event-edge**:HITL 审批 = pending 持久挂起 + 外部账本事件恢复,复用 ApprovalSeam(会话闸已生产,headless fail-closed),无新框架。

## 不引入 LangGraph 的判定(ADR-17 记录)
ADR-4 被拒备选即「自研状态机」控制平面;复用矩阵外(总纲刚性约束:先改纲要再动工);transactional-state RFC §2.1 已扫同一学派;M5 Entry gate(M4 exit + 供应链协议)未开,交易闭环零倒推(D-20)。

## 保鲜清单勾稽
六状态面:①architecture §1 ✅ ②§9 ✅ ③§10(+D-22 空 receipt 边界)✅ ④roadmap M5 ✅ ⑤README 让渡(产品形态无变化)⑥stage1 头(无涉)。

## 验证
- `scripts/run-all-tests.sh` §1-§36 全绿(新增 §36)
- `npx tsc --noEmit` 0 错
- 不接线任何工具写路径;M5 启封增量(空 receipt CHECK / seam 词汇 / L2 L4)仍为 M5 Entry 交付物