### PR TITLE
feat(booking): log raw planner boundary errors to the server journal

### DIFF
--- a/ts/src/booking-surface/server.ts
+++ b/ts/src/booking-surface/server.ts
@@ -188,6 +188,9 @@ function fallbackErrorEvent(task: BookingCopilotTaskState, code: string): Bookin
 
 function writeTypedError(res: ServerResponse, composition: BookingCopilotComposition, task: BookingCopilotTaskState, error: unknown, requestKey?: string, includeSubmitted = false): void {
   const code = normalizeBookingErrorCode(error)
+  // Operator-side diagnosability only: the raw boundary error stays on the
+  // server stderr/journal; clients keep receiving the safe typed vocabulary.
+  console.error(`[booking-copilot] planner boundary error (${code}):`, error instanceof Error ? error.stack || error.message : error)
   try {
     const decision = { kind: 'error' as const, error: { code, message: safeBookingErrorMessage(code), retryable: false } }
     if (requestKey) {


### PR DESCRIPTION
O-1 排查必需：客户端流只含安全词汇（PLANNER_FAILED），运维侧无法看到底层 planner 失败原因。本 PR 在 writeTypedError 处向服务端 stderr 输出原始错误（含 stack）——只进 journal，不进客户端流。