### PR TITLE
fix(booking): default the embedded planner to deepseek-v4-pro

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -182,7 +182,7 @@ async function createRealRunPort(options: DshEmbeddedBookingPlannerOptions): Pro
       processCwd: options.stateRoot ?? process.cwd(),
       cwd: options.stateRoot ?? process.cwd(),
       provider: options.provider ?? 'deepseek-official',
-      model: options.model ?? 'deepseek-v4-flash',
+      model: options.model ?? 'deepseek-v4-pro',
       maxTokens: options.maxTokens ?? 2_048,
       env: childEnv,
       ...(options.dshBin ? { dshBin: options.dshBin } : {}),


### PR DESCRIPTION
网关 A/B 单发探针：pro 通道输出完整（1815 字符 vs flash 1291），表示错误长尾预期收敛。本轮实测验收 10 轮为准。