### PR TITLE
fix(release): rebuild node-pty natively despite --ignore-scripts

### DIFF
--- a/scripts/build-booking-copilot-release.mjs
+++ b/scripts/build-booking-copilot-release.mjs
@@ -104,6 +104,13 @@ try {
   // Release consumers must resolve the complete DSH peer closure just like
   // the repository consumer. Keep strict resolution explicit at this seam.
   run('npm', ['ci', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund', '--strict-peer-deps=true', '--legacy-peer-deps=false'], release)
+  // --ignore-scripts also skips node-pty's native build, so the linux
+  // spawn-helper never exists and every planner PTY spawn fails. Rebuild the
+  // one package that legitimately needs install scripts, then restore the
+  // prebuilt helper's executable bit.
+  run('npm', ['rebuild', 'node-pty', '--ignore-scripts=false', '--no-audit', '--no-fund'], release)
+  const dshSubprocessLocal = join(release, 'node_modules/@deepseek-ai/dsh-subprocess-local/scripts/ensure-spawn-helper.mjs')
+  if (existsSync(dshSubprocessLocal)) run('node', [dshSubprocessLocal], release)
   const packageJson = JSON.parse(readFileSync(join(source, 'package.json'), 'utf8'))
   writeFileSync(join(release, 'package.json'), `${JSON.stringify({
     name: packageJson.name,


### PR DESCRIPTION
UAT 实测：release artifact 内 planner 每次会话秒失败（PLANNER_FAILED @ typed runtime boundary）。根因：release builder 的 `npm ci --ignore-scripts` 跳过了 node-pty 安装脚本，linux 的 `spawn-helper` 从未编译产生（prebuilds 只带 darwin 版），PTY spawn 即刻抛错。

修复：npm ci 后显式 `npm rebuild node-pty`（主机需 gcc/make/python3，Ubuntu 24 自带），并执行 dsh-subprocess-local 的 ensure-spawn-helper 恢复执行位——全部发生在 MANIFEST 写入前，产物清单自洽。