### PR TITLE
fix(分发 A): 打包脚本 store zip 剥离 key(商店首传实测)+ §43 防漂移断言

### DIFF
--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -53,9 +53,22 @@ for (const f of ['manifest.json', 'background.js', 'content-main.js', 'content-b
   cpSync(join(SRC, f), join(STAGE, f))
 }
 
+// store 变体:剥离 manifest 的 key 字段——Chrome Web Store 实测(2026-08-30 首传)拒绝 key,
+// 商店自派扩展 ID(≠未打包/GitHub 通道的固定 ID);tar.gz 不受影响,保留 key 保通道 ID 不变量
+const STAGE_STORE = join(OUT, 'gotry-session-bridge-store')
+mkdirSync(STAGE_STORE, { recursive: true })
+for (const f of ['manifest.json', 'background.js', 'content-main.js', 'content-bridge.js', 'README.md']) {
+  cpSync(join(SRC, f), join(STAGE_STORE, f))
+}
+{
+  const m = JSON.parse(readFileSync(join(STAGE_STORE, 'manifest.json'), 'utf8'))
+  delete m.key
+  writeFileSync(join(STAGE_STORE, 'manifest.json'), `${JSON.stringify(m, null, 2)}\n`)
+}
+
 must('tar', ['-czf', join(OUT, ASSET_TARBALL), '-C', OUT, 'gotry-session-bridge'], 'tar.gz 打包')
 // store zip:manifest 必须在 zip 根(Chrome Web Store 上传要求);tar.gz 才带顶层目录约定
-must('zip', ['-r', '-q', join(OUT, ASSET_STORE_ZIP), '.'], 'store zip 打包', STAGE)
+must('zip', ['-r', '-q', join(OUT, ASSET_STORE_ZIP), '.'], 'store zip 打包', STAGE_STORE)
 
 const sha256 = (p) => createHash('sha256').update(readFileSync(p)).digest('hex')
 let commit = ''

--- a/ts/scripts/extension-distribution-tests.ts
+++ b/ts/scripts/extension-distribution-tests.ts
@@ -60,6 +60,7 @@ function ok(cond: boolean, label: string) {
   ok(pkgSrc.includes(`const ASSET_STORE_ZIP = '${DIST_ASSET_STORE_ZIP}'`), 'package-extension.mjs store zip 资产名一致')
   ok(pkgSrc.includes(`const ASSET_MANIFEST = '${DIST_ASSET_MANIFEST}'`), 'package-extension.mjs dist-manifest 资产名一致')
   ok(pkgSrc.includes("const STAGE = join(OUT, 'gotry-session-bridge')"), '打包根目录名固定 gotry-session-bridge/(下载端 strip-components 依赖)')
+  ok(pkgSrc.includes('delete m.key'), 'store zip 变体剥离 manifest key(2026-08-30 商店首传实测拒绝 key;tar.gz 保留 key 保通道 ID 不变量)')
 }
 
 // ─── ② parseDistManifest fail-closed ────────────────────────────────────────


### PR DESCRIPTION
## 为什么改 · Why
商店首传(2026-08-30)实测:Chrome Web Store 拒绝 manifest 含 `key` 的 zip。当时为救上传在本地改了 `package-extension.mjs`(store 变体剥 key、tar.gz 保留 key 保通道 ID),但该修复未回提交——main 上的脚本仍会产出带 key 的 store zip。本 PR 把修复落回仓库,并给 §43 加防漂移断言。

ext-v0.1.0 Release 已用剥离版产物上线(三件套 + 回拉 SHA256 对账 + 真链路安装实测全过)。

## 改了什么 · What
- `scripts/package-extension.mjs`:新增 STAGE_STORE 变体(manifest `delete m.key`),store zip 从该变体打包;tar.gz 不变。
- `ts/scripts/extension-distribution-tests.ts`:断言脚本源码含 `delete m.key`(防未来漂移回带 key 版)。

## 测试证据 · Test evidence
- §43 扩展分发测试全绿(新断言 ok);`npx tsc --noEmit` 干净。
- Release 回拉实测:latest/download 三件套 HTTP 200,tarball SHA256 与远端 dist-manifest 一致;`HOME=隔离目录 gotry setup --extension-from=github` 真链路落位 v0.1.0(key 钉扎在场)。

## 自查清单 · Checklist
- [x] 本地对应套件绿(§43 + tsc;打包脚本为维护者面,产物已实测)
- [x] 单一关注点;具名文件暂存
- [x] 无 deprecated 层调用;无行为变化(仅打包产物形态)
- [x] N/A:ADR/六状态面(ADR-21 已covers 双通道;本修复是其实现细节)/WriteGate/共享状态