### PR TITLE
fix(booking): default the embedded planner to glm-4.6

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -182,7 +182,7 @@ async function createRealRunPort(options: DshEmbeddedBookingPlannerOptions): Pro
       processCwd: options.stateRoot ?? process.cwd(),
       cwd: options.stateRoot ?? process.cwd(),
       provider: options.provider ?? 'deepseek-official',
-      model: options.model ?? 'deepseek-v4-pro',
+      model: options.model ?? 'glm-4.6',
       maxTokens: options.maxTokens ?? 2_048,
       env: childEnv,
       ...(options.dshBin ? { dshBin: options.dshBin } : {}),


### PR DESCRIPTION
通道 A/B：glm-4.6 背靠背探针连续完美服从 typed 决策契约；MiniMax-M2.7 被 429 限流。10 轮全链路实测为准。