### PR TITLE
feat(tools): dsh-map-tools npm 依赖接入(#139 选项 B)

### DIFF
--- a/bin/gotry-inner.js
+++ b/bin/gotry-inner.js
@@ -369,6 +369,10 @@ if (!benchmarkEnvironmentConfig) {
     // npm 布局:子路径可能被 exports 挡(resolve 抛错不能留下旧值),裸包名返回真实入口
     try { mapEntry = require_.resolve('dsh-map-tools/lib/index.js') } catch { mapEntry = '' }
     if (!mapEntry) { try { mapEntry = require_.resolve('dsh-map-tools') } catch { mapEntry = '' } }
+    if (!mapEntry) {
+      // ts/node_modules 回退(source 模式:dsh-map-tools 安装在 ts/package.json)
+      try { mapEntry = require_.resolve(join(repoRoot, 'ts/node_modules/dsh-map-tools')) } catch { mapEntry = '' }
+    }
   }
 }
 // 结构化澄清卡(T2):ask_user_question 工具 + user-questions 服务,从 dsh 包

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -13,6 +13,7 @@
         "@deepseek-ai/schemastery": "^3.18.2",
         "@types/better-sqlite3": "^9.6.0",
         "better-sqlite3": "^13.0.3",
+        "dsh-map-tools": "0.5.1",
         "z3-solver": "^5.2.0"
       },
       "devDependencies": {
@@ -54,160 +55,11 @@
       "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
       "license": "MIT"
     },
-    "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-K1Pj9wqXmXjbMv4//wbPEPzaRBIYGluLzgnym2NPZFr9uS5h1soowUWVmI0lb3iU5FIUKuCg7YYEOrGSwPtRhQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-session": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-session-projection": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-alpha.3"
-      }
-    },
     "node_modules/@deepseek-ai/dsh-brand": {
       "version": "0.1.2-alpha.3",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-alpha.3.tgz",
       "integrity": "sha512-Wttwt7HN09rdqVpcZj4ZRSbEjkoHC46+Bw/ik9DllmkNOYh8cNVELeJZPdCh+lk3bifJttTB/OI79B0N95xDxg==",
       "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-+cHj36Z4aQVlIawfPO7vv1/8abbKDBbLVS96ld8cktOzy43L2Dugm3SjbicMkSMXvvp/W0rUO+utp4B7R+fcLw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-Y7O9XtME9u8HBtIT5b1tD32L3kTLRDnwpNw99MVmVWAcrHAZ40qbLnyH3DxiZi6nuKutbqsG1Bmypwt9hyUUng==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-xGedBtvxb1HJWCmVO9v3fhHqoZ1iMDQU1x7fqAhhDfjKjmLTljWC1/RdZqUFI/1a/CM1iGPSaDuPZDCMu45AtA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-timeout": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-util-crypto": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-util-values": "^0.1.2-alpha.3",
-        "@deepseek-ai/schemastery": "^3.18.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm/node_modules/zod": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
-      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-AeDC+NdV0cgZYDmqib0e7+RT1Fsjf/MI95Wo/zMfjvUo7tQzZND5i0BQg2jTHwqjx2l5JaEw9mFcqSOVvjl+zA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-iwWs0FdShoiCLLVk6lSZL18vKlFuliQXqy6gnu4U34B8K3uPb+QYWHjB3PrTXcK8ZVmb0zdWeyZ9osmANWWKnw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-util-values": "^0.1.2-alpha.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-IyiPZMXb8/xVBk0rc0nCu4bglGmszCVtraqt82WbspEAINSBdCf/ydLM15Fw+m0jB7K2fwgKg1ejGcXKnfpOoQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-session": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-projection/node_modules/zod": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
-      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-R+VVDew/0DdTypypAjkgTygh3M2yNYXNFO+DvMfdX98jgD7MSluw2iYaCFR/ax9bBNHXXHQ7eXHsIYI1a0FrPg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-BWCusO6Q3GPl5NsUJVNggKF4lOyij5IG5dSgAVdoDhB25b7TAnNHEzUvGt4qxBbQE2xGmeAj+WA0QG1E2X/NuQ==",
-      "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
         "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3"
@@ -233,48 +85,6 @@
         "@deepseek-ai/dsh-session": "^0.1.2-alpha.3",
         "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.3",
         "@deepseek-ai/dsh-user-approval": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-yE3qjCbbOD0y4c0rv7hYq2sV/kLsoJ/m8+a6d8uNlEwV+W74HtpuWS8VjfWqRJZCcDRpv7yvu+/6Arw0vYl0Xg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-ulp0zA1JnzrjJVyg4DbKMR6Vxz66+ltbIXKhDQcrPgYE93woI0U2VoWiQPuvlozcWqpEvDsmsmdM3rMTxQrB0A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-session": "^0.1.2-alpha.3",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.3"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-util-crypto": {
-      "version": "0.1.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-alpha.3.tgz",
-      "integrity": "sha512-bjHvzi4C4Xm04NNbYQChWBcPG7IJeujKxyKQYwY+muw+BC3EVVWw3JMovrjYdHzmu0/ePS0z0rAho73Etl4BVg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.3"
       }
     },
     "node_modules/@deepseek-ai/dsh-util-values": {
@@ -896,6 +706,23 @@
       "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dsh-map-tools": {
+      "version": "0.5.1",
+      "resolved": "https://bnpm.byted.org/dsh-map-tools/-/dsh-map-tools-0.5.1.tgz",
+      "integrity": "sha512-eeleEIBbs1YFr3f32/PW2yprnybZO2/EcavSmdf7DZ2CzmuAPCQBzIXN/Ta+GQ5iZdtlq87ko0NImqbNs1scxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": ">=0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": ">=0.1.2-rc.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -15,6 +15,7 @@
     "@deepseek-ai/schemastery": "^3.18.2",
     "@types/better-sqlite3": "^9.6.0",
     "better-sqlite3": "^13.0.3",
+    "dsh-map-tools": "0.5.1",
     "z3-solver": "^5.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 摘要

按 issue #139 决策包建议 B 落地:`ts/package.json` 精确 pin `dsh-map-tools@0.5.1`(唯一依赖 schemastery 已在 dsh 家族);`bin/gotry-inner.js` 增加 `ts/node_modules` 回退解析路径(source 模式下 bin/ 的 require 不遍历 ts/node_modules)。零 key 走 OSM/OSRM,地图/路线/POI 工具接入会话。

## 验证
- 全栈回归 run-all §1-§51 ALL SUITES GREEN(exit 0);
- `dsh-map-tools` 可从 `bin/gotry-inner.js` 解析上下文正确 resolve 到 `ts/node_modules/dsh-map-tools/lib/index.js`;
- npm 2026-09-06 实查:v0.5.1 在架,唯一依赖 schemastery,104KB,活跃维护。

Closes #139