### PR TITLE
fix(booking): keep BookingReadAction a type-only import; smoke the dist

### DIFF
--- a/scripts/build-booking-copilot-release.mjs
+++ b/scripts/build-booking-copilot-release.mjs
@@ -100,6 +100,10 @@ try {
     execFileSync('cp', ['-p', join(source, path), target], { env: childEnv })
   }
   execFileSync('cp', ['-a', join(source, 'dist'), join(release, 'dist')], { env: childEnv })
+  // The typed dist must load under the released runtime: a type-only symbol
+  // accidentally imported as a value survives tsc but crashes Node at boot.
+  execFileSync('/usr/bin/env', ['node', '--input-type=module', '-e',
+    `await import(${JSON.stringify('file://' + join(release, 'dist/src/booking-surface/startup.js'))})`], { env: childEnv })
   probeNode24()
   // Release consumers must resolve the complete DSH peer closure just like
   // the repository consumer. Keep strict resolution explicit at this seam.

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -13,7 +13,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { BOOKING_SURFACE_SCHEMA_VERSION, type BookingCopilotTurn, BookingReadAction, type BookingSurfaceEvent } from './contracts.ts'
+import { BOOKING_SURFACE_SCHEMA_VERSION, type BookingCopilotTurn, type BookingReadAction, type BookingSurfaceEvent } from './contracts.ts'
 import {
   EMBEDDED_BOOKING_CAPABILITY_IDS,
   actionsForEmbeddedCapability,


### PR DESCRIPTION
#150 的补丁把 type-only 的 `BookingReadAction` 挪进了 value import：tsc 通过，但 release ESM dist 运行时无法解析，服务启动即崩（UAT 已回滚到上一 artifact 恢复）。本 PR 恢复 type-only 形式，并在 release builder 复制 dist 后增加一次 `import(dist/startup.js)` 冒烟，让这类错误在构建期失败。contract proof 通过。