### PR TITLE
Fix CLI help conflict markers

### DIFF
--- a/bin/gotry-inner.js
+++ b/bin/gotry-inner.js
@@ -82,10 +82,7 @@ if (help) {
 Usage:
   gotry web                          # dsh Web UI on http://127.0.0.1:3080
   gotry setup                        # 扩展就位检查/指引(商店一键装)
-<<<<<<< HEAD
   gotry setup calendar               # 可选日历(CalDAV 工作窗口)挂载开关:默认关;--off 关闭;--status 查看
-=======
->>>>>>> origin/main
   gotry doctor                       # 可选依赖体检:扩展/agent-reach/hbcli/flyai/sidebar 状态 + 补装指引
   gotry doctor --fix                 # 体检 + 按报告补装(hbcli 官方脚本 / agent-reach pip / sidebar 插件)
   gotry "一段完整任务..."            # headless 一问一答


### PR DESCRIPTION
## TODO

1. Repair the pre-existing `ts` clean-install peer conflict: `dsh-map-tools@0.5.1` requires `@deepseek-ai/dsh-tools>=0.1.2-rc.1`, while `main` pins the DSH closure to `0.1.2-alpha.3`.
2. Re-run the Node 22/24 full regression jobs after that dependency repair lands.

## What

- Remove committed conflict marker lines from `bin/gotry-inner.js` help text.
- Keep the `gotry setup calendar` help line intact.

## Evidence

- `git diff --check origin/main...HEAD -- bin/gotry-inner.js` -> exit 0
- `node --check bin/gotry-inner.js` -> exit 0
- `node bin/gotry-inner.js help` -> calendar line present; no conflict marker lines
- `cd ts && npx tsx scripts/bootstrap-tests.ts` -> BOOTSTRAP TESTS: 10/10 OK
- `cd ts && npx tsx scripts/channel-registry-tests.ts` -> channel-registry-tests: all passed

## CI diagnosis

The two full-regression jobs fail before tests during `npm --prefix ts ci` with the peer conflict above. The one-file help patch does not change dependencies, but repository policy forbids merging while the gate is red, so this PR remains Draft.

No tag, npm publish, or release action was performed.
