### PR TITLE
fix(booking-surface): enforce runtime opaque-ref charset inside the planner retry budget

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -230,6 +230,36 @@ const unauthorisedDecisions = await unauthorised.plannerFactory(task).next({
 })
 assert.equal(unauthorisedDecisions[0]?.kind, 'error', 'text-channel decisions outside allowedActions stay non-executable')
 
+const unsafeRefPort: DshPlannerRunPort = {
+  async run() {
+    return {
+      finalResponse: '',
+      events: [{
+        type: 'tool/call',
+        data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, factRefs: ['draft:destination=Dubai'] } } }) },
+      }],
+    }
+  },
+  async close() {},
+}
+const unsafeRef = await createDshEmbeddedBookingPlanner({ runPort: unsafeRefPort })
+await assert.rejects(
+  unsafeRef.plannerFactory(task).next({
+    task,
+    turn: {
+      schemaVersion: 'booking.surface',
+      kind: 'user.turn',
+      taskId: task.taskId,
+      turnId: 'dsh-turn-6',
+      workspace,
+      request: { text: 'Find hotels' },
+    },
+  }),
+  /planner_invalid_action:unsafe_fact_ref/,
+  'model-invented unsafe refs retry as parse-class failures, not ledger-boundary crashes',
+)
+await unsafeRef.close()
+
 const plainProsePort: DshPlannerRunPort = {
   async run() {
     return { finalResponse: 'I would search hotels in Dubai for you.', events: [] }
@@ -305,5 +335,5 @@ await assert.rejects(
   /planner_identity_required/,
 )
 
-await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), plainProse.close(), forbidden.close(), terminalAdapter.close()])
+await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), forbidden.close(), terminalAdapter.close()])
 console.log('BOOKING COPILOT DSH PLANNER PROOF: task session/typed tool decisions/no Book/no prose parser/no portal token OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -363,6 +363,12 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
     console.error('[booking-copilot] finalResponse recovery rejected (invalid action):', JSON.stringify({ kind: action.kind, errors: validation.errors.slice(0, 6) }).slice(0, 600))
     return null
   }
+  try {
+    assertPlannerSafeRefs(action)
+  } catch (error) {
+    console.error('[booking-copilot] finalResponse recovery rejected (unsafe ref):', JSON.stringify({ actionId: action.actionId, factRefs: action.factRefs }).slice(0, 600))
+    return null
+  }
   const typed = action as unknown as BookingReadAction
   if (!task.allowedActions.includes(typed.kind)) return null
   if (typed.contextRef !== task.contextRef) return null
@@ -370,6 +376,23 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
   typed.expectedRevision = task.revision
   console.error('[booking-copilot] recovered typed decision from finalResponse:', JSON.stringify({ kind: typed.kind, actionId: typed.actionId }).slice(0, 240))
   return { kind: 'operation', action: typed }
+}
+
+const PLANNER_SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:._-]*$/
+
+function assertPlannerSafeRefs(action: Record<string, unknown>): void {
+  const actionId = action.actionId
+  if (typeof actionId !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(actionId)) {
+    throw new Error(`planner_invalid_action:unsafe_action_id:${String(actionId).slice(0, 60)}`)
+  }
+  const factRefs = action.factRefs
+  if (Array.isArray(factRefs)) {
+    for (const ref of factRefs) {
+      if (typeof ref !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(ref)) {
+        throw new Error(`planner_invalid_action:unsafe_fact_ref:${String(ref).slice(0, 60)}`)
+      }
+    }
+  }
 }
 
 function parseToolDecision(event: unknown, task: BookingCopilotTaskState): BookingPlannerDecision | null {
@@ -419,6 +442,11 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
     console.error(`[booking-copilot] raw invalid action (${decision.action && typeof decision.action === 'object' ? (decision.action as Record<string, unknown>).kind : '?'}):`, JSON.stringify({ errors: validation.errors.slice(0, 8), action: decision.action }).slice(0, 1200))
     throw new Error(`planner_invalid_action:${validation.errors.join('; ')}`)
   }
+  // The runtime rejects opaque refs outside its safe charset at the ledger
+  // boundary, past the retry budget. Enforce the same charset here so a
+  // model-invented unsafe ref retries as a parse-class failure instead of
+  // failing the turn as PLANNER_FAILED.
+  assertPlannerSafeRefs(decision.action)
   const action = decision.action as unknown as BookingReadAction
   const capability = TOOL_TO_CAPABILITY.get(name as DshEmbeddedBookingToolName)
   if (!capability || !actionsForEmbeddedCapability(capability).includes(action.kind)) throw new Error(`planner_capability_action_mismatch:${name}:${action.kind}`)


### PR DESCRIPTION
UAT 心跳捕获新签名 PLANNER_FAILED: unsafe_opaque_ref（1/20 轮）：runtime 在 ledger 边界对 actionId/factRefs 做安全字符集断言，但该边界在 planner 重试预算之外——模型自创一个不安全 factRef（如含 '='）就整轮不可重试失败。把同一字符集检查前移到 planner seam：违规归类 planner_invalid_action 走既有重试预算并落候选日志；finalResponse 恢复路径同样拒绝不安全 ref。新增 proof 用例锁行为。两套 proof + tsc 全绿。