### PR TITLE
fix(booking-surface): execute text-channel typed decisions through the authority path

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -2,8 +2,10 @@
  * Embedded Booking planner adapter proof.
  *
  * The fake below stops at the DeepSeek Harness SDK event boundary: planner
- * decisions may only come from typed dsh tool/call events, never assistant
- * prose. A separate core proof boots the real dsh SDK runtime.
+ * decisions come from typed dsh tool/call events, or from assistant
+ * finalResponse text only after it passes the same authority path
+ * (validation, allowedActions, contextRef, runtime-owned revision). A
+ * separate core proof boots the real dsh SDK runtime.
  */
 
 import assert from 'node:assert/strict'
@@ -181,14 +183,14 @@ assert.equal(childEnv.PORTAL_TOKEN, undefined)
 assert.equal(childEnv.HOTELBYTE_TOKEN, undefined)
 assert.equal(childEnv.GOTRY_BOOKING_COPILOT_API_KEY, undefined)
 
-const proseOnlyPort: DshPlannerRunPort = {
+const textChannelPort: DshPlannerRunPort = {
   async run() {
     return { finalResponse: JSON.stringify({ kind: 'operation', action: searchRun }), events: [] }
   },
   async close() {},
 }
-const proseOnly = await createDshEmbeddedBookingPlanner({ runPort: proseOnlyPort })
-const proseDecisions = await proseOnly.plannerFactory(task).next({
+const textChannel = await createDshEmbeddedBookingPlanner({ runPort: textChannelPort })
+const textDecisions = await textChannel.plannerFactory(task).next({
   task,
   turn: {
     schemaVersion: 'booking.surface',
@@ -202,7 +204,51 @@ const proseDecisions = await proseOnly.plannerFactory(task).next({
     request: { text: 'JSON prose must stay prose' },
   },
 })
-assert.equal(proseDecisions[0]?.kind, 'error', 'JSON-looking assistant prose is never executable')
+assert.equal(textDecisions[0]?.kind, 'operation', 'text-channel typed decisions execute through the same authority path')
+assert.deepEqual((textDecisions[0] as { action?: { actionId?: string; expectedRevision?: number } }).action, { ...searchRun, expectedRevision: 0 })
+
+const unauthorisedPort: DshPlannerRunPort = {
+  async run() {
+    return { finalResponse: JSON.stringify({ kind: 'operation', action: hotelSelect }), events: [] }
+  },
+  async close() {},
+}
+const unauthorised = await createDshEmbeddedBookingPlanner({ runPort: unauthorisedPort })
+const unauthorisedDecisions = await unauthorised.plannerFactory(task).next({
+  task,
+  turn: {
+    schemaVersion: 'booking.surface',
+    kind: 'user.turn',
+    taskId: task.taskId,
+    turnId: 'dsh-turn-4',
+    workspace: {
+      ...workspace,
+      capabilities: { ...workspace.capabilities, allowedActions: [...workspace.capabilities.allowedActions] },
+    },
+    request: { text: 'Select a hotel' },
+  },
+})
+assert.equal(unauthorisedDecisions[0]?.kind, 'error', 'text-channel decisions outside allowedActions stay non-executable')
+
+const plainProsePort: DshPlannerRunPort = {
+  async run() {
+    return { finalResponse: 'I would search hotels in Dubai for you.', events: [] }
+  },
+  async close() {},
+}
+const plainProse = await createDshEmbeddedBookingPlanner({ runPort: plainProsePort })
+const plainProseDecisions = await plainProse.plannerFactory(task).next({
+  task,
+  turn: {
+    schemaVersion: 'booking.surface',
+    kind: 'user.turn',
+    taskId: task.taskId,
+    turnId: 'dsh-turn-5',
+    workspace,
+    request: { text: 'Find hotels' },
+  },
+})
+assert.equal(plainProseDecisions[0]?.kind, 'error', 'prose without a typed decision envelope is never executable')
 
 const forbiddenPort: DshPlannerRunPort = {
   async run() {
@@ -259,5 +305,5 @@ await assert.rejects(
   /planner_identity_required/,
 )
 
-await Promise.all([adapter.close(), proseOnly.close(), forbidden.close(), terminalAdapter.close()])
+await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), plainProse.close(), forbidden.close(), terminalAdapter.close()])
 console.log('BOOKING COPILOT DSH PLANNER PROOF: task session/typed tool decisions/no Book/no prose parser/no portal token OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -338,6 +338,40 @@ function repairActionRepresentation(action: unknown): void {
   if (candidate) Object.assign(action, candidate)
 }
 
+function recoverFinalResponseDecision(response: string, task: BookingCopilotTaskState): BookingPlannerDecision | null {
+  const text = response.trim()
+  if (!text.includes('{')) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    const fenced = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/)
+    const candidate = fenced ? fenced[1]! : text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1)
+    try { parsed = JSON.parse(candidate) } catch { return null }
+  }
+  let envelope = parsed
+  if (isRecord(envelope) && isRecord(envelope.decision)) envelope = envelope.decision
+  if (!isRecord(envelope) || envelope.kind !== 'operation' || !isRecord(envelope.action)) return null
+  const action: Record<string, unknown> = { ...envelope.action }
+  if (typeof action.kind !== 'string' || !(BOOKING_READ_ACTION_KINDS as readonly string[]).includes(action.kind)) return null
+  if (typeof action === 'object' && typeof (action as Record<string, unknown>).schemaVersion !== 'string') {
+    ;(action as Record<string, unknown>).schemaVersion = 'booking.surface'
+  }
+  repairActionRepresentation(action)
+  const validation = validateBookingReadAction(action as unknown as BookingReadAction)
+  if (!validation.ok) {
+    console.error('[booking-copilot] finalResponse recovery rejected (invalid action):', JSON.stringify({ kind: action.kind, errors: validation.errors.slice(0, 6) }).slice(0, 600))
+    return null
+  }
+  const typed = action as unknown as BookingReadAction
+  if (!task.allowedActions.includes(typed.kind)) return null
+  if (typed.contextRef !== task.contextRef) return null
+  if (typed.relaxationApprovalRef) return null
+  typed.expectedRevision = task.revision
+  console.error('[booking-copilot] recovered typed decision from finalResponse:', JSON.stringify({ kind: typed.kind, actionId: typed.actionId }).slice(0, 240))
+  return { kind: 'operation', action: typed }
+}
+
 function parseToolDecision(event: unknown, task: BookingCopilotTaskState): BookingPlannerDecision | null {
   if (!isRecord(event) || event.type !== 'tool/call' || !isRecord(event.data)) return null
   const name = event.data.name
@@ -434,6 +468,11 @@ export async function createDshEmbeddedBookingPlanner(
                   notifications: result.notifications ?? [],
                   events: result.events,
                 }).slice(0, 2000))
+                // Models answer in the text channel with a fully typed
+                // decision envelope; dropping it fails turns the model
+                // actually solved. Same validation path as tool calls.
+                const recovered = recoverFinalResponseDecision(result.finalResponse, task)
+                if (recovered) return [recovered]
               }
             } catch (error) {
               const retryable = attempt < 3 && error instanceof Error && /^planner_(invalid|forbidden|question_runtime_owned)/.test(error.message)


### PR DESCRIPTION
UAT journal 实证：全新任务首轮，模型在 finalResponse 文本里给出完整合法的 search.patch decision（destination/occupancy/stay 全对、contextRef 匹配），无 tool/call 事件；planner 只认 tool 通道，把正确决策丢弃并报 PLANNER_TYPED_DECISION_REQUIRED。通道是传输不是权威：从 finalResponse 恢复类型化决策，走与 tool-call 完全相同的 repair→validate→allowedActions→contextRef→revision 钉定管线；无信封纯 prose 与越权 action 仍拒绝（新增三个 proof 用例）。两套 proof + tsc 全绿。