### PR TITLE
fix(inner): map LLM_BASE_URL to DEEPSEEK_BASE_URL (custom-relay endpoint passthrough)

### DIFF
--- a/bin/gotry-inner.js
+++ b/bin/gotry-inner.js
@@ -46,6 +46,12 @@ for (const line of envLines) {
 if (process.env.LLM_API_KEY && !process.env.DEEPSEEK_API_KEY) {
   process.env.DEEPSEEK_API_KEY = process.env.LLM_API_KEY
 }
+// 自定义端点映射:.env 的 LLM_BASE_URL(OpenAI 兼容中转)→ dsh 的 DEEPSEEK_BASE_URL
+// (dsh 端点覆盖词为 DEEPSEEK_BASE_URL——缺此映射时中转 key 会被发往 DeepSeek 官方
+// 端点而报「key 无效」,R1 期「key 失效」误诊的根因)
+if (process.env.LLM_BASE_URL && !process.env.DEEPSEEK_BASE_URL) {
+  process.env.DEEPSEEK_BASE_URL = process.env.LLM_BASE_URL
+}
 
 // --- argv 解析 ---
 const args = process.argv.slice(2)


### PR DESCRIPTION
Root cause behind the long-standing 'LLM key invalid' blocker: gotry-inner mapped only the key (LLM_API_KEY→DEEPSEEK_API_KEY), so with an OpenAI-compatible relay in .env the relay key was sent to the official DeepSeek endpoint — which rejects it. dsh honors DEEPSEEK_BASE_URL as the endpoint override (vendor BASE_URL_ENV constant; sits in app-boot's env allowlist); this adds the missing one-line mapping. Verified live end-to-end: headless one-shot conversation against a MiniMax relay completes with a real LLM answer (nl-quote-smoke OK, isolated stateRoot, interview-style clarify on a fixture hotel id — a contract-accepted form). Also retroactively explains the R1-era 'key 失效' misdiagnosis.