### PR TITLE
feat(seam): 通道探针 tick + 'ok' 恢复语义——外部事件接缝第 1 段

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Requires Node ≥ 22.15. LLM credentials are managed by your dsh host UI — got
 
 > **Quality metrics (repo-side)** — `npx tsx ts/scripts/build-metrics-report.ts [--state-root <root>] [--out report.md] [--days 7]` aggregates the persisted sidecars (fact-gate verdict distribution & blocked rate, channel down/cooldown, incidents, bridge latency vs the 500 ms re-audit budget, ledger / doctor-report presence) into one read-only markdown report. No new dependencies, zero LLM; the state root is never written (only `--out` produces a file, outside the state root).
 
+> **Channel probe tick (out-of-band health)** — `npx tsx ts/scripts/channel-probe.ts --state-root <root>` runs one read-only probe round over headless-probeable channels (hbcli whoami / open-meteo / opensky; session surfaces are skipped, FlyAI is not probed by default to preserve the shared anonymous quota) and appends `down` / `'ok'` recovery events to `channel-health.jsonl` — routing advice and doctor pick them up with zero changes. Driven by cron/loopx; no resident process. Remote (world2agent) callback stays gated on D-31.
+
 ### Developer source install
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ M3 最小可用产品,分发链路无已知堵点。
   - 安装只经用户终端 `npx gotry doctor --fix`;LLM key 归 dsh 宿主,刻意不管
   - 工具层 not-installed/needs-setup 报错统一指 doctor(2026-09-02 迪拜 session 复盘:阻断对已坏通道的盲目重试)
 - **运维面**:质量指标只读聚合 `ts/scripts/build-metrics-report.ts`(2026-09-05,#138 第一切片)——事实闸 verdict 分布与 blocked 率/通道健康 down·cooldown(30 天窗)/事故面(7 天窗)/桥延迟 p50·p95·max(**>500ms 超限计数=§11 复审节奏触发锚点的可见面**)/账本与 doctor 报告存在性,聚成单一 markdown;全程只读零 SQLite 打开(`openDb` 建连即可能写 kv),默认 stdout、`--out` 才落盘;工程面交付,不构成 M3 Exit 证据(归 #22)
+- **外驱面**:通道探针 tick `ts/scripts/channel-probe.ts`(2026-09-07,外部事件接缝第 1 段,#82 本地生产者)——只读探测无头可探通道(hbcli whoami / open-meteo / opensky;session 系不可探显式 skip,flyai 默认不探防空额度),异常写 `down` 事件、恢复写 `'ok'` 事件(latest-wins 超越 down)进 `channel-health.jsonl`,routing/doctor 零改动受益;loopx/cron 驱动一次一轮,非常驻;远程回调面仍待 D-31 拍板(seam 设计 §5)
 - **外联**:AgentReach wrapper(上游装于 `.venv`,反射桥 `agent-reach-bridge.py` 直调上游注册表,零渠道知识)
 
 **工具面无预设静态路由优先级**(persona (19) 平铺保持);通道顺位由**通道注册表**生成、健康态过滤(D-8):
@@ -382,6 +383,7 @@ Booking Copilot 是既有工作台内的 BFF-only embedded read-action 面:
 - **事实闸覆盖面·酒店入闸 + 渲染原语(2026-09-04,issue #118,D-26 收口)**:①`HotelFact`(gotry_bookable_fact.v1 第三形态)——exact-date 酒店检索 hit/miss 落账(flyai-hotel/session:ctrip-hotel 两通道接线);纪律与机/火同源:摸底不落账、needs-setup/error 传输失败永不落负事实、不落数字价(上游打码价保真,只记在架家数)。②`gotry_fact_gate` 酒店 claim 入闸——断言可住性的行按目的地+档期回溯酒店事实,无事实 fail-closed(`unverifiable_hotel_claim`),exact-date miss 在册却写有房 = `not_in_source`。③**渲染原语单向生成**:`renderFlightFact`/`renderHotelFact` 每条事实行内嵌 `<!-- fact:<fact_id> -->` 锚点——产物经原语渲染即自带溯源锚,闸侧锚点优先确定性回溯(启发式让位),手改/伪造锚点 = `fact_anchor_unknown` 直接违例。fact-gate-tests §10 八断言。余量:政策事实生产端(实时签证 API)仍记 D-26 外部依赖。
 
 - **指标面板第一切片(2026-09-05,issue #138,ADR-11 质量层工程面)**:`ts/scripts/build-metrics-report.ts` 只读聚合既有落盘侧车(不新增数据源)——事实闸 verdict 分布与 blocked 率/通道健康 down·cooldown(30 天窗)/事故面(7 天窗)/桥延迟百分位与超预算计数(>500ms=复审触发锚点)/账本与 doctor 报告存在性→单一 markdown;坏行跳过同侧车纪律,空根成型,collect 全程零写入;评测三层运行结果仍由 run-all-tests.sh/CI 承载,v1 不重跑评测。持续观测/可视化面留后续切片(metrics-report-tests §1-6 全绿,run-all §51)
+- **外部事件接缝第 1 段(2026-09-07,issue #82 本地生产者)**:`ts/scripts/channel-probe.ts` 探针 tick 落地 seam 设计 §6①——只读探测(hbcli whoami/open-meteo/opensky;session 系 skip,flyai 默认不探防空额度),异常写 `down`、恢复写 `'ok'`(latest-wins 超越 down,消费方 `state !== 'down'` 判健康);channel-health 增 `ChannelEventState`('ok' 仅持久面),doctor flyai 达限注释与 metrics 通道面均按超越口径兼容;探测结果→事件为纯函数锚点(channel-probe-tests 5/5,run-all §52)。远程回调面(world2agent 桥)仍待 D-31 拍板,拍板包已贴 issue #82
 
 ### 外部 benchmark 泛化(Round 1–9,Discussion #78,截至 Round 8 全部 diagnostic-only)
 

--- a/docs/design/external-event-seam.md
+++ b/docs/design/external-event-seam.md
@@ -82,8 +82,8 @@ incident 同级);world2agent 远程回调需要签名/通道绑定——**等第
 
 ## 6. 落地序列(触发式,每段独立 PR)
 
-1. **sensor 探针最小行**:一个只读探针 tick(可由 loopx/cron 驱动)对关键通道做
-   无副 mustard 探测,异常时调 `recordChannelEvent`——routing/doctor 即时受益;
+1. **sensor 探针最小行** ✅(2026-09-07 落地:`ts/scripts/channel-probe.ts`,run-all §52):只读探针 tick(可由 loopx/cron 驱动)对关键通道做
+   无副作用探测,异常时调 `recordChannelEvent`(down),恢复写 `'ok'`(latest-wins 超越)——routing/doctor 即时受益;
 2. **愿望池消费**:召回 context 纳入通道事件事实(条件含航线/目的地的愿望用
    最新通道状态佐证);
 3. **world2agent 回调**:auth 模型拍板后接远程生产者(D-31)。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@
 > 以下均为**工程面交付,不构成任何里程碑 Exit 证据**(D-20 口径)。
 
 - **政策事实生产端 v1(2026-09-05,issue #141,D-26)**:VISA_POLICY_FETCH effect 注册表行——C 档中国领事服务网(cs.mfa.gov.cn)国家指南树,礼貌抓取(永不重试+断路器护站)→ PolicyFact(as_of+review_by+来源证据链)落账;founder 拍板 C 档免费权威源先行,Timatic/Sherpa° 后议。
-- **外部事件接缝设计(2026-09-04,issue #119/#82 兼容方向,D-31 决策点)**:`docs/design/external-event-seam.md`——外部事件作为健康面(站点断→通道态 down,routing/doctor 零改动生效)与愿望池召回的新生产者,消费既有接缝不建新运行时;不做 push/总线/常驻监听;D-31=事件写入信任模型,触发式拍板;落地序列三段(触发式)。
+- **外部事件接缝设计(2026-09-04,issue #119/#82 兼容方向,D-31 决策点)**:`docs/design/external-event-seam.md`——外部事件作为健康面(站点断→通道态 down,routing/doctor 零改动生效)与愿望池召回的新生产者,消费既有接缝不建新运行时;不做 push/总线/常驻监听;D-31=事件写入信任模型,触发式拍板;落地序列三段(触发式)——第 1 段(本地探针 tick + `'ok'` 恢复事件,channel-probe.ts)已于 2026-09-07 落地(run-all §52);D-31 拍板包已贴 issue #82。
 
 - **HotelByte Booking Copilot 产品验收并行线**:GoTry 以单一 `booking.surface` 契约(2026-09-05 #133 收敛,原 v2 形态转正、v1 退役)的 typed read actions 提供协作面——六个生命周期阶段、七个 phase 字面值(`terminal`/`error` 是两种终态结果)的 durable projection,生产 standalone 默认只接受 BFF 已绑定的 `user.turn`/receipt continuation,完整 principal + binding seam 才开放 `user.turn.ingress`,`Book` 留在原 Checkout。Draft 候选已有 exact SHA/schema/Linux Node 24+ABI provenance 与实际进程 health identity/ingress mode;合并 gate 仍是 tenant/customer/storefront/payment-link 四 surface 真实库存、unavailable/changed 恢复链及 Checkout/QueryOrders/清理证据。该线不启封 M5,也不以离线合同或 CI 替代业务验收。
 - **效应解译器(2026-08-29,issue #16,ADR-18)**:`effect_interpreter.v1` 落地 L4 渠道边界——指数退避重试 / 断路器 / mock 解译器(纯离线 CI 面)收敛进解译层;五渠道工具 + realtime-pricing 已接,余下渠道增量迁移(D-23)。run-all §37。OTA 工具面照旧平铺,证据链逐源标注不变。

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -464,6 +464,10 @@ echo "=== 51. 指标面板只读聚合面(#138 第一切片:事实闸 verdict �
 (cd ts && npx tsx scripts/metrics-report-tests.ts) || FAIL=1
 
 echo
+echo "=== 52. 通道探针 tick(外部事件接缝第 1 段:evaluate 纯函数/latest-wins 'ok' 恢复语义/doctor 口径兼容/metrics ok 超越/CLI 探测面;全离线) ==="
+(cd ts && npx tsx scripts/channel-probe-tests.ts) || FAIL=1
+
+echo
 if [ "$FAIL" -ne 0 ]; then
   echo "REGRESSION FAILED"
   exit 1

--- a/ts/capabilities/channel-health.ts
+++ b/ts/capabilities/channel-health.ts
@@ -25,10 +25,19 @@
 
 export type ChannelHealthState = 'down' | 'cooldown'
 
+/**
+ * 持久事件面的状态全集:会话瞬态(down/cooldown)之外,持久面还接受 'ok'
+ * 恢复事件(外部事件接缝第 1 段,docs/design/external-event-seam.md §3.1/
+ * §6①)——本地探针 tick 探测通过后写 'ok',readLatestChannelEvents 按
+ * latest-wins 让它超越同通道更早的 down,消费方(doctor/metrics)据 state
+ * 判定当前健康。会话瞬态 Map 不接受 'ok'(进程内 hit 即清除,语义已存在)。
+ */
+export type ChannelEventState = ChannelHealthState | 'ok'
+
 export interface ChannelEvent {
   /** 通道 id(channel-registry.ts CHANNELS 的 id) */
   channel: string
-  state: ChannelHealthState
+  state: ChannelEventState
   /** 触发原因(小写连字符;人话渲染归消费方) */
   reason?: string
   /** ISO 时间戳 */
@@ -122,6 +131,9 @@ export async function recordChannelEvent(stateRoot: string, event: ChannelEvent)
 /**
  * 读最近事件(每通道取最新一条)——doctor(CLI 独立进程)的持久面输入。
  * 容忍坏行/空文件/缺文件;limitDays 过滤过旧事件(默认 30 天)。
+ * latest-wins:'ok' 恢复事件可超越同通道更早的 down/cooldown(外部事件接缝
+ * 第 1 段);消费方以 `state !== 'down'` 判当前健康,旧判定(`=== 'down'`)
+ * 不受影响。
  */
 export async function readLatestChannelEvents(stateRoot: string, opts: { limitDays?: number; now?: number } = {}): Promise<Map<string, ChannelEvent>> {
   const latest = new Map<string, ChannelEvent>()
@@ -136,7 +148,7 @@ export async function readLatestChannelEvents(stateRoot: string, opts: { limitDa
       try {
         const ev = JSON.parse(t) as ChannelEvent
         if (!ev || typeof ev.channel !== 'string' || typeof ev.state !== 'string') continue
-        if (!['down', 'cooldown'].includes(ev.state)) continue
+        if (!['down', 'cooldown', 'ok'].includes(ev.state)) continue
         const atMs = Date.parse(ev.at ?? '')
         if (Number.isFinite(atMs) && atMs < cutoff) continue
         latest.set(ev.channel, ev)

--- a/ts/scripts/build-metrics-report.ts
+++ b/ts/scripts/build-metrics-report.ts
@@ -3,7 +3,7 @@
  *
  * 聚合既有落盘侧车(不新增任何数据源)→ 单一 markdown 报告:
  *   - 事实闸 verdict 分布 + blocked 牊(<stateRoot>/gotry-state/bookable-facts.jsonl)
- *   - 通道健康 down/cooldown(<stateRoot>/gotry-state/channel-health.jsonl,30 天窗,
+ *   - 通道健康 down/cooldown('ok' 恢复事件 latest-wins 超越;<stateRoot>/gotry-state/channel-health.jsonl,30 天窗,
  *     与 doctor 持久面 readLatestChannelEvents 同口径)
  *   - 事故面(<stateRoot>/gotry-state/incidents.jsonl,--days 窗,默认 7)
  *   - 桥延迟 p50/p95/max + >500ms 违约计数(<stateRoot>/gotry-state/bridge-latency.jsonl;
@@ -91,10 +91,21 @@ export function aggregateChannels(
   const cutoff = nowMs - (opts.windowDays ?? CHANNEL_WINDOW_DAYS) * 86_400_000
   const counts = new Map<string, number>()
   const newest = new Map<string, ChannelRow & { atMs: number }>()
+  // ok 超越(外部事件接缝第 1 段):通道最新事件若为 'ok'(本地探针恢复),
+  // 该通道从「当前 down/cooldown」展示面退出——down 计数(历史频率)保留。
+  const lastState = new Map<string, string>()
+  for (const raw of rows) {
+    const row = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>
+    if (typeof row.channel !== 'string' || !row.channel) continue
+    if (typeof row.state === 'string' && ['down', 'cooldown', 'ok'].includes(row.state)) {
+      lastState.set(row.channel, row.state)
+    }
+  }
   for (const raw of rows) {
     const row = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>
     if (typeof row.channel !== 'string' || !row.channel) continue
     if (row.state !== 'down' && row.state !== 'cooldown') continue
+    if (lastState.get(row.channel) === 'ok') continue
     const at = typeof row.at === 'string' ? row.at : ''
     const atMs = Date.parse(at)
     if (Number.isFinite(atMs) && atMs < cutoff) continue
@@ -263,7 +274,7 @@ export function renderMetricsReport(s: MetricsSnapshot): string {
   }
   L.push('')
 
-  L.push(`## 通道健康(channel-health.jsonl,${s.channels.windowDays} 天窗;hit 即清除,此处只见 down/cooldown)`)
+  L.push(`## 通道健康(channel-health.jsonl,${s.channels.windowDays} 天窗;hit 即清除,此处只见当前处于 down/cooldown 的通道;'ok' 恢复事件已超越)`)
   L.push('')
   if (s.channels.latest.length === 0) {
     L.push('(空:窗口内无 down/cooldown 事件)')

--- a/ts/scripts/channel-probe-tests.ts
+++ b/ts/scripts/channel-probe-tests.ts
@@ -1,0 +1,92 @@
+/**
+ * 通道探针 tick 测试(外部事件接缝第 1 段,issue #82 兼容方向;全离线):
+ *  1. evaluateProbeResults 纯函数:fail→down / ok+此前down→'ok'恢复 / ok+健康→零写 / skip→不产事件
+ *  2. readLatestChannelEvents latest-wins:'ok' 事件超越同通道更早的 down(恢复语义落地)
+ *  3. doctor 消费口径:恢复后 `state === 'down'` 判定不再命中(飞行可达性注释消失)
+ *  4. metrics aggregateChannels:'ok' 超越后 newest 不含该通道,down 事件计数保留(历史频率面)
+ *  5. CLI:--list 列探测面(session 系与 flyai 显式 skip);--only 未匹配 exit 2
+ *
+ * 运行: cd ts && npx tsx scripts/channel-probe-tests.ts
+ */
+
+import assert from 'node:assert/strict'
+import { mkdtemp, writeFile, mkdir, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { evaluateProbeResults, defaultProbes, parseArgs, main } from './channel-probe.ts'
+import { readLatestChannelEvents, recordChannelEvent } from '../capabilities/channel-health.ts'
+import { aggregateChannels } from './build-metrics-report.ts'
+
+const tmp = await mkdtemp(join(tmpdir(), 'gotry-probe-test-'))
+
+// ── 1. evaluateProbeResults 纯函数 ───────────────────────────────────────────
+const probes = defaultProbes()
+const hb = probes.find((p) => p.channel === 'hbcli-hotel')!
+const om = probes.find((p) => p.channel === 'open-meteo')!
+const fly = probes.find((p) => p.channel === 'flyai')!
+const now = new Date('2026-09-07T12:00:00Z')
+
+const evs = evaluateProbeResults([
+  { probe: hb, result: { ok: false, reason: 'auth-denied', ms: 5 } },
+  { probe: om, result: { ok: true, ms: 100 } },
+  { probe: fly, result: { ok: true, ms: 0 } },
+], new Set(['open-meteo']), now)
+assert.equal(evs.length, 2, `fail→down + ok恢复→'ok' 共 2 条,实际 ${evs.length}`)
+assert.deepEqual(
+  { channel: evs[0].channel, state: evs[0].state, reason: evs[0].reason },
+  { channel: 'hbcli-hotel', state: 'down', reason: 'auth-denied' },
+  'fail 应产 down 事件带 reason',
+)
+assert.deepEqual(
+  { channel: evs[1].channel, state: evs[1].state },
+  { channel: 'open-meteo', state: 'ok' },
+  'ok 且此前 down 应产 ok 恢复事件',
+)
+const noWrites = evaluateProbeResults([{ probe: om, result: { ok: true, ms: 90 } }], new Set(), now)
+assert.equal(noWrites.length, 0, 'ok 且此前健康 → 零写放大')
+
+// ── 2. latest-wins:'ok' 超越更早的 down ──────────────────────────────────────
+const stateRoot = join(tmp, 'state')
+await mkdir(join(stateRoot, 'gotry-state'), { recursive: true })
+const jsonl = join(stateRoot, 'gotry-state', 'channel-health.jsonl')
+await writeFile(jsonl, [
+  JSON.stringify({ channel: 'opensky', state: 'down', reason: 'http-503', at: '2026-09-07T10:00:00.000Z' }),
+  JSON.stringify({ channel: 'opensky', state: 'ok', at: '2026-09-07T11:00:00.000Z' }),
+  JSON.stringify({ channel: 'hbcli-hotel', state: 'down', reason: 'auth-denied', at: '2026-09-07T10:30:00.000Z' }),
+  'not-json-garbage',
+  '',
+].join('\n'), 'utf-8')
+const latest = await readLatestChannelEvents(stateRoot, { now: Date.parse('2026-09-07T12:00:00Z') })
+assert.equal(latest.get('opensky')?.state, 'ok', "'ok' 应超越同通道更早的 down")
+assert.equal(latest.get('hbcli-hotel')?.state, 'down', '未恢复通道保持 down')
+assert.equal(latest.size, 2, '坏行跳过,latest 只含两通道')
+
+// ── 3. doctor 消费口径:恢复后 '=== down' 不命中 ─────────────────────────────
+const openskyEv = latest.get('opensky')
+assert.ok(openskyEv && openskyEv.state !== 'down', 'doctor 的 down 判定应不再命中已恢复通道')
+
+// ── 4. metrics:ok 超越后 newest 不含该通道,计数保留 ─────────────────────────
+const rows = (await readFile(jsonl, 'utf-8')).split('\n').filter((l) => l.trim()).flatMap((l) => {
+  try { return [JSON.parse(l)] } catch { return [] }
+})
+const stats = aggregateChannels(rows, { now: new Date('2026-09-07T12:00:00Z'), windowDays: 30 })
+const openskyStat = stats.latest.find((c) => c.channel === 'opensky')
+assert.equal(openskyStat, undefined, 'ok 超越的通道不应出现在当前 down/cooldown newest 面')
+const hbStat = stats.latest.find((c) => c.channel === 'hbcli-hotel')
+assert.ok(hbStat && hbStat.state === 'down', '未恢复通道仍在 newest 面')
+
+// ── 5. CLI 面 ────────────────────────────────────────────────────────────────
+const listed = defaultProbes()
+assert.ok(listed.find((p) => p.channel === 'flyai')?.probeable === false, 'flyai 默认不探(共享额度)')
+assert.ok(listed.filter((p) => p.channel.startsWith('session:')).every((p) => !p.probeable), 'session:* 全部 skip')
+assert.deepEqual(
+  parseArgs(['--state-root', '/tmp/x', '--only', 'a, b', '--dry-run']),
+  { stateRoot: '/tmp/x', only: ['a', 'b'], dryRun: true, list: false },
+  'parseArgs 解析',
+)
+const rcList = await main(['--list'])
+assert.equal(rcList, 0, '--list exit 0')
+const rcBad = await main(['--only', 'no-such-channel'])
+assert.equal(rcBad, 2, '--only 未匹配 exit 2')
+
+console.log('CHANNEL PROBE TESTS: 5/5 OK(evaluate 纯函数 / latest-wins 恢复 / doctor 口径 / metrics 超越 / CLI 面)')

--- a/ts/scripts/channel-probe.ts
+++ b/ts/scripts/channel-probe.ts
@@ -1,0 +1,196 @@
+/**
+ * 通道探针 tick(外部事件接缝落地第 1 段,docs/design/external-event-seam.md §6①;
+ * issue #82 兼容方向)——外部事件作为健康面第二个生产者的本地形态。
+ *
+ * 设计边界(设计文档 §4,边界即信任):
+ *  - 只读探测:每通道一个无副作用最小调用(whoami/免费公开 GET),不检索、不下单;
+ *  - 本地生产者免鉴权(§3.2 本地可信):异常写 `down` 事件进
+ *    <stateRoot>/gotry-state/channel-health.jsonl,routingAdvice/doctor 零改动受益;
+ *  - 恢复走事件:探测通过且该通道此前处于 down → 写 'ok' 恢复事件
+ *    (readLatestChannelEvents latest-wins 超越 down);此前健康则零写放大;
+ *  - session:* 通道(需用户 Chrome 会话)无头不可探,显式 skip 不误报;
+ *  - flyai 默认不探(匿名共享额度,探针烧额度弊大于利)——`--only flyai` 显式选入;
+ *  - 不做常驻监听:tick 由 loopx/cron 驱动,一次运行一轮探测后退出。
+ *
+ * 用法(loopx/cron 驱动):
+ *   npx tsx ts/scripts/channel-probe.ts --state-root <root>            # 探测+落账
+ *   npx tsx ts/scripts/channel-probe.ts --dry-run                      # 只打印不落账
+ *   npx tsx ts/scripts/channel-probe.ts --only hbcli-hotel,open-meteo  # 选通道
+ *   npx tsx ts/scripts/channel-probe.ts --list                         # 列探测面
+ *
+ * @module scripts/channel-probe
+ */
+
+import { recordChannelEvent, readLatestChannelEvents, type ChannelEvent } from '../capabilities/channel-health.ts'
+
+export interface ProbeOutcome {
+  ok: true
+  /** 探测耗时 ms(仅日志用) */
+  ms: number
+}
+
+export interface ProbeFailure {
+  ok: false
+  /** 小写连字符原因(如 rate-limited / unreachable / auth-denied / timeout) */
+  reason: string
+  ms: number
+}
+
+export type ProbeResult = ProbeOutcome | ProbeFailure
+
+export type ChannelProbe = {
+  channel: string
+  /** 无头可探=true 才会进默认探测面;session:* 面显式 false 并给 skip 原因 */
+  probeable: boolean
+  /** 不可探/不默认探的人话原因 */
+  skipReason?: string
+  run: () => Promise<ProbeResult>
+}
+
+function timeout(ms: number): AbortSignal {
+  return AbortSignal.timeout(ms)
+}
+
+async function fetchOk(url: string, what: string, ms = 8000): Promise<ProbeResult> {
+  const t0 = Date.now()
+  try {
+    const res = await fetch(url, { signal: timeout(ms), headers: { Accept: 'application/json' } })
+    if (res.ok) return { ok: true, ms: Date.now() - t0 }
+    return { ok: false, reason: `${what}-http-${res.status}`, ms: Date.now() - t0 }
+  } catch (err) {
+    const msg = err instanceof Error ? err.name : String(err)
+    return { ok: false, reason: msg === 'TimeoutError' ? 'timeout' : 'unreachable', ms: Date.now() - t0 }
+  }
+}
+
+function spawnOk(cmd: string, args: string[], what: string, ms = 10000): () => Promise<ProbeResult> {
+  return async (): Promise<ProbeResult> => {
+    const t0 = Date.now()
+    try {
+      const { spawn } = await import('node:child_process')
+      const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'ignore'] })
+      const code = await new Promise<number>((resolve, reject) => {
+        const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('timeout')) }, ms)
+        child.on('exit', (c) => { clearTimeout(timer); resolve(c ?? 1) })
+        child.on('error', (e) => { clearTimeout(timer); reject(e) })
+      })
+      return code === 0 ? { ok: true, ms: Date.now() - t0 } : { ok: false, reason: `${what}-exit-${code}`, ms: Date.now() - t0 }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { ok: false, reason: msg === 'timeout' ? 'timeout' : 'spawn-failed', ms: Date.now() - t0 }
+    }
+  }
+}
+
+/** 默认探测面(设计文档 §6①「关键通道」的无头子集;session 系与 flyai 显式 skip) */
+export function defaultProbes(): ChannelProbe[] {
+  return [
+    {
+      channel: 'hbcli-hotel',
+      probeable: true,
+      run: spawnOk('hbcli', ['auth', 'whoami'], 'auth-denied'),
+    },
+    {
+      channel: 'open-meteo',
+      probeable: true,
+      run: () => fetchOk('https://api.open-meteo.com/v1/forecast?latitude=25.2048&longitude=55.2708&current=temperature_2m', 'weather'),
+    },
+    {
+      channel: 'opensky',
+      probeable: true,
+      run: () => fetchOk('https://opensky-network.org/api/states/all?lamin=24.0&lomin=53.0&lamax=26.5&lomax=56.5', 'flights', 12000),
+    },
+    { channel: 'flyai', probeable: false, skipReason: 'anonymous-shared-quota——探针烧额度弊大于利;--only flyai 显式选入', run: async () => ({ ok: true, ms: 0 }) },
+    { channel: 'session:ctrip-flight', probeable: false, skipReason: '需用户 Chrome 会话,无头不可探', run: async () => ({ ok: true, ms: 0 }) },
+    { channel: 'session:ctrip-hotel', probeable: false, skipReason: '需用户 Chrome 会话,无头不可探', run: async () => ({ ok: true, ms: 0 }) },
+    { channel: 'session:12306-train', probeable: false, skipReason: '需用户 Chrome 会话,无头不可探', run: async () => ({ ok: true, ms: 0 }) },
+    { channel: 'anything-geo', probeable: false, skipReason: '静态包通道,无远端可探', run: async () => ({ ok: true, ms: 0 }) },
+    { channel: 'static-hotel', probeable: false, skipReason: '静态包通道,无远端可探', run: async () => ({ ok: true, ms: 0 }) },
+    { channel: 'web-read', probeable: false, skipReason: '依赖 agent-reach 装配态,探测意义低;--only 显式选入可探', run: async () => ({ ok: true, ms: 0 }) },
+  ]
+}
+
+/**
+ * 探测结果 → 事件序列(纯函数,测试锚点):
+ *  - fail → down 事件(永远落,哪怕已 down——重申事实,消费方幂等);
+ *  - ok 且此前处于 down → 'ok' 恢复事件(latest-wins 超越);
+ *  - ok 且此前健康 → 不落(零写放大);
+ *  - skip(probeable=false)→ 不产生事件。
+ */
+export function evaluateProbeResults(
+  results: { probe: ChannelProbe; result: ProbeResult }[],
+  priorDown: Set<string>,
+  now = new Date(),
+): ChannelEvent[] {
+  const events: ChannelEvent[] = []
+  for (const { probe, result } of results) {
+    if (!probe.probeable) continue
+    if (result.ok) {
+      if (priorDown.has(probe.channel)) {
+        events.push({ channel: probe.channel, state: 'ok', at: now.toISOString() })
+      }
+      continue
+    }
+    events.push({ channel: probe.channel, state: 'down', reason: result.reason, at: now.toISOString() })
+  }
+  return events
+}
+
+export function parseArgs(argv: string[]): { stateRoot?: string; only?: string[]; dryRun: boolean; list: boolean } {
+  let stateRoot: string | undefined
+  let only: string[] | undefined
+  let dryRun = false
+  let list = false
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i]
+    if (a === '--state-root') stateRoot = argv[++i]
+    else if (a === '--only') only = (argv[++i] ?? '').split(',').map((s) => s.trim()).filter(Boolean)
+    else if (a === '--dry-run') dryRun = true
+    else if (a === '--list') list = true
+  }
+  return { stateRoot, only, dryRun, list }
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseArgs(argv)
+  const all = defaultProbes()
+  if (args.list) {
+    for (const p of all) {
+      console.log(`${p.probeable ? 'probe' : 'skip '}  ${p.channel}${p.skipReason ? `  # ${p.skipReason}` : ''}`)
+    }
+    return 0
+  }
+  const selected = args.only?.length ? all.filter((p) => args.only!.includes(p.channel)) : all.filter((p) => p.probeable)
+  if (selected.length === 0) {
+    console.error('[channel-probe] --only 未匹配任何通道;--list 查看探测面')
+    return 2
+  }
+  const results: { probe: ChannelProbe; result: ProbeResult }[] = []
+  for (const probe of selected) {
+    const result = await probe.run()
+    results.push({ probe, result })
+    console.log(`[channel-probe] ${result.ok ? 'ok  ' : 'FAIL'} ${probe.channel} (${result.ms}ms)${result.ok ? '' : ` reason=${result.reason}`}`)
+  }
+  const failures = results.filter((r) => !r.result.ok).length
+  if (args.dryRun || !args.stateRoot) {
+    if (!args.stateRoot) console.log('[channel-probe] 未给 --state-root:只探测不落账(等价 --dry-run)')
+    return failures > 0 ? 1 : 0
+  }
+  let priorDown = new Set<string>()
+  try {
+    const latest = await readLatestChannelEvents(args.stateRoot)
+    priorDown = new Set([...latest.entries()].filter(([, ev]) => ev.state === 'down' || ev.state === 'cooldown').map(([ch]) => ch))
+  } catch { /* 读不到按全健康处理 */ }
+  for (const ev of evaluateProbeResults(results, priorDown)) {
+    await recordChannelEvent(args.stateRoot, ev)
+    console.log(`[channel-probe] 记录 ${ev.state} ${ev.channel}${ev.reason ? `(${ev.reason})` : ''}`)
+  }
+  return failures > 0 ? 1 : 0
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).then((code) => process.exit(code)).catch((err) => {
+    console.error('[channel-probe] fatal:', err instanceof Error ? err.message : err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
Closes #189 · 服务 #82(不关——远程回调面待 D-31 拍板)

## 为什么

seam 设计(`docs/design/external-event-seam.md`)落地序列第 1 段=本地探针,设计 §3.2 已定「本地生产者免鉴权」,**不需要 D-31 拍板**(D-31 只管 world2agent 远程回调/第 3 段)。带外健康事实(站点断/上游不可达)今天没有入口,只能等用户会话撞上失败;探针让 routing/doctor 在用户撞上之前就知道。

## 改动

1. **channel-health 'ok' 恢复语义**:设计说「恢复走 `state:'ok'` 事件」,代码此前不成立(读取器跳过 ok 行)——补 `ChannelEventState` + readLatestChannelEvents latest-wins 超越;消费方零改动兼容(doctor `==='down'` 判定自然失效=健康);
2. **探针 tick `ts/scripts/channel-probe.ts`**:只读探测(hbcli whoami / open-meteo / opensky;session 系显式 skip 不误报;flyai 默认不探防烧共享匿名额度);异常→`down`、恢复→`'ok'`;loopx/cron 驱动一次一轮非常驻;无 `--state-root` 只探测不落账;evaluate 结果→事件为纯函数锚点;
3. **metrics** aggregateChannels 尊重 ok 超越(当前 down 面退出,历史计数保留)。

## 验证

- channel-probe-tests 5/5(evaluate 纯函数 / latest-wins 恢复 / doctor 口径 / metrics 超越 / CLI 面),run-all 新 §52,**ALL SUITES GREEN**(exit 0);
- 真实探测冒烟:hbcli-hotel ✅(194ms)/ open-meteo ✅(857ms)/ opensky unreachable(6128ms)=真实带外事实被捕获;
- 六状态面:arch §1 外驱面 + §9 演进条目、roadmap 接缝条目(第 1 段已落地)、README 探针行、seam 设计文档 §6① 标已落地。

## 关联

- #82:本 PR 是接缝第 1 段;第 2 段(愿望池消费)与第 3 段(world2agent 远程桥,待 D-31 拍板——决策包已贴 issue #82)后续推进,#82 保持 open。