### PR TITLE
fix(booking-surface): repair JSON-pointer fragment factRefs into the safe charset

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -230,6 +230,37 @@ const unauthorisedDecisions = await unauthorised.plannerFactory(task).next({
 })
 assert.equal(unauthorisedDecisions[0]?.kind, 'error', 'text-channel decisions outside allowedActions stay non-executable')
 
+const fragmentRefPort: DshPlannerRunPort = {
+  async run() {
+    return {
+      finalResponse: '',
+      events: [{
+        type: 'tool/call',
+        data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, factRefs: [`turn_${task.lastTurnId}#request`] } } }) },
+      }],
+    }
+  },
+  async close() {},
+}
+const fragmentRef = await createDshEmbeddedBookingPlanner({ runPort: fragmentRefPort })
+const fragmentDecisions = await fragmentRef.plannerFactory(task).next({
+  task,
+  turn: {
+    schemaVersion: 'booking.surface',
+    kind: 'user.turn',
+    taskId: task.taskId,
+    turnId: 'dsh-turn-7',
+    workspace,
+    request: { text: 'Find hotels' },
+  },
+})
+assert.equal(fragmentDecisions[0]?.kind, 'operation', 'JSON-pointer fragment factRefs repair into the safe charset')
+assert.deepEqual(
+  (fragmentDecisions[0] as { action?: { factRefs?: string[] } }).action?.factRefs,
+  [`turn_${task.lastTurnId}:request`],
+)
+await fragmentRef.close()
+
 const unsafeRefPort: DshPlannerRunPort = {
   async run() {
     return {
@@ -335,5 +366,5 @@ await assert.rejects(
   /planner_identity_required/,
 )
 
-await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), forbidden.close(), terminalAdapter.close()])
+await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), fragmentRef.close(), forbidden.close(), terminalAdapter.close()])
 console.log('BOOKING COPILOT DSH PLANNER PROOF: task session/typed tool decisions/no Book/no prose parser/no portal token OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -363,6 +363,7 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
     console.error('[booking-copilot] finalResponse recovery rejected (invalid action):', JSON.stringify({ kind: action.kind, errors: validation.errors.slice(0, 6) }).slice(0, 600))
     return null
   }
+  repairPlannerFactRefs(action)
   try {
     assertPlannerSafeRefs(action)
   } catch (error) {
@@ -379,6 +380,15 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
 }
 
 const PLANNER_SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:._-]*$/
+
+// Models cite prompt facts with JSON-pointer fragment syntax (`turn_X#request`);
+// `#` sits outside the runtime ref charset while `:` is inside, and the mapping
+// is deterministic, so repair instead of burning the retry budget.
+function repairPlannerFactRefs(action: Record<string, unknown>): void {
+  const factRefs = action.factRefs
+  if (!Array.isArray(factRefs)) return
+  action.factRefs = factRefs.map((ref) => (typeof ref === 'string' ? ref.replace(/#/g, ':') : ref))
+}
 
 function assertPlannerSafeRefs(action: Record<string, unknown>): void {
   const actionId = action.actionId
@@ -443,9 +453,10 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
     throw new Error(`planner_invalid_action:${validation.errors.join('; ')}`)
   }
   // The runtime rejects opaque refs outside its safe charset at the ledger
-  // boundary, past the retry budget. Enforce the same charset here so a
-  // model-invented unsafe ref retries as a parse-class failure instead of
-  // failing the turn as PLANNER_FAILED.
+  // boundary, past the retry budget. Repair the common fragment syntax first,
+  // then enforce the same charset here so remaining violations retry as
+  // parse-class failures instead of failing the turn as PLANNER_FAILED.
+  repairPlannerFactRefs(decision.action)
   assertPlannerSafeRefs(decision.action)
   const action = decision.action as unknown as BookingReadAction
   const capability = TOOL_TO_CAPABILITY.get(name as DshEmbeddedBookingToolName)


### PR DESCRIPTION
#179 闸门上线后首个失败签名：模型确定性地以 turn_X#request（JSON 片段语法）引用 prompt 事实，'#' 不在 runtime 安全字符集，3 连重试同形同炸，末次尝试仍以 PLANNER_FAILED 透出。在 planner seam 的安全闸门前把 '#' 确定性映射为 ':'（字符集内、无碰撞歧义）；其余不安全字符仍按 parse-class 重试。新增 fragment 修复 proof 用例（tool 通道验证映射结果）。两套 proof + tsc 全绿。