### PR TITLE
dx: bug 模板必填精简 + gotry --version 取证入口

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,11 +7,21 @@ body:
       value: |
         感谢反馈！提 bug 前请先[搜索既有 issue](https://github.com/Danceiny/gotry/issues?q=) 避免重复。
         Thanks for reporting — please search existing issues first.
+        只有两项必填:**问题描述**和 **GoTry 版本**;其余尽量填,但留空也能提交。
   - type: textarea
     id: what-happened
     attributes:
       label: 发生了什么？ / What happened?
       description: 一句话说清问题本质。
+    validations:
+      required: true
+  - type: input
+    id: gotry-version
+    attributes:
+      label: GoTry 版本 / GoTry version
+      description: |
+        运行 `gotry --version` 获取(npm 形态 `npx @danceiny/gotry --version`);源码形态也可填 `git rev-parse --short HEAD`。
+      placeholder: "如 0.0.1-rc.19 / 源码填 commit 短哈希"
     validations:
       required: true
   - type: textarea
@@ -22,14 +32,10 @@ body:
         1. 运行 `./gotry web`
         2. 输入「我想去 …」
         3. 见到 …
-    validations:
-      required: true
   - type: textarea
     id: expected
     attributes:
       label: 期望行为 / Expected behavior
-    validations:
-      required: true
   - type: textarea
     id: evidence
     attributes:
@@ -43,15 +49,11 @@ body:
         - npm 形态(`npx @danceiny/gotry web`)
         - 源码形态(`./gotry web`)
         - 其他 / Other
-    validations:
-      required: true
   - type: input
     id: node-version
     attributes:
       label: Node 版本 / Node version
       placeholder: "v22.14.0"
-    validations:
-      required: true
   - type: textarea
     id: context
     attributes:

--- a/bin/gotry-inner.js
+++ b/bin/gotry-inner.js
@@ -87,9 +87,16 @@ Usage:
   gotry doctor --fix                 # 体检 + 按报告补装(hbcli 官方脚本 / agent-reach pip / sidebar 插件)
   gotry "一段完整任务..."            # headless 一问一答
   gotry help                         # this help
+  gotry --version                    # 版本号(bug 报告必填项)
 
 Detail: https://github.com/Danceiny/gotry — README
 `)
+  process.exit(0)
+}
+
+// repoRoot 在 npm 安装与源码检出两种形态下都是包根,version 统一从这里取
+if (args[0] === '-v' || args[0] === '--version') {
+  console.log(JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')).version)
   process.exit(0)
 }
 

--- a/gotry
+++ b/gotry
@@ -43,6 +43,9 @@ GoTry —— dsh 运行时驱动
 详细文档: README.md
 EOF
     ;;
+  --version|-v)
+    exec node "$ROOT/bin/gotry-inner.js" "$@"
+    ;;
   *)
     exec node "$ROOT/bin/gotry-inner.js" "$@"
     ;;


### PR DESCRIPTION
## 为什么

bug 报告模板原来有 5 个必填项,门槛偏高;同时报告者经常说不清版本号,定位困难。

## 改动

### 1. bug 模板必填精简(`.github/ISSUE_TEMPLATE/bug_report.yml`)
- 必填项 5 → 2:**发生了什么** + **GoTry 版本**
- 复现步骤/期望行为/安装方式/Node 版本改为选填,引导语注明「留空也能提交」
- 两个必填项前置,报告者一眼可见

### 2. `gotry --version`(`bin/gotry-inner.js` + 根 `gotry`)
- 新增 `--version`/`-v`:从包根 `package.json` 读版本号(npm 安装与源码检出两种形态 `repoRoot` 都指向包根,一处取值)
- 在 dsh runtime 解析之前短路退出,无依赖环境也能输出
- 根目录 `./gotry` 的 `--version|-v` case 直接转发 inner,版本逻辑只写一处
- help 文案同步加了一行

## 验证
- 模板 YAML 解析通过,required 字段确认为 2 项
- `node bin/gotry-inner.js --version` / `-v` → `0.0.1-rc.18`(worktree 无 node_modules,验证了提前退出路径)
- `./gotry --version` / `-v` → `0.0.1-rc.18`
- `--help` 输出含新行

## 备注
发现一个 main 上已有的独立问题(本 PR 未动):macOS 自带 bash 3.2 下,根 `gotry` 脚本在 `.env` 不存在时 `source ... || true` 仍会因 `set -e` 终止脚本(正常用户机器上有 `.env` 所以没暴露)。如需要可另开 issue/PR。