### PR TITLE
docs(#50): ② 收口——rc dist-tag 迁 rc.16 + rc.16 补发态勘误(回拉实测)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ M3 最小可用产品,分发链路无已知堵点。
 |---|---|
 | 入口 | `./gotry`(仓内)或 `npx @danceiny/gotry@latest web`(npm) |
 | 运行时 | dsh 成品形态,DeepSeek 原生 |
-| 版本 | 见 `package.json` 与 `release-notes.md`;**`rc` dist-tag 滞留旧版,#50② 治理完成前不要用 `@rc`** |
+| 版本 | 见 `package.json` 与 `release-notes.md`;**`rc` dist-tag 已指向最新 rc(2026-09-02 #50② 完成),`@rc` 可用;用户引导仍优先 `@latest`** |
 | License | MIT |
 | 人格 | 行为契约 21 条;锚点卡与记忆 brief 注入 persona。**运行时组合唯一来源 = 仓根 `cordis.gotry-patch.yml`** |
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,6 @@
 # GoTry 发版记录
 
-## v0.0.1-rc.16(价表 provider-aware v2 + 价格漂移监测长机制 + CHANGELOG 自动化,**tag 已推 2026-08-30——npm 发布未落地:registry 无此版本,补发待 founder 浏览器 approve(#50 勘误)**)
+## v0.0.1-rc.16(价表 provider-aware v2 + 价格漂移监测长机制 + CHANGELOG 自动化,**已发布:npm 2026-08-30T13:00Z + GitHub Release 同日;#50② 于 2026-09-02 同窗完成 dist-tag 治理并回拉实测**)
 
 rc.15 → rc.16 增量(founder 确认制下 agent 执行,owner 「这次要把 changelog 机制补上」):
 
@@ -21,7 +21,7 @@ rc.15 → rc.16 增量(founder 确认制下 agent 执行,owner 「这次要把 c
 - run-all 新增 §41(LLM 价格漂移,11/11 绿) + §42(CHANGELOG 生成器,11/11 绿);六状态面同步:architecture §1/§97/ADR-20 ·roadmap §7 ·data-sources §7 ·stage1 状态头 ·tokens.md 价表与漂移监测节 ·README 中英双语「Switching models / providers?」节
 
 ### 发布闸状态
-- ① 全栈回归:§1-§22 + §24-§41 + §42 全绿(§23b 发布面 dist 缺失预存回归,非本 PR)✅ ② 六状态面同步(本提交 + 保鲜清单勾稽)✅ ③ README 用法实测 ⏳(2026-08-30 #50 核实:registry 无 rc.16、GitHub Release 未建——publish 实际未发生,本条与「已发布」口径一并勘误;补发后重勾) ④ License MIT ✅ ⑤ 版本号一致(package.json `0.0.1-rc.16` / 双 README Last verified / roadmap rc 序列 / release-notes / CHANGELOG = rc.16)✅
+- ① 全栈回归:§1-§22 + §24-§41 + §42 全绿(§23b 发布面 dist 缺失预存回归,非本 PR)✅ ② 六状态面同步(本提交 + 保鲜清单勾稽)✅ ③ README 用法实测 ✅(2026-09-02 回拉:registry latest=rc.16;干净安装 @latest 489 包、`gotry --help`、dist 入口全通;GitHub Release v0.0.1-rc.16 已建) ④ License MIT ✅ ⑤ 版本号一致(package.json `0.0.1-rc.16` / 双 README Last verified / roadmap rc 序列 / release-notes / CHANGELOG = rc.16)✅
 
 ## v0.0.1-rc.15(预订 saga 状态机具名化,**已发布 2026-08-29**)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,10 +10,10 @@
 
 ### 发行状态
 
-**当前 npm latest = `0.0.1-rc.15`;rc.16 tag 已推但 npm 发布未落地。**
+**当前 npm latest = `0.0.1-rc.16`(已发布);`rc` dist-tag 已同步指向 rc.16。**
 
-- 2026-08-30 #50 核实:registry versions/dist-tags 均无 rc.16、GitHub Release 亦未建——发布凭证缺位,补发待 founder 浏览器 approve 窗口。
-- **勘误**:此前「registry 回拉实测全过」的记载不实(#50 勘误)——publish 实际未完成。
+- 2026-08-30 上午 #50 核实 registry 无 rc.16(「已发布」口径勘误);**同日 13:00Z 补发落地**(npm time 实测 `0.0.1-rc.16` = 2026-08-30T13:00:38Z),GitHub Release 13:03Z 随建(#76 修复生效)。
+- 2026-09-02 #50② 收口:回拉实测 latest=rc.16(干净安装 489 包 / bin `--help` / dist 入口全通);`rc` 由滞留 rc.7 迁至 rc.16,杂散 `rc.5` 改指同名版本、`rc.11–rc.14` 各自同名自洽——五别名彻底删除需 npmjs web UI(granular token 对 DELETE dist-tag 端点 403,curl 复核同)。
 - rc 逐版范围见下方「rc 序列总览」与 `release-notes.md`。
 
 Evaluation Phase 0 foundation boundary: contracts/registry/validators/unmatched diagnostic fixtures/test-only aggregate admission plus a deterministic PR/nightly/weekly/milestone cadence policy/planner. It returns admission, `pass^k`, budgets, calibration, failure-registry, and cross-benchmark synthesis obligations only; it does not schedule or launch adapters, spend, generate a benchmark score, create an Agent optimization round, or support an uplift claim. No external runner, Python runtime dependency, baseline, or matched production evidence is included.
@@ -72,7 +72,7 @@ rc 序列总览(细节见 release-notes.md,版本历史归 git):
 | v0.0.1-rc.4 | 已推 | agent-reach 接入(router 形态,后被 wrapper 化取代)+ License MIT |
 | v0.0.1-rc.5 | 已发 npm(不可用,被 rc.6 取代) | 首发打通 2FA/恢复码/隔离发布命令;tarball 缺 runtime(教训) |
 | **v0.0.1-rc.6** | **已发 npm,可用** | bin 运行时解析 + dist 预编译(绕 Node 拒 strip node_modules .ts)+ data 入包;干净安装 web 200 实测 |
-| v0.0.1-rc.7 | 已发 npm;rc tag 仍滞留本版(可用但旧,#50② 迁移待授权窗) | .env 读用户当前目录 + 无 key 可执行指引 |
+| v0.0.1-rc.7 | 已发 npm;rc tag 曾滞留本版至 2026-09-02(#50② 已迁至 rc.16) | .env 读用户当前目录 + 无 key 可执行指引 |
 | v0.0.1-rc.8 | 已发 npm(曾直指 latest) | `npx @danceiny/gotry` 即得;干净安装 headless 实测跑通 |
 | v0.0.1-rc.9 | 已发 npm(曾为 latest;**含缺陷:better-sqlite3 未入 dependencies,装得上跑不起**——被发布后干净安装验证抓出) | M4 记忆域全链/账本/17 工具/D-6 校准 |
 | **v0.0.1-rc.10** | 已发 npm(曾为 latest;registry 回拉实测:489 包安装/插件加载/bin 全通) | 双形态冻结 ADR-16 + 会话传输层 puppeteer 定案 + 依赖面根治;rc.9 标缺陷由本版覆盖后退役 |
@@ -81,7 +81,7 @@ rc 序列总览(细节见 release-notes.md,版本历史归 git):
 | **v0.0.1-rc.13** | **已发 npm,latest 直指本版**(registry 回拉实测通过) | 账号会话三连修复:登录自动检测(已登录零弹窗)+ 登录页置前可见性(`newPage` 纪律)+ 例行测试永不自动开窗;README 可读性一版(18 工具分组/账号会话隐私专节/状态重排) |
 | **v0.0.1-rc.14** | **已发 npm,latest 直指本版**(registry 回拉实测:干净安装/bin/npm 页英文 README) | 文档中英分开发布:`README.md`(英文,完整镜像)+ `README.zh-CN.md`(中文)互链,顶层 switcher;npm files 增补中文版 |
 | **v0.0.1-rc.15** | **已发 npm,latest 直指本版**(registry 回拉实测:干净安装/bin/插件加载全通) | issue #17 采纳:预订 saga 状态机具名化 `booking_saga_fsm.v1`(ADR-17,纯函数词汇层+§36 与账本物理对账)+ HITL 审批边/合规确定性边词汇;run-all 新增 §36 |
-| v0.0.1-rc.16 | **tag 已推,npm 未发布**(registry 无此版本,#50 勘误;补发待授权窗) | issue #49 采纳:价表 provider-aware v2 + MiniMax 入表(ADR-20)+ 价格漂移监测长机制 + CHANGELOG 机制 + §38 扩展桥 zombie port 根治;run-all §41/§42 两闸。详见上方「架构面增量」 |
+| **v0.0.1-rc.16** | **已发 npm,latest 直指本版**(2026-08-30T13:00Z 补发落地;2026-09-02 回拉实测干净安装/bin 全通,#50② 同窗完成 dist-tag 治理) | issue #49 采纳:价表 provider-aware v2 + MiniMax 入表(ADR-20)+ 价格漂移监测长机制 + CHANGELOG 机制 + §38 扩展桥 zombie port 根治;run-all §41/§42 两闸。详见上方「架构面增量」 |
 | dev(未发) | 持续 main 直推 | issue 冲刺 14/14 交付(README 一致性/域边界/数据污染根除等),17 套 ALL GREEN |
 | 后续 | founder 侧 | 种子用户邀约;rc.16 补发 + dist-tag 卫生(rc tag→最新可用版、清杂散 rc.5/rc.11-rc.14)同一次浏览器 approve 窗口内做完(#50②③) |
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -29,7 +29,7 @@ XHS_COOKIES=             # 小红书 Cookie-Editor JSON
   - web 会话 token(`.npmrc.publish`,路径 A)可登录、可 whoami,但 **publish PUT 被账号级 2FA 拦截(EOTP→网页二次确认)**;npm 日志同时给出 deprecation 警告——bypass-2FA token 的 direct publish 正被收紧(<https://github.blog/changelog/2026-07-31-restricting-npm-bypass-2fa-granular-access-tokens/>,target 2027-01)。
   - 实走通路径 = **PTY 终端下 `npm publish`**(rc.10 起为 expect 包 PTY)→ otplib 弹网页授权 → **founder 浏览器点一次 Approve** → PUT 自动重试成功。**「发布 = 一次浏览器 approve,由 founder 点击」自此为标准动作**(已同步 AGENTS.md 发布闸)
 - **以后每次发布**: `TAG=latest ./scripts/publish-npm.sh`(dist-tag 必须显式传,#50①:旧默认 rc.5 曾把新包发到陈旧通道);凭据走路径 A web 会话——`--otp=<恢复码>` 已被 npm 拒收,granular bypass token(路径 B)在 npm 收紧通道上,均不作主路径
-- **dist-tag 维护(与发布同窗顺手做,#50②)**:dist-tag 写操作同样吃 2FA,窗口外单发会再触发一次授权(rc.15 发布时即因此未做)。登录会话仍活的窗口内执行:`npm dist-tag add @danceiny/gotry@<最新可用版> rc --registry=https://registry.npmjs.org/`;截至 2026-08-30 `rc` 仍滞留 rc.7,杂散 dist-tag(rc.5/rc.11/rc.12/rc.13/rc.14)待同窗清理
+- **dist-tag 维护(#50②,2026-09-02 已执行)**:founder 指令窗内经 `.env` NPM_TOKEN(granular)执行 `npm dist-tag add @danceiny/gotry@0.0.1-rc.16 rc --registry=https://registry.npmjs.org/` 成功——`rc` 由滞留 rc.7 迁至 rc.16;**但 DELETE dist-tag 端点对该 token 403**(curl 直连复核同 403,granular token 无删除权)→ 杂散 `rc.5` 以 add 通道改指 `0.0.1-rc.5` 自洽,`rc.11–rc.14` 各指同名版本;五别名彻底删除需 npmjs web UI 一次 founder 登录(package → Settings → manage dist-tags)。**runbook 拆两档**:改指(add)token 可直做;删除必须 web UI
 - **⚠️ 登录时刻的三连批次**(2026-08-26 巡检发现,凭证就绪后一次做完):
   1. 发布 rc.8(工件 /tmp 就绪)
   2. `npm dist-tag add @danceiny/gotry@0.0.1-rc.8 latest` —— **latest 还指着 rc.5(坏包,缺 runtime)**,不带 @rc 的裸安装/npx 用户会中招
@@ -146,6 +146,7 @@ NPM_TOKEN=npm_xxx TAG=latest ./scripts/publish-npm.sh  # 或临时注入 token
 
 | 日期 | 变更 |
 |---|---|
+| 2026-09-02 | #50② 执行:rc dist-tag 迁至 rc.16;杂散别名自洽化(rc.5→同名版);DELETE 端点 403 留痕,删除改 web UI 档;rc.16 发布态勘误同步状态面 |
 | 2026-08-30 | #50:rc.15 网页批准发布实录固化为标准动作;路径 B 降级(收紧中)/路径 C 升中期主评估;新增 dist-tag 维护 runbook;发布命令改 TAG 显式传 |
 | 2026-08-24 | 立 v1:npm 三路径(A web 会话/B granular bypass/C OIDC)+ agent-reach 8 渠道获取表 + 统一 .env 存放 |
 | 2026-08-22 | 雪球行纠正:实测需 cookie(上游 check warn + configure 指引),非零门槛 |


### PR DESCRIPTION
Closes #50(② 收口;①③已于 #71 闭环)。

## registry 维护(2026-09-02,founder 指令窗内,经 .env NPM_TOKEN)

- ✅ `rc` dist-tag:rc.7 → **0.0.1-rc.16**(`npm dist-tag add` 成功)
- ✅ 杂散 `rc.5`(曾被脚枪指到 rc.16)→ 改指同名版本 `0.0.1-rc.5`,全部 tag 自洽
- ⚠️ `rc.11–rc.14`/`rc.5` 五个别名的**彻底删除 403**(granular token 无 DELETE dist-tag 权,curl 直连复核同)——留 npmjs web UI 一次 founder 登录即可(package → Settings → manage dist-tags),纯化妆品级残留
- 回拉终态:`{ rc: rc.16, latest: rc.16, rc.5→rc.5, rc.11–14→同名 }`

## rc.16 发布态勘误(比 #50 更早的过时口径)

- npm time 实测 rc.16 **2026-08-30T13:00Z 已发布**、GitHub Release 13:03Z 已建(#76 修复生效)——但 #71 上午勘误后无人重勾状态面
- 本次回拉:干净安装 @latest 489 包、`gotry --help`、dist 入口全通 → 发布闸③重勾
- 六状态面同步:roadmap 发行状态/rc 序列、release-notes 头+闸③、architecture §1、tokens.md runbook+修订史(README 双语随另一 PR,口径已一致为 rc.16 published)