### PR TITLE
fix(booking-surface): journal prose-only planner responses; content-key proof mock

### DIFF
--- a/ts/scripts/booking-copilot-dsh-core-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-core-proof-tests.ts
@@ -46,6 +46,7 @@ function objectKeys(value: unknown): string[] {
 
 const requests: Array<{ headers: Record<string, string | string[] | undefined>; body: any }> = []
 let modelCall = 0
+let continuationServed = false
 const modelServer = createServer((req, res) => {
   const parts: Buffer[] = []
   req.on('data', (part: Buffer) => parts.push(part))
@@ -53,6 +54,17 @@ const modelServer = createServer((req, res) => {
     const body = JSON.parse(Buffer.concat(parts).toString('utf8'))
     requests.push({ headers: req.headers, body })
     modelCall += 1
+    // Script by request content, not call order: the prose-only retry budget
+    // issues additional runs whose scripted response must stay prose, not the
+    // continuation terminal.
+    if (!continuationServed && JSON.stringify(body).includes('action.receipt.continuation')) {
+      continuationServed = true
+      sse(res, [{
+        id: 'chatcmpl-booking-continuation', object: 'chat.completion.chunk', created: 0, model: 'deepseek-v4-flash',
+        choices: [{ index: 0, delta: { role: 'assistant', tool_calls: [{ index: 0, id: 'call-booking-continuation', type: 'function', function: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'terminal', terminal: { status: 'stopped', summary: 'receipt continuation handled', factRefs: [] } } }) } }] }, finish_reason: 'tool_calls' }],
+      }])
+      return
+    }
     if (modelCall === 1) {
       sse(res, [{
         id: 'chatcmpl-booking-1',
@@ -76,13 +88,6 @@ const modelServer = createServer((req, res) => {
           finish_reason: 'tool_calls',
         }],
         usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
-      }])
-      return
-    }
-    if (modelCall === 4) {
-      sse(res, [{
-        id: 'chatcmpl-booking-continuation', object: 'chat.completion.chunk', created: 0, model: 'deepseek-v4-flash',
-        choices: [{ index: 0, delta: { role: 'assistant', tool_calls: [{ index: 0, id: 'call-booking-continuation', type: 'function', function: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'terminal', terminal: { status: 'stopped', summary: 'receipt continuation handled', factRefs: [] } } }) } }] }, finish_reason: 'tool_calls' }],
       }])
       return
     }

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -424,6 +424,9 @@ export async function createDshEmbeddedBookingPlanner(
             try {
               const result = await runPort.run(plannerPrompt(turn, task), { sessionId })
               decisions = result.events.map((event) => parseToolDecision(event, task)).filter((decision): decision is BookingPlannerDecision => decision !== null)
+              if (decisions.length === 0) {
+                console.error(`[booking-copilot] prose-only planner response (attempt ${attempt}):`, JSON.stringify(result.events).slice(0, 800))
+              }
             } catch (error) {
               const retryable = attempt < 3 && error instanceof Error && /^planner_(invalid|forbidden|question_runtime_owned)/.test(error.message)
               if (!retryable) throw error


### PR DESCRIPTION
UAT 10 轮探针出现 2 轮 PLANNER_TYPED_DECISION_REQUIRED（全新任务首轮即 3 连 prose-only），该空决策重试路径此前零日志。①每次空决策尝试落一行原始 events journal（对齐 #174 先例）；②core proof mock 改按请求内容编排（原全局计数把 continuation terminal 泄漏进 prose 重试预算，基线即红），continuation terminal 只服务一次避免 post-tool transcript 请求循环 OOM。两套 proof 全绿 + tsc 通过。