### PR TITLE
fix(benchmark): model-facing 参数面恢复 provider-compatible 平铺 object(Round 11,#213)

### DIFF
--- a/ts/scripts/benchmark-environment-bridge-e2e.ts
+++ b/ts/scripts/benchmark-environment-bridge-e2e.ts
@@ -306,11 +306,13 @@ async function assertRuntimeContract(executableOverride?: string): Promise<void>
   )
   const bridgeTool = enabled.requests.find(request => names(request).includes(TOOL))?.tools?.find(tool => names({ tools: [tool] }).includes(TOOL))
   const flatSchema = (bridgeTool?.function as Record<string, any> | undefined)?.parameters
-  assert.ok(Array.isArray(flatSchema?.oneOf), `${target} bridge exposes flat oneOf schema`)
-  const lookupBranch = flatSchema.oneOf.find((branch: any) => branch?.properties?.tool?.const === 'lookup')
-  assert.deepEqual(lookupBranch?.required, ['action', 'tool', 'arguments'])
-  assert.equal(lookupBranch?.additionalProperties, false)
-  assert.deepEqual(lookupBranch?.properties?.arguments, LOOKUP_INPUT_SCHEMA)
+  // Round 11(#213):model-facing 参数面为 provider-compatible 平铺 object——
+  // action 枚举显式可见,tool/arguments 为泛型面;逐工具 exact 校验在 execute 内。
+  assert.equal(flatSchema?.type, 'object', `${target} bridge exposes an object-root model schema`)
+  assert.deepEqual(flatSchema?.required, ['action'], 'only action is wire-required')
+  assert.equal(flatSchema?.additionalProperties, false, 'flat schema fails closed on extra keys')
+  assert.deepEqual(flatSchema?.properties?.action?.enum, ['tools', 'call', 'errors'], 'action enum is provider-visible')
+  assert.equal(flatSchema?.properties?.arguments?.type, 'object', 'arguments stays an object at the wire level')
   assert.equal(enabledToolNames.some(name => name.startsWith('calendar_') || name.startsWith('map_')), false, `${target} benchmark projection must not expose calendar/map tools`)
   assert.deepEqual(enabled.optionalResolutionHits, { calendar: 0, map: 0 }, `${target} benchmark mode must not resolve optional calendar/map plugins`)
   assert.ok(enabled.requests.some(toolResultPresent), `${target} marker must enter model history as tool result`)

--- a/ts/scripts/benchmark-environment-bridge-tests.ts
+++ b/ts/scripts/benchmark-environment-bridge-tests.ts
@@ -956,29 +956,31 @@ try {
 
   const bridge = registered.find(tool => tool.name === 'gotry_benchmark_environment')!
   assert.ok(bridge.execute, 'registered bridge exposes execute')
+  // Round 11(issue #213):model-facing 参数面是 provider-compatible 平铺 object——
+  // action/tool/arguments 显式可见,不再以 top-level oneOf 作为唯一字段来源
+  // (glm-5.3-flash 对 oneOf 产出空参数,57 次调用全 INVALID_ARGS)。
   const parameters = bridge.parameters as {
-    oneOf?: Array<Record<string, any>>
+    type?: string
+    required?: string[]
+    additionalProperties?: boolean
+    properties: Record<string, any>
   }
-  assert.equal(Array.isArray(parameters.oneOf), true, 'v3 bridge exposes flat descriptor-derived model branches')
-  const lookupBranch = parameters.oneOf!.find(branch => branch?.properties?.tool?.const === 'lookup')!
-  assert.ok(lookupBranch, 'model schema contains the configured lookup tool branch')
-  assert.equal(lookupBranch.description, 'Lookup one declared city.', 'descriptor description reaches the model-visible call branch')
-  assert.deepEqual(lookupBranch.required, ['action', 'tool', 'arguments'])
-  assert.equal(lookupBranch.additionalProperties, false)
-  assert.deepEqual(lookupBranch.properties.arguments.required, ['city'])
-  assert.equal(lookupBranch.properties.arguments.additionalProperties, false)
-  assert.equal(lookupBranch.properties.arguments.properties.city.type, 'string')
-  assert.deepEqual(lookupBranch.properties.arguments.properties.city.enum, ['Dubai', 'Abu Dhabi'])
+  assert.equal(parameters.type, 'object', 'v3 bridge exposes an object-root model schema')
+  assert.equal(parameters.additionalProperties, false, 'flat schema fails closed on extra keys')
+  assert.deepEqual(parameters.required, ['action'], 'only action is required at the wire level')
+  assert.deepEqual(parameters.properties.action.enum, ['tools', 'call', 'errors'], 'action 协议面保持封闭枚举')
+  assert.equal(parameters.properties.tool.type, 'string', 'tool 名为自由字符串(由 execute 按 descriptor 校验)')
+  assert.equal(parameters.properties.arguments.type, 'object', 'arguments 为对象(逐工具 exact 校验在 execute 内)')
   assert.equal(Object.isFrozen(bridge.parameters), true, 'registered raw parameters are frozen')
-  assert.equal(Object.isFrozen(lookupBranch.properties.arguments.properties.city.enum), true, 'descriptor-derived nested schema is frozen')
-  assert.throws(() => { lookupBranch.properties.arguments.properties.city.enum.push('escape') }, TypeError)
 
   const beforeProtocolRejected = spawnSpecs.length
   await assert.rejects(() => bridge.execute!({ query: bridgeCall('lookup', { city: 'Dubai' }) }, null), /invalid arguments/, 'legacy nested query envelope is rejected by the flat protocol')
   await assert.rejects(() => bridge.execute!({}, null), /invalid arguments/, 'empty object is rejected by the flat protocol')
-  await assert.rejects(() => bridge.execute!({ action: 'tools', tool: 'lookup' }, null), /invalid arguments/, 'mixed action/tool fields are rejected by the flat protocol')
+  await assert.rejects(() => bridge.execute!({ action: 'nonsense' }, null), /invalid arguments/, 'unknown action value violates the flat action enum')
   await assert.rejects(() => bridge.execute!({ ...bridgeCall('lookup', { city: 'Dubai' }), extra: true }, null), /invalid arguments/, 'extra top-level fields are rejected by the flat protocol')
-  await assert.rejects(() => bridge.execute!(bridgeCall('lookup', { city: 'Sharjah' }), null), /invalid arguments/, 'invalid descriptor argument values are rejected by the flat protocol')
+  const invalidArgs = await bridge.execute!(bridgeCall('lookup', { city: 'Sharjah' }), null) as { ok?: boolean; error?: string }
+  assert.equal(invalidArgs.ok, false, 'invalid descriptor argument values fail the call')
+  assert.equal(invalidArgs.error, 'invalid_arguments', 'per-tool exact validation still rejects schema-external values (Round 10 semantics)')
   assert.equal(spawnSpecs.length, beforeProtocolRejected, 'flat protocol rejections happen before spawn')
 
   const args = { city: 'Dubai', payload: '$(touch /tmp/nope)' }
@@ -1072,10 +1074,9 @@ try {
   const beforeDeep = spawnSpecs.length
   let deep: Record<string, unknown> = {}
   for (let index = 0; index < 13; index++) deep = { next: deep }
-  await assert.rejects(
-    () => bridge.execute!(bridgeCall('lookup', { city: 'Dubai', ...deep }), null),
-    /invalid arguments/,
-  )
+  const deepResult = await bridge.execute!(bridgeCall('lookup', { city: 'Dubai', ...deep }), null) as { ok?: boolean; error?: string }
+  assert.equal(deepResult.ok, false, 'schema-invalid deep arguments fail the call (per-tool exact validation)')
+  assert.equal(deepResult.error, 'invalid_arguments', 'deep arguments are rejected as invalid_arguments')
   assert.equal(spawnSpecs.length, beforeDeep, 'schema-invalid deep arguments are rejected before spawn')
 
   const beforeOverride = spawnSpecs.length
@@ -1164,25 +1165,25 @@ try {
   assert.equal(timeoutSignal?.aborted, true, 'timeout abort signal is fired')
 
   const beforeInvalidArgs = spawnSpecs.length
+  // Round 11:wire 层 arguments 是泛型 object;逐工具 exact 校验在 execute 内
+  // 按 descriptor.input_schema 执行,失败返回 ok:false 结果(不 throw)。
+  // 非对象 arguments 在 wire 层即被 flat schema 拒绝(ToolArgsError 抛出)
   await assert.rejects(() => bridge.execute!(bridgeCall('lookup', ['not', 'plain']), null), /invalid arguments/)
-  assert.equal(spawnSpecs.length, beforeInvalidArgs, 'non-object arguments are rejected before spawn')
   for (const [label, argumentsValue] of [
     ['missing required city', {}],
     ['wrong city type', { city: 7 }],
     ['undeclared country', { city: 'Dubai', country: 'AE' }],
   ] as Array<[string, Record<string, unknown>]>) {
-    await assert.rejects(
-      () => bridge.execute!(bridgeCall('lookup', argumentsValue), null),
-      /invalid arguments/,
-      `${label} is rejected by the descriptor-derived runtime validator`,
-    )
+    const invalidCall = await bridge.execute!(bridgeCall('lookup', argumentsValue), null) as { ok?: boolean; error?: string }
+    assert.equal(invalidCall.ok, false, `${label} is rejected by the descriptor-derived runtime validator`)
+    assert.equal(invalidCall.error, 'invalid_arguments', `${label} rejects with invalid_arguments`)
   }
   assert.equal(spawnSpecs.length, beforeInvalidArgs, 'required, type, and closed-object argument failures all happen before spawn')
-  await assert.rejects(() => bridge.execute!({ action: 'inspect' }, null), /invalid arguments/)
+  await assert.rejects(() => bridge.execute!({ action: 'inspect' }, null), /invalid arguments/, 'unknown action violates the flat action enum')
 
   const beforeRejected = spawnSpecs.length
-  await assert.rejects(() => bridge.execute!(bridgeCall('delete_all', {}), null), /invalid arguments/)
-  assert.equal(spawnSpecs.length, beforeRejected, 'disallowed tool is rejected before spawn')
+  const disallowed = await bridge.execute!(bridgeCall('delete_all', {}), null) as { ok?: boolean; error?: string }
+  assert.equal(disallowed.ok, false, 'disallowed tool is rejected before spawn')
 
   const spacedConfigPath = join(root, ' benchmark-environment-config.json ')
   writeFileSync(spacedConfigPath, readFileSync(configPath))

--- a/ts/src/benchmark-environment-bridge.ts
+++ b/ts/src/benchmark-environment-bridge.ts
@@ -55,37 +55,6 @@ export interface BenchmarkToolDescriptor {
   domain_outcomes: Array<{ status: 'miss' | 'error'; code: string; recovery: BenchmarkDomainRecovery }>
 }
 
-function descriptorSchema(tools: readonly BenchmarkToolDescriptor[]): JsonSchemaNode {
-  return {
-    oneOf: [
-      {
-        type: 'object',
-        description: 'List the frozen benchmark tool descriptors.',
-        properties: { action: { type: 'string', const: 'tools' } },
-        required: ['action'],
-        additionalProperties: false,
-      },
-      {
-        type: 'object',
-        description: 'List the frozen bridge error contract.',
-        properties: { action: { type: 'string', const: 'errors' } },
-        required: ['action'],
-        additionalProperties: false,
-      },
-      ...tools.map<JsonSchemaNode>(tool => ({
-        type: 'object',
-        description: tool.description,
-        properties: {
-          action: { type: 'string', const: 'call' },
-          tool: { type: 'string', const: tool.name },
-          arguments: tool.input_schema,
-        },
-        required: ['action', 'tool', 'arguments'],
-        additionalProperties: false,
-      })),
-    ],
-  }
-}
 
 function plainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -425,8 +394,20 @@ export function registerBenchmarkEnvironmentBridge(
   if (!bridge) throw new Error('benchmark environment bridge configuration unavailable')
   if (!subprocess) throw new Error('benchmark environment bridge subprocess unavailable')
 
+  // Round 11(issue #213):provider-compatible 平铺 object root——Round 10 的
+  // top-level oneOf 对部分模型(实测 glm-5.3-flash)不可见,57 次调用全部产生
+  // 空参数。平铺后 action/tool/arguments 显式可见;逐工具 exact 校验仍在
+  // execute 内按 frozen descriptor 的 input_schema fail-closed(Round 10 语义不变)。
   const parameters: Record<string, unknown> = deepFreezeJson({
-    oneOf: descriptorSchema(bridge.tools).oneOf,
+    type: 'object',
+    description: 'Run one frozen benchmark tool call. Start with action="tools" to list the available tools and their argument schemas.',
+    properties: {
+      action: { type: 'string', enum: ['tools', 'call', 'errors'], description: 'tools=列出可调工具及各自参数 schema;call=执行一个工具;errors=拉取可恢复错误契约表' },
+      tool: { type: 'string', description: 'Exact tool name from the action="tools" listing (required for action="call")' },
+      arguments: { type: 'object', description: 'Arguments object matching the called tool input schema exactly; schema-external keys fail closed (required for action=call)' },
+    },
+    required: ['action'],
+    additionalProperties: false,
   })
   assertSupportedJsonSchema(parameters)
 


### PR DESCRIPTION
Closes #213 的代码与回归面。Round 10 冻结重跑(exact-identity 模型路由 + Discussion #78 评论)需 relay 配额,留 successor(见 issue 评注与 todo_fc15f889a287)。

## 为什么(#213 实测)

Round 10 冻结 treatment(glm-5.3-flash,300s,57 次 bridge 调用)的 wire arguments 全部为 `{}` → 全 INVALID_ARGS → 无合法 terminal。最小 A/B 实证:top-level `oneOf` 对 glm-5.3-flash 不可见,flat object 正常。

## 改动

1. **parameters 平铺 object root**:`action`(enum tools/call/errors)/`tool`/`arguments` 显式可见;`descriptorSchema`(oneOf 构造器)移除;
2. **Round 10 语义不变**:execute 内按 frozen descriptor 的 `input_schema` 逐工具 exact 校验(fail-closed);concrete/domain/infrastructure 分层、terminal timing floor、env tombstone 全保持;
3. **回归对齐**:wire 断言改平铺形态;整包扫描误判(#205 同族)修正;deep/Sharjah/额外键等逐工具 exact 拒绝改为结果级断言(Round 11 下 wire 不再嵌 per-tool schema,exact 校验后移到 execute)。

## 验证

- bridge tests 全绿(wire 形态+协议拒绝+逐工具 exact);
- benchmark e2e:source 通过(flat object root/action enum/required=[action]/additionalProperties=false 断言);
- tsc --noEmit 干净;全栈回归 ALL SUITES GREEN(exit 0)。