### PR TITLE
fix(e2e): handoff 判定只认真实 role=tool 消息——persona (21) 字面量不再误判已交接(#205)

### DIFF
--- a/ts/scripts/agent-planning-turn-deadline-e2e.ts
+++ b/ts/scripts/agent-planning-turn-deadline-e2e.ts
@@ -100,7 +100,13 @@ async function startRelay(): Promise<Relay> {
       if (toolNames(body).includes(TOOL)) {
         plannerBodies.push(body)
         const plannerIndex = plannerBodies.length
-        const alreadyHandedOff = JSON.stringify(body).includes(HANDOFF)
+        // issue #205:已交接判定只认真实 role=tool 消息(persona (21) 的
+        // TURN_DEADLINE_HANDOFF 字面量也在 system 文本里,整包扫描会首轮误判
+        // 已交接 → 永不派发工具 → handoff 语义测试退化为纯文本收尾)。
+        const realToolMessages = (body.messages ?? []).filter(
+          message => message.role === 'tool'
+        )
+        const alreadyHandedOff = realToolMessages.some(message => JSON.stringify(message).includes(HANDOFF))
         // 首个 planner 响应拖过硬阈:首个工具派发必然越过 wall-clock 边界。
         // handoff 发生后,后续 planner 请求一律回 text-only final,收敛回路。
         const stall = !alreadyHandedOff && plannerIndex === 1 ? RELAY_STALL_MS : 0


### PR DESCRIPTION
Closes #205

## 问题

persona (21) 对齐 ADR-24 v2 后含 `TURN_DEADLINE_HANDOFF` 字面量;§45 e2e 的 mock relay 用 `JSON.stringify(body).includes(HANDOFF)` 扫**整个请求**判「已交接」——system persona 里的同名字面量让首轮 planner 请求即被误判已交接,relay 跳过工具派发直接回 text-only 终态,§45 稳定失败(`messages=[]`)。

## 修法

`alreadyHandedOff` 只扫真实 `role=tool` 消息。main@5f47c7d 的 persona 本身就含该字面量,修复后 e2e 通过即证明「persona 含同名字面量仍产生 handoff tool result」的回归语义。

## 验证

- 打包安装 e2e:Node 24.16 ✅ 与 Node 22.23 ✅ 双跑通过(plannerRequests=2, handoffResults=1, ticket settled);
- 全栈回归 `run-all-tests.sh` **ALL SUITES GREEN**(exit 0,含 §45)。