### PR TITLE
fix(booking-surface): journal model finalResponse and harness notifications on empty decisions

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -48,6 +48,8 @@ export interface DshPlannerRunResult {
   finalResponse: string
   /** DeepSeek Harness Session events for this one receipt-to-idle interval. */
   events: readonly unknown[]
+  /** Harness wire notifications (LLM errors/retries land here); absent on test seams. */
+  notifications?: readonly unknown[]
 }
 
 export interface DshPlannerRunPort {
@@ -75,6 +77,7 @@ export interface DshEmbeddedBookingPlannerHandle {
 interface HarnessRunResultLike {
   finalResponse?: unknown
   events?: unknown
+  notifications?: unknown
 }
 
 interface HarnessLike {
@@ -199,6 +202,7 @@ async function createRealRunPort(options: DshEmbeddedBookingPlannerOptions): Pro
       return {
         finalResponse: typeof result.finalResponse === 'string' ? result.finalResponse : '',
         events: Array.isArray(result.events) ? result.events : [],
+        notifications: Array.isArray(result.notifications) ? result.notifications : [],
       }
     },
     async close() {
@@ -425,7 +429,11 @@ export async function createDshEmbeddedBookingPlanner(
               const result = await runPort.run(plannerPrompt(turn, task), { sessionId })
               decisions = result.events.map((event) => parseToolDecision(event, task)).filter((decision): decision is BookingPlannerDecision => decision !== null)
               if (decisions.length === 0) {
-                console.error(`[booking-copilot] prose-only planner response (attempt ${attempt}):`, JSON.stringify(result.events).slice(0, 800))
+                console.error(`[booking-copilot] empty planner decision (attempt ${attempt}):`, JSON.stringify({
+                  finalResponse: result.finalResponse,
+                  notifications: result.notifications ?? [],
+                  events: result.events,
+                }).slice(0, 2000))
               }
             } catch (error) {
               const retryable = attempt < 3 && error instanceof Error && /^planner_(invalid|forbidden|question_runtime_owned)/.test(error.message)


### PR DESCRIPTION
空决策 journal 此前只落 harness session events（只有 inbox 回显），既没有 assistant 文本也没有 LLM 层错误/重试通知——'无 tool-call'与'模型根本无输出'无法区分。真实 run port 带出 finalResponse + notifications，空决策时一并落 journal（2KB 截断）。下轮复现即可拿到真实根因证据。两套 proof + tsc 全绿。