### PR TITLE
fix(booking): stringify repaired array elements to satisfy string-item schemas

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -291,7 +291,7 @@ function repairActionRepresentation(action: unknown): void {
       if (messagePart === 'must be array') {
         const current = actionValueAt(action, pathPart)
         if (!Array.isArray(current)) {
-          actionAssignAt(action, pathPart, current === undefined || current === null || current === '' ? [] : [current])
+          actionAssignAt(action, pathPart, current === undefined || current === null || current === '' ? [] : [String(current)])
           mutated = true
         }
       } else if ((messagePart === 'must be integer' || messagePart === 'must be number') && typeof actionValueAt(action, pathPart) === 'string') {


### PR DESCRIPTION
UAT 心跳采样新签名：`factRefs/0: must be string`——矫正时把标量包进数组但未转字符串（模型输出了非字符串标量）。改为 String() 包裹。