### PR TITLE
docs(setup): note OpenAPI-ticket requirement for trade/checkAvail endpoints (issue #142)

### DIFF
--- a/bin/gotry-bootstrap.js
+++ b/bin/gotry-bootstrap.js
@@ -123,6 +123,7 @@ async function setupHbcli() {
   say('    · 快速试用(官方沙箱演示账号): hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo')
   say('    · 正式接入: 向 HotelByte 申请专属 appKey/appSecret 后用同一命令替换')
   say('    · 门户账号(权限更大,酒店搜索无必要): hbcli auth login --username <email>')
+  say('  · 预订链端点(trade.* / search/checkAvail)只接受 OpenAPI ticket;portal ticket 会 401(issue #142)')
   say('  自检: hbcli auth whoami(api_key.configured=true 即就位)')
   return { ok: true }
 }


### PR DESCRIPTION
## Context

[Issue #142](https://github.com/Danceiny/gotry/issues/142) (booking-copilot merge gate) is blocked on mechanical steps ②③④ because every `@permission: openapi` endpoint answered 401. Root cause: not in hotel-be, not in gotry, but in [hotelbyte-cli#10](https://github.com/hotelbyte-com/hotelbyte-cli/pull/10) — the auth resolver was returning the literal placeholder `"stored-ticket"` as a bearer token.

## This PR

Adds one line to `bin/gotry-bootstrap.js` after the hbcli setup hints, clarifying that the booking-copilot endpoints (`trade.*`, `search/checkAvail`) require an OpenAPI ticket — a portal login alone produces 401.

No code change in gotry's booking-copilot runtime; `booking-surface/availability-policy.ts` and the receipt/typed-state code are untouched (already correct, confirmed by offline run-all §49 per issue #142 comment 1).

## Verification

```
$ bash scripts/run-all-tests.sh
... (unchanged)
FAIL count: 11 (baseline: 11)
diff of failure sets: empty
```

Baseline failures are pre-existing (missing tsx binary, ledger migrate expectations against missing fixtures, etc.) and unrelated to this one-line doc note.

## Cross-repo

- **Real fix**: [hotelbyte-com/hotelbyte-cli#10](https://github.com/hotelbyte-com/hotelbyte-cli/pull/10) (PR already opened; rebases the auth resolver so portal-ticket-unavailable falls back to openapi)
- **Tracking**: [Danceiny/gotry#142](https://github.com/Danceiny/gotry/issues/142)

## What still needs founder

Per issue #142 gate discipline, the UAT-side Chrome UI verification (gate ① across 4 surfaces) is still founder-side. Once hotelbyte-cli#10 merges and a fresh `hbcli` binary ships, agent-side mechanical steps ②③④ can be re-run end-to-end with this branch.