### PR TITLE
fix(test): bootstrap 测试 8 的 CI 环境疏漏——去掉 --auto 修复 CI 红

### DIFF
--- a/ts/scripts/bootstrap-tests.ts
+++ b/ts/scripts/bootstrap-tests.ts
@@ -86,16 +86,16 @@ assert.equal(c7.code, 1, `wizard(超时)应 exit 1,实际 ${c7.code}\n${c7.out}`
 assert.ok(c7.out.includes('3 步') || c7.out.includes('gotry-wizard'), '应输出引导标题')
 console.log('7. wizard 真实路径(扩展未就绪,exit 1 + 引导标题 + 心跳)OK')
 
-// 8. 扩展分发 github 通道(ADR-21):基址指不可达回环(127.0.0.1:1 拒连,离线确定性)
+// 8. 扩展分发 github 通道(ADR-21):基址指不可达回环(127.0.0.1:1 拒连,离线确定性);显式模式不带 --auto——CI 环境里 AUTO+CI 会提前跳过全部节,断言面会落空
 //    → 显式降级 bundled + check-only 报告,exit 0;非法 --extension-from 值回落 bundled 不进网络通道。
-const c8 = runBootstrap(['--check-only', '--extension-from=github', '--auto'], {
+const c8 = runBootstrap(['--check-only', '--extension-from=github'], {
   GOTRY_SETUP_HBCLI: '0', GOTRY_SETUP_REACH: '0', GOTRY_SETUP_SIDEBAR: '0',
   GOTRY_EXTENSION_RELEASE_BASE: 'http://127.0.0.1:1/releases',
 })
 assert.equal(c8.code, 0, `github 通道降级应 exit 0,实际 ${c8.code}\n${c8.out}`)
 assert.ok(c8.out.includes('GitHub Releases 下载通道'), '应打印 github 通道标题')
 assert.ok(c8.out.includes('降级包内副本'), '失败应显式降级 bundled')
-const c8b = runBootstrap(['--check-only', '--extension-from=不合法值', '--auto'], {
+const c8b = runBootstrap(['--check-only', '--extension-from=不合法值'], {
   GOTRY_SETUP_HBCLI: '0', GOTRY_SETUP_REACH: '0', GOTRY_SETUP_SIDEBAR: '0',
 })
 assert.equal(c8b.code, 0, `非法 --extension-from 值应回落 bundled 且 exit 0,实际 ${c8b.code}\n${c8b.out}`)


### PR DESCRIPTION
## 为什么改 · Why
PR #72 的 bootstrap-tests 测试 8 用了 `--auto`:在 GitHub Actions 里 `AUTO && CI=true` 命中 postinstall 提前跳过路径,扩展分发通道断言面落空 → 两个矩阵 CI 红;本地无 CI 变量,回归全绿未暴露。

## 改了什么 · What
测试 8 两个用例去掉 `--auto`(显式模式,节照常执行);断言与语义不变。

## 测试证据 · Test evidence
- 本地 `npx tsx scripts/bootstrap-tests.ts` 8/8 OK;`CI=1` 模拟环境同样 8/8 OK(修复前红)。
- `npx tsc --noEmit` 干净。

## 自查清单 · Checklist
- [x] 本地全栈回归对应套件绿(bootstrap-tests;其余节未受影响)
- [x] 单一关注点;具名文件暂存
- [x] 无 deprecated 层调用;无行为变化(纯测试修复)
- [x] N/A:ADR/六状态面(无形态变化)/WriteGate/共享状态