### PR TITLE
fix(ci): point package-lock resolved URLs at the official registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,7 +1836,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/@tanstack/react-virtual": {
       "version": "3.14.10",
-      "resolved": "https://bnpm.byted.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
       "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
       "license": "MIT",
       "dependencies": {
@@ -1853,7 +1853,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react": {
       "version": "19.2.8",
-      "resolved": "https://bnpm.byted.org/react/-/react-19.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
@@ -1863,7 +1863,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react-dom": {
       "version": "19.2.8",
-      "resolved": "https://bnpm.byted.org/react-dom/-/react-dom-19.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "peer": true,
@@ -6270,7 +6270,7 @@
     },
     "node_modules/@tanstack/virtual-core": {
       "version": "3.17.8",
-      "resolved": "https://bnpm.byted.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
       "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
       "license": "MIT",
       "funding": {
@@ -7926,7 +7926,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://bnpm.byted.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
       "peer": true,
@@ -8561,7 +8561,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://bnpm.byted.org/react/-/react-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
       "peer": true,
@@ -8700,7 +8700,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://bnpm.byted.org/scheduler/-/scheduler-0.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT",
       "peer": true


### PR DESCRIPTION
45b0958 重生成 lockfile 时 resolved URL 记录了内网镜像 bnpm.byted.org（7 处），GitHub runner 与 UAT 构建主机均无法解析，npm ci 直接 ENOTFOUND。本 PR 仅把 resolved host 换回 registry.npmjs.org——包与 integrity 哈希完全不变。本地 `npm ci --dry-run` 验证通过。