### PR TITLE
fix(args): interpretArgs forms 4 (XML-tag string) and 5 (JSON string)

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -329,6 +329,10 @@ echo "=== 40. A2A 入口(M2:骨架+SSE——Agent Card/JSON-RPC message-send+str
 (cd ts && npx tsx scripts/a2a-server-tests.ts) || FAIL=1
 
 echo
+echo "=== 41. interpretArgs 参数形态归一(①对象/②平铺/③主键串/④XML标签串/⑤JSON串;真 LLM 对话实测暴露的 ④⑤) ==="
+(cd ts && npx tsx scripts/dbg-args.ts) || FAIL=1
+
+echo
 if [ "$FAIL" -ne 0 ]; then
   echo "REGRESSION FAILED"
   exit 1

--- a/ts/scripts/dbg-args.ts
+++ b/ts/scripts/dbg-args.ts
@@ -1,0 +1,18 @@
+/**
+ * interpretArgs 形态回归(④XML 标签串/⑤JSON 字符串):真 LLM 对话实测暴露的两形态。
+ * 运行: cd ts && npx tsx scripts/dbg-args.ts
+ */
+import assert from 'node:assert/strict'
+import { interpretArgs } from '../src/tool-packet.ts'
+const x4 = interpretArgs<{ hotelId?: unknown }>({ query: '<hotelId>900000001</hotelId><checkIn>2026-10-10</checkIn><adults>1</adults>' })
+assert.equal(String(x4.hotelId), '900000001', '④ XML 标签串解析')
+assert.equal(x4.checkIn, '2026-10-10')
+const x5 = interpretArgs<{ hotelId?: unknown }>({ query: '{"hotelId":"900000001","checkIn":"2026-10-10"}' })
+assert.equal(String(x5.hotelId), '900000001', '⑤ JSON 字符串解析')
+const x3 = interpretArgs<{ destination?: string }>({ query: '大理' }, 'destination')
+assert.equal(x3.destination, '大理', '③ 主键字符串不回归')
+const x2 = interpretArgs<{ a?: number }>({ query: { a: 1 } })
+assert.equal(x2.a, 1, '① 对象形态不回归')
+const x1 = interpretArgs<{ a?: number }>({ a: 2 })
+assert.equal(x1.a, 2, '② 平铺形态不回归')
+console.log('INTERPRET-ARGS FORMS: 5/5 OK(①对象/②平铺/③主键串/④XML标签串/⑤JSON串)')

--- a/ts/src/tool-packet.ts
+++ b/ts/src/tool-packet.ts
@@ -27,6 +27,29 @@ export function interpretArgs<T extends Record<string, unknown>>(args: { query?:
   if (args.query && typeof args.query === 'object') return args.query as T
   const { query, ...rest } = args as Record<string, unknown>
   if (Object.keys(rest).length > 0) return rest as T
-  if (typeof query === 'string' && stringKey) return { [stringKey]: query } as T
+  if (typeof query === 'string') {
+    // ⑤ JSON 字符串形态(传输层把对象参数 stringify 后塞进 query):先尝试解析回对象
+    if (query.trimStart().startsWith('{')) {
+      try {
+        const parsed = JSON.parse(query) as Record<string, unknown>
+        if (parsed && typeof parsed === 'object' && Object.keys(parsed).length > 0) return parsed as T
+      } catch { /* 非合法 JSON 落到后续形态 */ }
+    }
+    // ④ XML 标签串形态(dsh/部分模型把 JSON 参数序列化为 <k>v</k> 串):
+    //    <hotelId>900000001</hotelId><checkIn>2026-10-10</checkIn> → {hotelId,checkIn}
+    //    值域先试 JSON.parse(数字/对象复原),失败留字符串;数字字符串由能力层强转兜底
+    if (/^\s*<[a-zA-Z][^>]*>/.test(query)) {
+      const out: Record<string, unknown> = {}
+      const re = /<([a-zA-Z][a-zA-Z0-9_]*)>([\s\S]*?)<\/\1>/g
+      let m: RegExpExecArray | null
+      while ((m = re.exec(query)) !== null) {
+        const raw = m[2].trim()
+        if (raw === '') continue
+        try { out[m[1]] = JSON.parse(raw) } catch { out[m[1]] = raw }
+      }
+      if (Object.keys(out).length > 0) return out as T
+    }
+    if (stringKey) return { [stringKey]: query } as T
+  }
   return {} as T
 }


### PR DESCRIPTION
Live conversational E2E (MiniMax-M2.7 via relay) exposed two more query-parameter serialization forms that the three-form normalizer didn't cover: (4) XML tag strings '<hotelId>900000001</hotelId><checkIn>...' and (5) stringified JSON '{"hotelId":...}' — both previously collapsed the whole payload into the tool's main key value (backend 'invalid ID string'). interpretArgs now recovers both before falling back to the main-key form; values are JSON.parse'd when possible, numeric strings handled by the capability/staicli coercion layers (hotelbyte-cli#7/#8). run-all §41 adds a five-form regression (object/flat/main-key/XML/JSON-string); tsc clean, smoke OK. Also observed (not addressed here): the model occasionally leaks native tool-call syntax while trying to read repo sources inside think — a persona/model-hardening follow-up.