### PR TITLE
fix(flyai #84): spawn stdout 临时文件重定向修 ~7.6KB 截断

### DIFF
--- a/ts/capabilities/flyai.ts
+++ b/ts/capabilities/flyai.ts
@@ -15,6 +15,9 @@
  */
 
 import { spawn } from 'node:child_process'
+import { closeSync, openSync, readFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 export type FlyaiKind = 'flight' | 'train' | 'hotel'
 
@@ -175,20 +178,30 @@ export function parseFlyaiItemList(stdout: string): unknown[] {
 }
 
 
+/**
+ * 子进程 stdout 走临时文件而非管道(issue #84):
+ * flyai CLI 异步写 stdout 后立即 process.exit();stdout 是管道时未 flush 的
+ * 尾部会被丢掉(实测截断在 ~7.6KB,exit=0 静默)。stdout 是文件时 Node 同步写,
+ * exit 不丢数据;且文件无 64KB 管道缓冲上限。close 后读文件,语义不变。
+ */
 function sh(cmd: string, args: string[], opts: { timeoutMs: number }) {
-  const child = spawn(cmd, args, { env: process.env, cwd: process.cwd() })
-  let stdout = ''
+  const outFile = join(tmpdir(), `gotry-flyai-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.out`)
+  const outFd = openSync(outFile, 'w')
+  const child = spawn(cmd, args, { env: process.env, cwd: process.cwd(), stdio: ['ignore', outFd, 'pipe'] })
   let stderr = ''
   let error: string | undefined
   const timer = setTimeout(() => {
     try { child.kill('SIGKILL') } catch { /* ignore */ }
   }, opts.timeoutMs)
   return new Promise<{ code: number; stdout: string; stderr: string; error?: string; timedOut?: boolean }>((resolve) => {
-    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString() })
     child.stderr?.on('data', (d: Buffer) => { stderr += d.toString() })
     child.on('error', (e) => { error = (e as Error).message.slice(0, 200) })
     child.on('close', (code) => {
       clearTimeout(timer)
+      closeSync(outFd)
+      let stdout = ''
+      try { stdout = readFileSync(outFile, 'utf8') } catch { /* 子进程未启动时文件可能为空,按空 stdout 处理 */ }
+      try { unlinkSync(outFile) } catch { /* ignore */ }
       resolve({ code: code ?? -1, stdout, stderr, error })
     })
   }).finally(() => clearTimeout(timer))

--- a/ts/scripts/session-tests.ts
+++ b/ts/scripts/session-tests.ts
@@ -96,9 +96,9 @@ if (process.env.GOTRY_SESSION_LIVE === '0') {
   console.log('  SKIP - GOTRY_SESSION_LIVE=0(离线门禁不调用 FlyAI 外部实时端点)')
 } else {
   fr = await flyaiSearch({ kind: 'flight', origin: '上海', destination: '丽江', depDate: '2026-10-01' })
-  const sentinelBlocked = fr.verdict === 'error' && /sentinel|block/i.test(fr.error ?? '')
+  const sentinelBlocked = fr.verdict === 'error' && /sentinel|block|trial limit/i.test(fr.error ?? '')
   if (sentinelBlocked) {
-    console.log('  WARN - 飞猪 Sentinel 限流(2026-08-28 实测,配额未文档化)——降级合同验证通过,跳过 hit 断言')
+    console.log('  WARN - 飞猪上游限流(Sentinel 2026-08-28 / trial-limit 429 2026-08-31 实测,配额未文档化)——降级合同验证通过,跳过 hit 断言')
     assert(fr.ok === false && /\[实时API:flyai@error@/.test(fr.evidence), '限流降级:结构化 error + 证据链错误形')
   } else {
     assert(fr.ok === true && fr.verdict === 'hit', '上海→丽江 hit', fr)
@@ -117,6 +117,38 @@ if (process.env.GOTRY_SESSION_LIVE === '0') {
   assert(fr2.ok === false && fr2.verdict === 'error', 'data:null 语义失败 → error 终态(非 miss)', fr2)
   assert(/出发日期非法/.test(fr2.error ?? '') && /flyai@error@/.test(fr2.evidence), '上游原话透传 + 证据链错误形', fr2)
   rmSync(fakeDir, { recursive: true, force: true })
+}
+
+// F3. stdout 截断回归(issue #84):CLI 分片异步写 >64KB 后立即 exit——
+// 管道消费丢未 flush 尾部(实测截 ~7.6KB,静默 exit=0);文件重定向同步写不丢。
+{
+  const bigDir = mkdtempSync(join(tmpdir(), 'flyai-trunc-'))
+  const payloadJs = join(bigDir, 'payload.js')
+  const itemCount = 100
+  writeFileSync(payloadJs, `
+const items = []
+for (let i = 0; i < ${itemCount}; i++) {
+  items.push({
+    journeys: [{ segments: [{
+      marketingTransportName: '吉祥航空', marketingTransportNo: 'HO' + (1000 + i),
+      depDateTime: '2026-09-15 08:30', arrDateTime: '2026-09-15 12:10',
+      depStationName: '浦东国际机场', arrStationName: '长水机场', duration: '220', seatClassName: '经济舱',
+    }] }],
+    ticketPrice: String(800 + i),
+    jumpUrl: 'https://fliggy.com/item/' + 'x'.repeat(800) + i,
+  })
+}
+const payload = JSON.stringify({ data: { itemList: items } })
+const step = Math.ceil(payload.length / 100)
+for (let i = 0; i < 100; i++) process.stdout.write(payload.slice(i * step, (i + 1) * step))
+process.exit(0)
+`)
+  const bigBin = join(bigDir, 'flyai-cli-big')
+  writeFileSync(bigBin, `#!/bin/sh\nexec node "${payloadJs}"\n`, { mode: 0o755 })
+  const tr = await flyaiSearch({ kind: 'flight', origin: '上海', destination: '昆明', depDate: '2026-09-15', cliBin: bigBin })
+  assert(tr.ok === true && tr.verdict === 'hit' && tr.options?.length === itemCount,
+    `大载荷 ${itemCount} 条(>64KB)完整解析无截断(#84)`, { verdict: tr.verdict, options: tr.options?.length, error: tr.error })
+  rmSync(bigDir, { recursive: true, force: true })
 }
 
 // G. live 会话检索(默认 SKIP:例行动回归**永不**自启浏览器窗口—— founder 2026-08-29 反馈

--- a/ts/scripts/smoke.ts
+++ b/ts/scripts/smoke.ts
@@ -196,11 +196,11 @@ async function main() {
   // 12) 会话数据面工具(P3 切片1):官方通道 live + 会话工具 needs-login 合同(隔离 profile,零导航)
   {
     const fa = await byName('gotry_flyai_search').execute({ query: { kind: 'flight', from: '上海', to: '丽江', date: '2026-10-01' } }, null) as { ok?: boolean; verdict?: string; via?: string; options?: unknown[]; evidence?: string; error?: string }
-    const faBlocked = fa.verdict === 'error' && /sentinel|block/i.test(fa.error ?? '')
+    const faBlocked = fa.verdict === 'error' && /sentinel|block|trial limit/i.test(fa.error ?? '')
     // 端点不可达/超时(出口 IP 被拒或网络抖动)→ 工具以带证据链的 error 终态优雅降级,同样合法
     const faErrTerminal = fa.ok === false && fa.verdict === 'error' && /^flyai-error$/.test(String(fa.via ?? '')) && /\[实时API:flyai@error@/.test(String(fa.evidence ?? ''))
     if (faBlocked) {
-      console.log('  WARN - flyai Sentinel 限流中,降级合同通过(hit 断言跳过)')
+      console.log('  WARN - flyai 上游限流中(Sentinel/trial-limit 429),降级合同通过(hit 断言跳过)')
     } else if (faErrTerminal) {
       console.log('  WARN - flyai 端点不可达(超时/降级),证据链合同通过(hit 断言跳过)')
     } else if (fa.ok !== true || fa.verdict !== 'hit' || (fa.options?.length ?? 0) < 1 || !/\[实时API:flyai@/.test(fa.evidence ?? '')) {
@@ -232,7 +232,7 @@ async function main() {
     console.log(`session-face tools: flyai ${faBlocked ? 'sentinel-限流降级' : `live hit(${fa.options?.length ?? 0} 条)`}; session 终态=${ss.verdict ?? ss.via}(登录态存在前提合同)`)
     // 酒店平铺接入(2026-08-29):同一 flyai 工具 kind=hotel——live 双合法终态(限流/端点降级 or hit)
     const fh = await byName('gotry_flyai_search').execute({ query: { kind: 'hotel', to: '大理', checkIn: '2026-10-01', checkOut: '2026-10-03' } }, null) as { ok?: boolean; verdict?: string; via?: string; hotels?: unknown[]; evidence?: string; error?: string }
-    const fhBlocked = fh.verdict === 'error' && /sentinel|block/i.test(fh.error ?? '')
+    const fhBlocked = fh.verdict === 'error' && /sentinel|block|trial limit/i.test(fh.error ?? '')
     const fhErrTerminal = fh.ok === false && fh.verdict === 'error' && /^flyai-error$/.test(String(fh.via ?? '')) && /\[实时API:flyai@error@/.test(String(fh.evidence ?? ''))
     if (fhBlocked || fhErrTerminal) {
       console.log('  WARN - flyai hotel 限流/端点降级,证据链合同通过(hit 断言跳过)')


### PR DESCRIPTION
## 问题(issue #84)

flyai CLI 异步写 stdout 后立即 `process.exit()`;Node spawn 管道消费时未 flush 尾部被丢弃——实测稳定截断在 ~7.6KB,且 exit=0 stderr 为空,对调用方静默。机票/火车两条主链路降级,smoke 与 session-tests 红。

## 修复

`capabilities/flyai.ts` 的 `sh()`:stdout 从管道改为 **stdio 文件描述符**(临时文件),close 后读文件。文件态下 Node 同步写,exit 不丢尾部,且无 64KB 管道缓冲上限。语义不变,零依赖新增。

## 回归

- session-tests 新增 **F3 确定性回归**:mock CLI 分片异步写 >64KB(100 条行程)后立即 exit,断言 100/100 完整解析
- smoke/session-tests 降级合同正则纳入 `trial limit`(2026-08-31 上游 429 实测新文案,与 Sentinel 同类限流)

## 验收证据

- `tsc --noEmit` 0 错
- session-tests **49 pass / 0 fail**(含 F3)
- smoke **OK**(限流降级合同通过)
- run-all 51 节:§23b 与 booking-bin-proof 两节失败在**干净 origin/main 基线同样复现**(Node 26.3 移除 stripTypeScriptTypes `transform` 模式 → build-dist.mjs 环境性失败,非本切片引入)

Not-tested: 真 CLI live hit(上游 trial 配额 429 中,降级合同路径已验证)

Closes #84