### PR TITLE
fix(booking-surface): recover truncated finalResponse decisions from reasoning-budget cuts

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -261,6 +261,30 @@ assert.deepEqual(
 )
 await fragmentRef.close()
 
+const truncatedPort: DshPlannerRunPort = {
+  async run() {
+    // Real UAT capture: a reasoning-token budget cut the visible JSON before
+    // its closing braces; the authority path must still judge the payload.
+    const truncated = JSON.stringify({ decision: { action: { ...searchRun, factRefs: ['turn_cap-request'] }, kind: 'operation' } }).replace(/}+$/, '')
+    return { finalResponse: truncated, events: [] }
+  },
+  async close() {},
+}
+const truncatedRecovery = await createDshEmbeddedBookingPlanner({ runPort: truncatedPort })
+const truncatedDecisions = await truncatedRecovery.plannerFactory(task).next({
+  task,
+  turn: {
+    schemaVersion: 'booking.surface',
+    kind: 'user.turn',
+    taskId: task.taskId,
+    turnId: 'dsh-turn-8',
+    workspace,
+    request: { text: 'Find hotels' },
+  },
+})
+assert.equal(truncatedDecisions[0]?.kind, 'operation', 'truncated-but-reconstructable finalResponse recovers through the authority path')
+await truncatedRecovery.close()
+
 const unsafeRefPort: DshPlannerRunPort = {
   async run() {
     return {
@@ -366,5 +390,5 @@ await assert.rejects(
   /planner_identity_required/,
 )
 
-await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), fragmentRef.close(), forbidden.close(), terminalAdapter.close()])
+await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), fragmentRef.close(), truncatedRecovery.close(), forbidden.close(), terminalAdapter.close()])
 console.log('BOOKING COPILOT DSH PLANNER PROOF: task session/typed tool decisions/no Book/no prose parser/no portal token OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -186,7 +186,7 @@ async function createRealRunPort(options: DshEmbeddedBookingPlannerOptions): Pro
       cwd: options.stateRoot ?? process.cwd(),
       provider: options.provider ?? 'deepseek-official',
       model: options.model ?? 'glm-4.6',
-      maxTokens: options.maxTokens ?? 2_048,
+      maxTokens: options.maxTokens ?? 4_096,
       env: childEnv,
       ...(options.dshBin ? { dshBin: options.dshBin } : {}),
     })
@@ -346,8 +346,49 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
     parsed = JSON.parse(text)
   } catch {
     const fenced = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/)
-    const candidate = fenced ? fenced[1]! : text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1)
-    try { parsed = JSON.parse(candidate) } catch { return null }
+    const candidates: string[] = []
+    if (fenced) {
+      candidates.push(fenced[1]!)
+    } else {
+      candidates.push(text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1))
+      candidates.push(text.slice(text.indexOf('{')))
+    }
+    for (const base of candidates) {
+      const attempts = [base]
+      // Reasoning-token budgets can cut the visible JSON before its closing
+      // braces; append the structurally missing closers and let the authority
+      // path judge the reconstructed payload.
+      let depth = 0
+      let inString = false
+      let escaped = false
+      for (const ch of base) {
+        if (inString) {
+          if (escaped) escaped = false
+          else if (ch === '\\') escaped = true
+          else if (ch === '"') inString = false
+          continue
+        }
+        if (ch === '"') inString = true
+        else if (ch === '{' || ch === '[') depth += 1
+        else if (ch === '}' || ch === ']') depth -= 1
+      }
+      if (depth > 0 && depth <= 4 && !inString) {
+        attempts.push(base.trimEnd().replace(/,+$/, '') + '}'.repeat(depth))
+      }
+      for (const candidate of attempts) {
+        try {
+          const attempted = JSON.parse(candidate)
+          // A repaired cut can yield valid JSON that lost the operation
+          // envelope; that is still a failed recovery for this candidate.
+          if (isRecord(attempted) && isRecord(attempted.decision) && attempted.decision.kind === 'operation') {
+            parsed = attempted
+            break
+          }
+        } catch { /* try the next reconstruction */ }
+      }
+      if (parsed !== undefined) break
+    }
+    if (parsed === undefined) return null
   }
   let envelope = parsed
   if (isRecord(envelope) && isRecord(envelope.decision)) envelope = envelope.decision


### PR DESCRIPTION
UAT 新签名：模型推理开销吃满 completion 预算，可见 finalResponse 在 686B 处被腰斩（缺收尾括号，深度停 2），三次尝试同样死法，turn 以 PLANNER_TYPED_DECISION_REQUIRED 失败——但截断点之前是完全正确的 decision。双修：①恢复器深度感知补全缺失括号，双候选（末括号切片/全尾）尝试，仅接受仍带 operation 信封的重建（修复后的部分信封不再误判成功）；②planner completion 预算 2048→4096 治本。真实 UAT 载荷本地验证可修复并过权威校验。两套 proof + tsc 全绿。