### PR TITLE
fix(booking-surface): prevent fact ref alias collisions

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -9,6 +9,7 @@
  */
 
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
 import type { ActionReceipt, BookingWorkspaceSnapshot } from '../src/booking-surface/contracts.ts'
 import type { BookingCopilotTaskState } from '../src/booking-surface/runtime.ts'
 import {
@@ -213,7 +214,7 @@ const sanitizedRefPort: DshPlannerRunPort = {
       finalResponse: '',
       events: [{
         type: 'tool/call',
-        data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, factRefs: ['draft:destination=Dubai'] } } }) },
+        data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, factRefs: ['draft:destination=Dubai', 'draft:destination.Dubai'] } } }) },
       }],
     }
   },
@@ -234,9 +235,82 @@ const sanitizedDecisions = await sanitizedRef.plannerFactory(task).next({
 assert.equal(sanitizedDecisions[0]?.kind, 'operation', 'sanitizer maps off-charset characters deterministically')
 assert.deepEqual(
   (sanitizedDecisions[0] as { action?: { factRefs?: string[] } }).action?.factRefs,
-  ['draft:destination.Dubai'],
+  ['modelref:43b07dd7fc80f4a9889b6c672c450a911086293cab2ef4058b95b53559a2d100', 'draft:destination.Dubai'],
 )
 await sanitizedRef.close()
+
+const collisionRawRefs = ['fact://a/b', 'fact:..a?b'] as const
+const collisionResults: string[] = []
+for (const [index, rawRef] of collisionRawRefs.entries()) {
+  const collisionPlanner = await createDshEmbeddedBookingPlanner({
+    runPort: {
+      async run() {
+        return { finalResponse: '', events: [{ type: 'tool/call', data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, actionId: `action-dsh-collision-${index}`, factRefs: [rawRef] } } }) } }] }
+      },
+      async close() {},
+    },
+  })
+  const decisions = await collisionPlanner.plannerFactory(task).next({ task, turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: `dsh-collision-${index}`, workspace, request: { text: 'Find hotels' } } })
+  const ref = (decisions[0] as { action?: { factRefs?: string[] } }).action?.factRefs?.[0]
+  assert.match(ref ?? '', /^[A-Za-z0-9][A-Za-z0-9:._-]*$/, 'unsafe refs map to the runtime-safe pattern')
+  collisionResults.push(ref ?? '')
+  await collisionPlanner.close()
+}
+assert.notEqual(collisionResults[0], collisionResults[1], 'distinct unsafe raw refs retain collision-resistant aliases')
+assert.equal(
+  collisionRawRefs[0].replace(/#/g, ':').replace(/[^A-Za-z0-9:._-]/g, '.'),
+  collisionRawRefs[1].replace(/#/g, ':').replace(/[^A-Za-z0-9:._-]/g, '.'),
+  'the collision pair shares the legacy readable projection',
+)
+
+async function assertFactRefsRejected(factRefs: unknown[], message: string): Promise<void> {
+  const planner = await createDshEmbeddedBookingPlanner({
+    runPort: {
+      async run() {
+        return { finalResponse: '', events: [{ type: 'tool/call', data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, factRefs } } }) } }] }
+      },
+      async close() {},
+    },
+  })
+  await assert.rejects(
+    planner.plannerFactory(task).next({ task, turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: 'dsh-ref-rejection', workspace, request: { text: 'Find hotels' } } }),
+    /planner_invalid_action/,
+    message,
+  )
+  await planner.close()
+}
+const firstAlias = 'modelref:'.concat(createHash('sha256').update(collisionRawRefs[0], 'utf8').digest('hex'))
+await assertFactRefsRejected([collisionRawRefs[0], firstAlias], 'unsafe raw ref cannot alias a same-action reserved modelref')
+await assertFactRefsRejected([collisionRawRefs[0], collisionRawRefs[0]], 'repair-time duplicate factRefs are rejected by canonical validation')
+await assertFactRefsRejected(['modelref:'.concat('a'.repeat(64))], 'direct modelref namespace input is reserved and rejected')
+
+const reservedRecovery = await createDshEmbeddedBookingPlanner({
+  runPort: {
+    async run() {
+      return { finalResponse: JSON.stringify({ kind: 'operation', action: { ...searchRun, factRefs: ['modelref:'.concat('b'.repeat(64))] } }), events: [] }
+    },
+    async close() {},
+  },
+})
+const reservedRecoveryDecision = await reservedRecovery.plannerFactory(task).next({ task, turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: 'dsh-reserved-recovery', workspace, request: { text: 'Find hotels' } } })
+assert.equal(reservedRecoveryDecision[0]?.kind, 'error', 'finalResponse recovery rejects direct reserved modelref aliases')
+await reservedRecovery.close()
+
+let stableRefCall = 0
+const stableRawRef = 'fact://same/raw'
+const stablePlanner = await createDshEmbeddedBookingPlanner({
+  runPort: {
+    async run() {
+      stableRefCall += 1
+      return { finalResponse: '', events: [{ type: 'tool/call', data: { name: 'booking_search_hotels', arguments: JSON.stringify({ decision: { kind: 'operation', action: { ...searchRun, actionId: `action-dsh-stable-${stableRefCall}`, factRefs: [stableRawRef] } } }) } }] }
+    },
+    async close() {},
+  },
+})
+const stableFirst = await stablePlanner.plannerFactory(task).next({ task, turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: 'dsh-stable-1', workspace, request: { text: 'Find hotels' } } })
+const stableSecond = await stablePlanner.plannerFactory(task).next({ task, turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: 'dsh-stable-2', workspace, request: { text: 'Find hotels again' } } })
+assert.equal((stableFirst[0] as { action?: { factRefs?: string[] } }).action?.factRefs?.[0], (stableSecond[0] as { action?: { factRefs?: string[] } }).action?.factRefs?.[0], 'same raw ref is stable across actions and turns')
+await stablePlanner.close()
 
 const unauthorisedPort: DshPlannerRunPort = {
   async run() {
@@ -288,7 +362,7 @@ const fragmentDecisions = await fragmentRef.plannerFactory(task).next({
 assert.equal(fragmentDecisions[0]?.kind, 'operation', 'JSON-pointer fragment factRefs repair into the safe charset')
 assert.deepEqual(
   (fragmentDecisions[0] as { action?: { factRefs?: string[] } }).action?.factRefs,
-  [`fact:..turn_${task.lastTurnId}.request`],
+  [`modelref:c7819d3c0c375fe1bd389006338b99be890fa8e3ddd9390f243cba8b5c139d9a`],
 )
 await fragmentRef.close()
 

--- a/ts/scripts/booking-copilot-runtime-proof-tests.ts
+++ b/ts/scripts/booking-copilot-runtime-proof-tests.ts
@@ -91,6 +91,68 @@ const action = (id: string, revision = 0, extra: Record<string, unknown> = {}) =
   contextRef: 'ctx-v2', expectedRevision: revision, reason: 'search current workspace', factRefs: [], input: {}, ...extra,
 })
 
+// Repaired planner fact refs are evidence citations, never capability tokens.
+// Even authority-looking values must not grant an action, a newer offer
+// version, or the verified tuple required to prepare Checkout.
+const repairedFactRef = `modelref:${'a'.repeat(64)}`
+{
+  const root = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-factref-action-authority-'))
+  const ledger = ensureLedger(root)
+  const rt = new BookingCopilotTaskRuntime(ledger, { contextRefFactory: () => 'ctx-v2' })
+  const limitedWorkspace: BookingWorkspaceSnapshot = {
+    ...workspace(0),
+    capabilities: { surface: 'tenant', allowedActions: ['search.run'] },
+  }
+  const t = rt.startTask({ ...turn('task-factref-action-authority'), workspace: limitedWorkspace })
+  const before = ledger.countEvents()
+  assert.throws(() => rt.issueOperation(t.taskId, {
+    ...action('factref-forged-action', 0, { factRefs: [repairedFactRef, 'checkout.prepare'] }),
+    kind: 'checkout.prepare' as const,
+    input: { offerRef: 'offer-a', offerVersionRef: 'offer-a:v1', verifiedOfferRef: 'verified-offer-a' },
+  }), /unsupported_action/, 'factRefs cannot add an action to the surface allowlist')
+  assert.equal(ledger.countEvents(), before, 'rejected factRef authority does not persist an operation')
+  ledger.close(); rmSync(root, { recursive: true, force: true })
+}
+{
+  const root = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-factref-offer-authority-'))
+  const ledger = ensureLedger(root)
+  const rt = new BookingCopilotTaskRuntime(ledger, { contextRefFactory: () => 'ctx-v2' })
+  const offerWorkspace: BookingWorkspaceSnapshot = {
+    ...workspace(0),
+    visibleHotels: [{ hotelRef: 'hotel-a', name: 'Hotel A', factRefs: [] }],
+    loadedOffers: [loadedOffer('offer-a', 'hotel-a', 'offer-a:v1')],
+  }
+  const t = rt.startTask({ ...turn('task-factref-offer-authority'), workspace: offerWorkspace })
+  const before = ledger.countEvents()
+  assert.throws(() => rt.issueOperation(t.taskId, {
+    ...action('factref-forged-version', 0, { factRefs: [repairedFactRef, 'offer-a:v2'] }),
+    kind: 'offer.check' as const,
+    input: { offerRef: 'offer-a', offerVersionRef: 'offer-a:v2' },
+  }), /offer_version_not_loaded/, 'factRefs cannot promote an unloaded offer version')
+  assert.equal(ledger.countEvents(), before, 'rejected factRef version does not persist an operation')
+  ledger.close(); rmSync(root, { recursive: true, force: true })
+}
+{
+  const root = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-factref-verified-authority-'))
+  const ledger = ensureLedger(root)
+  const rt = new BookingCopilotTaskRuntime(ledger, { contextRefFactory: () => 'ctx-v2', now: () => '2026-09-01T10:00:00.000Z' })
+  const offerWorkspace: BookingWorkspaceSnapshot = {
+    ...workspace(0),
+    visibleHotels: [{ hotelRef: 'hotel-a', name: 'Hotel A', factRefs: [] }],
+    loadedOffers: [loadedOffer('offer-a', 'hotel-a', 'offer-a:v1')],
+    selectedOfferRef: 'offer-a',
+  }
+  const t = rt.startTask({ ...turn('task-factref-verified-authority'), workspace: offerWorkspace })
+  const before = ledger.countEvents()
+  assert.throws(() => rt.issueOperation(t.taskId, {
+    ...action('factref-forged-verified', 0, { factRefs: [repairedFactRef, 'verified-offer-a'] }),
+    kind: 'checkout.prepare' as const,
+    input: { offerRef: 'offer-a', offerVersionRef: 'offer-a:v1', verifiedOfferRef: 'verified-offer-a' },
+  }), /offer_version_not_loaded/, 'factRefs cannot create verified-offer authority')
+  assert.equal(ledger.countEvents(), before, 'rejected factRef verification does not persist an operation')
+  ledger.close(); rmSync(root, { recursive: true, force: true })
+}
+
 let id = 0
 const runtime = new BookingCopilotTaskRuntime(ensureLedger(stateRoot), {
   idFactory: (prefix) => `${prefix}-${++id}`,
@@ -1299,4 +1361,4 @@ rmSync(forgedSourceRoot, { recursive: true, force: true }); rmSync(tamperRoot, {
 rmSync(crashRoot, { recursive: true, force: true }); rmSync(reverseRoot, { recursive: true, force: true }); rmSync(crossRoot, { recursive: true, force: true })
 rmSync(terminalRoot, { recursive: true, force: true })
 rmSync(offerRoot, { recursive: true, force: true })
-console.log('BOOKING COPILOT RUNTIME PROOF: task scope, receipt binding, approval authority/one-time, recovery, ingress/SSE session OK')
+console.log('BOOKING COPILOT RUNTIME PROOF: task scope, receipt binding, factRef non-authority, approval authority/one-time, recovery, ingress/SSE session OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -407,9 +407,11 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
     console.error('[booking-copilot] finalResponse recovery rejected (invalid action):', JSON.stringify({ kind: action.kind, errors: validation.errors.slice(0, 6) }).slice(0, 600))
     return null
   }
-  repairPlannerFactRefs(action)
+  const repairedRefs = repairPlannerFactRefs(action)
+  const repairedValidation = validateBookingReadAction(action as unknown as BookingReadAction)
+  if (!repairedValidation.ok) return null
   try {
-    assertPlannerSafeRefs(action)
+    assertPlannerSafeRefs(action, repairedRefs)
   } catch (error) {
     console.error('[booking-copilot] finalResponse recovery rejected (unsafe ref):', JSON.stringify({ actionId: action.actionId, factRefs: action.factRefs }).slice(0, 600))
     return null
@@ -426,17 +428,22 @@ function recoverFinalResponseDecision(response: string, task: BookingCopilotTask
 const PLANNER_SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:._-]*$/
 
 // Models cite prompt facts in URI-ish syntax (`fact://turn_X/request`,
-// `turn_X#request`); characters outside the runtime ref charset are mapped
-// deterministically to '.' so repair succeeds without burning the retry
-// budget. Anything the sanitizer cannot make unique enough still fails the
-// safe-ref gate into the retry path.
-function repairPlannerFactRefs(action: Record<string, unknown>): void {
+// `turn_X#request`). Preserve already-safe refs exactly; unsafe refs enter the
+// reserved modelref namespace with the full SHA-256 of the raw UTF-8 value.
+function repairPlannerFactRefs(action: Record<string, unknown>): Set<string> {
   const factRefs = action.factRefs
-  if (!Array.isArray(factRefs)) return
-  action.factRefs = factRefs.map((ref) => (typeof ref === 'string' ? ref.replace(/#/g, ':').replace(/[^A-Za-z0-9:._-]/g, '.') : ref))
+  const repairedRefs = new Set<string>()
+  if (!Array.isArray(factRefs)) return repairedRefs
+  action.factRefs = factRefs.map((ref) => {
+    if (typeof ref !== 'string' || PLANNER_SAFE_REF_PATTERN.test(ref)) return ref
+    const alias = `modelref:${createHash('sha256').update(ref, 'utf8').digest('hex')}`
+    repairedRefs.add(alias)
+    return alias
+  })
+  return repairedRefs
 }
 
-function assertPlannerSafeRefs(action: Record<string, unknown>): void {
+function assertPlannerSafeRefs(action: Record<string, unknown>, repairedRefs: Set<string>): void {
   const actionId = action.actionId
   if (typeof actionId !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(actionId)) {
     throw new Error(`planner_invalid_action:unsafe_action_id:${String(actionId).slice(0, 60)}`)
@@ -444,7 +451,7 @@ function assertPlannerSafeRefs(action: Record<string, unknown>): void {
   const factRefs = action.factRefs
   if (Array.isArray(factRefs)) {
     for (const ref of factRefs) {
-      if (typeof ref !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(ref)) {
+      if (typeof ref !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(ref) || (ref.startsWith('modelref:') && !repairedRefs.has(ref)) || ref.length > 512) {
         throw new Error(`planner_invalid_action:unsafe_fact_ref:${String(ref).slice(0, 60)}`)
       }
     }
@@ -502,8 +509,13 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
   // boundary, past the retry budget. Repair the common fragment syntax first,
   // then enforce the same charset here so remaining violations retry as
   // parse-class failures instead of failing the turn as PLANNER_FAILED.
-  repairPlannerFactRefs(decision.action)
-  assertPlannerSafeRefs(decision.action)
+  const repairedRefs = repairPlannerFactRefs(decision.action)
+  const repairedValidation = validateBookingReadAction(decision.action)
+  if (!repairedValidation.ok) {
+    console.error(`[booking-copilot] repaired action rejected:`, JSON.stringify({ errors: repairedValidation.errors.slice(0, 8) }).slice(0, 800))
+    throw new Error(`planner_invalid_action:${repairedValidation.errors.join('; ')}`)
+  }
+  assertPlannerSafeRefs(decision.action, repairedRefs)
   const action = decision.action as unknown as BookingReadAction
   const capability = TOOL_TO_CAPABILITY.get(name as DshEmbeddedBookingToolName)
   if (!capability || !actionsForEmbeddedCapability(capability).includes(action.kind)) {


### PR DESCRIPTION
## Why

The planner previously replaced unsafe factRef characters with dots. Distinct raw facts could therefore collapse to the same executable alias across actions and turns.

## Change

- preserve already-safe refs
- map unsafe refs into a reserved modelref namespace using the full SHA-256 digest
- reject direct model-authored use of the reserved namespace
- revalidate the canonical action after repair so duplicate aliases fail closed
- cover tool-call and finalResponse entry paths
- prove factRefs cannot grant surface actions, loaded offer versions, verified offers, or Checkout authority

## Verification

- Node 24.20.0 scripts/run-all-tests.sh: exit 0, sections 0-54 green
- Node 24.20.0 ts/scripts/smoke.ts: exit 0
- Booking surface contract proof: positive=77, negative=164
- Booking Copilot runtime/planner/ledger/DSH proofs: green
- Independent review: P0=0, P1=0, P2=0

## Boundary

This PR does not expand the closed capability registry, add Book, merge, deploy, or change UAT.