### PR TITLE
fix(booking-surface): tolerate UI-loaded offers outside the availability state

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -18,7 +18,7 @@ import {
   type DshPlannerRunPort,
 } from '../src/booking-surface/dsh-planner.ts'
 
-const availability = { initialized: true, recoveryStarted: false, availabilityPhase: 'need_offers' as const, activeHotelOrdinal: 0, hotelRefs: [], hotels: {}, attempts: [], queryReservations: [] }
+const availability: import("../src/booking-surface/runtime.ts").BookingCopilotTaskState["availability"] = { initialized: true, recoveryStarted: false, availabilityPhase: 'need_offers' as const, activeHotelOrdinal: 0, hotelRefs: [], hotels: {}, attempts: [], queryReservations: [] }
 const task: BookingCopilotTaskState = {
   schemaVersion: 'booking.surface',
   taskId: 'task-dsh-1',
@@ -315,6 +315,27 @@ await assert.rejects(
 )
 await unsafeRef.close()
 
+// A workspace with loadedOffers for a hotel absent from the availability
+// state (UI-loaded offers) must not crash the prompt projection.
+const foreignOfferWorkspace = {
+  ...workspace,
+  loadedOffers: [{ offerRef: "offer-ui-1", offerVersionRef: "offerv-ui-1", hotelRef: "hotel-ui-9", evidenceLevel: "rate_loaded" as const, factRefs: [] }],
+}
+const uiOffersPort: DshPlannerRunPort = {
+  async run(prompt) {
+    assert.ok(prompt.includes("hotel-ui-9"), "workspace loadedOffers reach the planner payload")
+    return { finalResponse: "", events: [] }
+  },
+  async close() {},
+}
+const uiOffers = await createDshEmbeddedBookingPlanner({ runPort: uiOffersPort })
+const uiOffersDecisions = await uiOffers.plannerFactory(task).next({
+  task,
+  turn: { schemaVersion: "booking.surface", kind: "user.turn", taskId: task.taskId, turnId: "dsh-turn-ui", workspace: foreignOfferWorkspace, request: { text: "Prepare the loaded offer" } },
+})
+assert.equal(uiOffersDecisions[0]?.kind, "error", "foreign loadedOffers reach the payload without crashing the projection")
+await uiOffers.close()
+
 const plainProsePort: DshPlannerRunPort = {
   async run() {
     return { finalResponse: 'I would search hotels in Dubai for you.', events: [] }
@@ -390,5 +411,5 @@ await assert.rejects(
   /planner_identity_required/,
 )
 
-await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), fragmentRef.close(), truncatedRecovery.close(), forbidden.close(), terminalAdapter.close()])
+await Promise.all([adapter.close(), textChannel.close(), unauthorised.close(), fragmentRef.close(), truncatedRecovery.close(), uiOffers.close(), forbidden.close(), terminalAdapter.close()])
 console.log('BOOKING COPILOT DSH PLANNER PROOF: task session/typed tool decisions/no Book/no prose parser/no portal token OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -223,7 +223,10 @@ function plannerPrompt(turn: BookingCopilotTurn, task: BookingCopilotTaskState):
     phase: availability.availabilityPhase,
     activeHotelRef: availability.hotelRefs[availability.activeHotelOrdinal],
     criteria: availability.criteria,
-    hotels: availability.hotelRefs.map((hotelRef) => { const hotel = availability.hotels[hotelRef]!; return { hotelRef, status: hotel.status, currentOfferRefs: hotel.currentOfferRefs, generation: hotel.generation, checksRemaining: Math.max(0, 2 - hotel.checksIssued), queriesRemaining: Math.max(0, 2 - hotel.offerQueriesIssued), freshOffersRequired: hotel.freshOffersRequired } }),
+    // Workspace snapshots can carry loadedOffers for hotels the availability
+    // machine has not registered (the UI loads offers outside this state);
+    // skip those instead of asserting and 500ing the whole turn.
+    hotels: availability.hotelRefs.flatMap((hotelRef) => { const hotel = availability.hotels[hotelRef]; if (!hotel) return []; return [{ hotelRef, status: hotel.status, currentOfferRefs: hotel.currentOfferRefs, generation: hotel.generation, checksRemaining: Math.max(0, 2 - hotel.checksIssued), queriesRemaining: Math.max(0, 2 - hotel.offerQueriesIssued), freshOffersRequired: hotel.freshOffersRequired }] }),
     terminalCode: availability.terminal?.code,
   }
   const payload = {


### PR DESCRIPTION
UAT 漏斗驱动实修发现：生产 UI 在 copilot 循环外加载 offers，workspace 快照会携带 availability 状态机未注册酒店的 loadedOffers；plannerPrompt 的投影用非空断言直接崩掉整轮（未类型化 500，依赖错误透出）。改为跳过未注册酒店；proof 锁行为。两套 proof + tsc 全绿。