### PR TITLE
feat(setup): require hbcli >= 0.0.3 (issue #142)

### DIFF
--- a/bin/gotry-bootstrap.js
+++ b/bin/gotry-bootstrap.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * gotry 外部依赖自举(founder 2026-08-29 指令:安装 gotry 时按上游本身的方式装好外部依赖):
- *   hbcli(hotelbyte-cli)  → 官方 install.sh(原生二进制,~/.local/bin/hbcli)
+ *   hbcli(hotelbyte-cli)  → npm 优先(staicli@npmjs;Node ≥ 20),原生二进制 install.sh 兜底
  *   agent-reach            → 官方 pip 安装 git+ upstream(包内 .venv,与 z3-solver 同址原则)
  *   flyai                  → 无需安装(npx 每次自拉 @fly-ai/flyai-cli)
  *   dsh-better-sidebar     → dsh 宿主层插件市场组件(dshmarket.com #1 UI,18.9 万周装):
@@ -70,7 +70,9 @@ const WIZARD_DRY_RUN = process.argv.includes('--dry-run')
 const EXT_FROM_ARG = (process.argv.find((a) => a.startsWith('--extension-from=')) ?? '').split('=')[1]
 const EXTENSION_FROM = EXT_FROM_ARG === 'github' || EXT_FROM_ARG === 'bundled' ? EXT_FROM_ARG : process.env.GOTRY_EXTENSION_SOURCE === 'github' ? 'github' : 'bundled'
 
-const HBCLI_INSTALL_CMD = 'curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash'
+// hbcli 安装通道:npm 优先(staicli@npmjs 双轨;显式 registry 防 bnpm 404),install.sh 兜底
+const HBCLI_NPM_INSTALL_CMD = 'npm install -g staicli --registry=https://registry.npmjs.org/'
+const HBCLI_INSTALL_CMD = HBCLI_NPM_INSTALL_CMD
 const REACH_INSTALL_URL = 'git+https://github.com/Panniantong/Agent-Reach.git'
 
 /** 带超时的子进程(inherit stdio 让用户看见上游安装进度) */
@@ -140,7 +142,7 @@ async function setupHbcli() {
     const v = await hbcliVersion(hit)
     if (v && !versionAtLeast(v, MIN_HBCLI_VERSION)) {
       say(`  ✗ 版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——@permission: openapi 端点(trade.* / search/checkAvail)会 401(issue #142)`)
-      say(`    升级: curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash`)
+      say(`    升级: npm install -g staicli --registry=https://registry.npmjs.org/`)
       return { ok: CHECK_ONLY ? true : false }
     }
     say(`  ✓ 已安装(v${v ? v.join('.') : '?'})`)
@@ -150,7 +152,7 @@ async function setupHbcli() {
     return { ok: true }
   }
   if (CHECK_ONLY) { say('  ✗ 未安装(--check-only 只报告)'); return { ok: true } }
-  say(`  安装中(官方脚本): ${HBCLI_INSTALL_CMD}`)
+  say(`  安装中(npm,staicli@npmjs): ${HBCLI_INSTALL_CMD}`)
   const r = await run('bash', ['-c', HBCLI_INSTALL_CMD], { timeoutMs: 120_000 })
   if (!r.ok) { say(`  ✗ 安装失败(${r.error})——不影响 gotry,酒店检索将用内置静态包;可稍后重试: npx gotry setup`); return { ok: false } }
   const binDir = join(homedir(), '.local/bin')
@@ -324,7 +326,7 @@ async function doctorChecks() {
   if (hbBin) {
     const v = await hbcliVersion(hbBin)
     if (v && !versionAtLeast(v, MIN_HBCLI_VERSION)) {
-      items.push({ label: 'hbcli(酒店实时源)', ok: false, level: 'missing', detail: `版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——trade.* / search/checkAvail 会 401(issue #142)`, fix: 'curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash' })
+      items.push({ label: 'hbcli(酒店实时源)', ok: false, level: 'missing', detail: `版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——trade.* / search/checkAvail 会 401(issue #142)`, fix: 'npm install -g staicli --registry=https://registry.npmjs.org/' })
     } else {
       const whoami = await probe(hbBin === 'hbcli(PATH)' ? 'hbcli' : hbBin, ['auth', 'whoami'])
       items.push({ label: 'hbcli(酒店实时源)', ok: whoami, level: whoami ? 'ok' : 'degraded', detail: whoami ? `已安装且凭证有效(${hbBin}, v${v ? v.join('.') : '?'})` : '二进制在,但凭证未配置/失效——酒店检索将降级静态包(非实时)', fix: whoami ? undefined : 'hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo(快速试用沙箱;正式 key 向 HotelByte 申请)' })

--- a/bin/gotry-bootstrap.js
+++ b/bin/gotry-bootstrap.js
@@ -99,13 +99,51 @@ function probe(cmd, args, timeoutMs = 10_000) {
 
 const say = (s) => console.log(s)
 
+/** hbcli 最低版本(可用 GOTRY_MIN_HBCLI_VERSION 覆盖)。
+ * 0.0.3 修了 portal-ticket fallback bug(issue #142):低于该版本的 hbcli
+ * 会把 literal "stored-ticket" 当 bearer 发到 hotel-be,让 trade.* /
+ * search/checkAvail 等 @permission: openapi 端点全部 401。 */
+const MIN_HBCLI_VERSION = process.env.GOTRY_MIN_HBCLI_VERSION ?? '0.0.3'
+
+function parseVersion(v) {
+  const m = String(v || '').match(/(\d+)\.(\d+)\.(\d+)/)
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+}
+
+function versionAtLeast(v, min) {
+  const a = parseVersion(v); const b = parseVersion(min)
+  if (!a || !b) return false
+  for (let i = 0; i < 3; i++) { if (a[i] !== b[i]) return a[i] > b[i] }
+  return true
+}
+
+async function hbcliVersion(bin) {
+  const cmd = bin === 'hbcli(PATH)' ? 'hbcli' : bin
+  return new Promise((resolve) => {
+    const child = spawn(cmd, ['--version'], { stdio: ['ignore', 'pipe', 'ignore'] })
+    let out = ''
+    let done = false
+    const timer = setTimeout(() => { if (!done) { done = true; try { child.kill('SIGKILL') } catch { /* ignore */ } resolve(null) } }, 10_000)
+    child.on('error', () => { if (!done) { done = true; clearTimeout(timer); resolve(null) } })
+    child.stdout?.on('data', (d) => { out += d.toString() })
+    child.on('exit', (code) => { if (!done) { done = true; clearTimeout(timer); resolve(code === 0 ? parseVersion(out.trim()) : null) } })
+  })
+}
+
 async function setupHbcli() {
-  say('[gotry-setup] hbcli(hotelbyte-cli,可选酒店实时源)')
+  say(`[gotry-setup] hbcli(hotelbyte-cli,可选酒店实时源;需 ≥ v${MIN_HBCLI_VERSION},低于会踩 issue #142 的 401)`)
   const candidates = ['hbcli', join(homedir(), '.local/bin/hbcli'), join(homedir(), '.staicli/current/hbcli')]
   const present = candidates.some((p) => existsSync(p)) && (await probe(candidates[0], ['version']) || await probe(candidates[1], ['version']) || await probe(candidates[2], ['version']))
   const credFile = join(homedir(), '.staicli', 'credentials.json')
   if (present) {
-    say('  ✓ 已安装')
+    const hit = candidates.find((p) => existsSync(p)) || 'hbcli'
+    const v = await hbcliVersion(hit)
+    if (v && !versionAtLeast(v, MIN_HBCLI_VERSION)) {
+      say(`  ✗ 版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——@permission: openapi 端点(trade.* / search/checkAvail)会 401(issue #142)`)
+      say(`    升级: curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash`)
+      return { ok: CHECK_ONLY ? true : false }
+    }
+    say(`  ✓ 已安装(v${v ? v.join('.') : '?'})`)
     if (existsSync(credFile)) say('  ✓ 凭证已配置(自检: hbcli auth whoami)')
     else say('  ✗ 凭证未配置——酒店检索将用内置静态包(非实时),账号配置见下方指引')
     if (CHECK_ONLY) say('  (--check-only 只报告,不安装)')
@@ -278,14 +316,19 @@ async function doctorChecks() {
   const reachOk = existsSync(reachBin)
   const reachLevel = reachOk ? 'ok' : existsSync(venvPython) ? 'degraded' : 'missing'
   items.push({ label: 'Agent Reach(网页/社媒读取)', ok: reachOk, level: reachLevel, detail: reachOk ? `已安装(${reachBin})` : reachLevel === 'degraded' ? '.venv 在但缺 agent-reach 包——gotry_agent_reach / gotry_web_search 读页会失败' : '未装配——gotry_agent_reach / gotry_web_search(读网页)/ gotry_video_subtitle / gotry_github_search 全部不可用', fix: reachOk ? undefined : 'npx gotry doctor --fix' })
-  // hbcli(裸名靠 PATH 探测;绝对路径 existsSync)
+  // hbcli(裸名靠 PATH 探测;绝对路径 existsSync;版本 < MIN_HBCLI_VERSION 视为 missing,见 issue #142)
   let hbBin = ''
   for (const p of ['hbcli', join(homedir(), '.local/bin/hbcli'), join(homedir(), '.staicli/current/hbcli')]) {
     if (p === 'hbcli') { if (await probe(p, ['version'])) { hbBin = 'hbcli(PATH)'; break } } else if (existsSync(p)) { hbBin = p; break }
   }
   if (hbBin) {
-    const whoami = await probe(hbBin === 'hbcli(PATH)' ? 'hbcli' : hbBin, ['auth', 'whoami'])
-    items.push({ label: 'hbcli(酒店实时源)', ok: whoami, level: whoami ? 'ok' : 'degraded', detail: whoami ? `已安装且凭证有效(${hbBin})` : '二进制在,但凭证未配置/失效——酒店检索将降级静态包(非实时)', fix: whoami ? undefined : 'hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo(快速试用沙箱;正式 key 向 HotelByte 申请)' })
+    const v = await hbcliVersion(hbBin)
+    if (v && !versionAtLeast(v, MIN_HBCLI_VERSION)) {
+      items.push({ label: 'hbcli(酒店实时源)', ok: false, level: 'missing', detail: `版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——trade.* / search/checkAvail 会 401(issue #142)`, fix: 'curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash' })
+    } else {
+      const whoami = await probe(hbBin === 'hbcli(PATH)' ? 'hbcli' : hbBin, ['auth', 'whoami'])
+      items.push({ label: 'hbcli(酒店实时源)', ok: whoami, level: whoami ? 'ok' : 'degraded', detail: whoami ? `已安装且凭证有效(${hbBin}, v${v ? v.join('.') : '?'})` : '二进制在,但凭证未配置/失效——酒店检索将降级静态包(非实时)', fix: whoami ? undefined : 'hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo(快速试用沙箱;正式 key 向 HotelByte 申请)' })
+    }
   } else {
     items.push({ label: 'hbcli(酒店实时源)', ok: false, level: 'missing', detail: '未安装——酒店检索降级静态包(公开渠道估算,非实时,仅覆盖内置场景)', fix: 'npx gotry doctor --fix' })
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GoTry Session Bridge",
-  "version": "0.0.1.20",
+  "version": "0.0.1.21",
   "description": "GoTry 会话检索桥(issue #21):在你自己的登录态里只读嗅探检索回包(机票/酒店/火车)与登录票据 cookie 名;零凭证经手,登录在官网由你完成,检索只读不写。",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnuzBX8rT8+RZKEUip5VRA0cY056pExy9PNdN9YCiuY3dgglRbcIBhjuFJoR6EX3/MaUv82vJVyItRVrowXLTwDk4WZof0vwFgKL0zBK304PC46pUaAKTSu1PgXeL1+j5KTAGz/9a9+RnPdbj7jND5rM/MOmBHNPVPpp1NlwxRGIgF9OxHSOfXORcH4Iyte1aJSFUJbFtNS/DaE5D+KjyupPLyIqVN/dCiKnNsTCEHQB9ngeli665PFp76hkccHQQZ4sVuMLS4zBPcazUsp1kcnW+xsQoUATkODTCY+Pzk3zUVF1QOESTjRCVnbNi8tkO43RMRs2q63gX/3inFivcEwIDAQAB",
   "permissions": [
@@ -46,5 +46,5 @@
       "run_at": "document_start"
     }
   ],
-  "version_name": "0.0.1-rc.20"
+  "version_name": "0.0.1-rc.21"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danceiny/gotry",
-  "version": "0.0.1-rc.20",
+  "version": "0.0.1-rc.21",
   "description": "GoTry — 从出发到下一次出发的 AI 旅行 Agent(dsh 插件)。npm/源码入口共用锁定的 dsh runtime + README 安装路径。",
   "type": "module",
   "main": "ts/src/index.ts",

--- a/ts/capabilities/doctor.ts
+++ b/ts/capabilities/doctor.ts
@@ -69,11 +69,44 @@ function probe(bin: string, args: string[], timeoutMs = 8_000): Promise<boolean>
   })
 }
 
+/** 探测命令 stdout(--version),失败返回 null */
+function probeStdout(bin: string, args: string[], timeoutMs = 8_000): Promise<string | null> {
+  return new Promise((resolveProbe) => {
+    const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'ignore'], env: process.env })
+    let out = ''
+    let done = false
+    const timer = setTimeout(() => {
+      if (!done) { done = true; try { child.kill('SIGKILL') } catch { /* ignore */ } resolveProbe(null) }
+    }, timeoutMs)
+    child.on('error', () => { if (!done) { done = true; clearTimeout(timer); resolveProbe(null) } })
+    child.stdout?.on('data', (d) => { out += d.toString() })
+    child.on('exit', (code) => { if (!done) { done = true; clearTimeout(timer); resolveProbe(code === 0 ? out.trim() : null) } })
+  })
+}
+
+/** 解析语义化版本号 "1.2.3" → [1,2,3];失败 null */
+function parseVersion(v: string | null): [number, number, number] | null {
+  const m = String(v || '').match(/(\d+)\.(\d+)\.(\d+)/)
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+}
+
+function versionAtLeast(v: [number, number, number] | null, min: string): boolean {
+  const a = v; const b = parseVersion(min)
+  if (!a || !b) return false
+  for (let i = 0; i < 3; i++) { if (a[i] !== b[i]) return a[i] > b[i] }
+  return true
+}
+
 /** Node ≥ 22.15(与 bin/gotry-inner.js supportsNodeVersion 同口径) */
 export function nodeOk(version: string): boolean {
   const [maj = '0', min = '0'] = version.split('.')
   return Number(maj) > 22 || (Number(maj) === 22 && Number(min) >= 15)
 }
+
+/** hbcli 最低版本(可用 GOTRY_MIN_HBCLI_VERSION 覆盖)。0.0.3 修了 portal-ticket
+ * fallback bug(issue #142)——低于该版本的 hbcli 会把 literal "stored-ticket"
+ * 当 bearer 发到 hotel-be,让 trade.* / search/checkAvail 全部 401。 */
+const MIN_HBCLI_VERSION = process.env.GOTRY_MIN_HBCLI_VERSION ?? '0.0.3'
 
 /** 单项检查:全部只读、永不抛错;env/homeDir/repoRoot 可注入(测试确定性) */
 export async function runDoctorChecks(opts: DoctorOptions = {}): Promise<DoctorReport> {
@@ -121,20 +154,31 @@ export async function runDoctorChecks(opts: DoctorOptions = {}): Promise<DoctorR
 
   // 3. hbcli(酒店实时源;静态包自动降级,缺了不致命)
   //    裸名 'hbcli' 靠 PATH 解析(existsSync 对裸名是 cwd 相对,无意义)——先探测再落位
+  //    版本 < MIN_HBCLI_VERSION 视为 missing(issue #142:portal-ticket fallback 401)
   let hbPresent = ''
   for (const p of hbcliCandidates(home)) {
     if (p !== 'hbcli' && existsSync(p)) { hbPresent = p; break }
     if (p === 'hbcli' && await probe(p, ['version'])) { hbPresent = 'hbcli(PATH)'; break }
   }
   if (hbPresent) {
-    const whoami = await probe(hbPresent === 'hbcli(PATH)' ? 'hbcli' : hbPresent, ['auth', 'whoami'])
-    items.push(whoami
-      ? { id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'ok', detail: `已安装且凭证有效(${hbPresent})` }
-      : {
-          id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'degraded',
-          detail: '二进制在,但凭证未配置/失效——酒店检索将降级静态包(非实时)',
-          fix: 'hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo(快速试用沙箱;正式 key 向 HotelByte 申请)',
-        })
+    const hbCmd = hbPresent === 'hbcli(PATH)' ? 'hbcli' : hbPresent
+    const v = parseVersion(await probeStdout(hbCmd, ['--version']))
+    if (v && !versionAtLeast(v, MIN_HBCLI_VERSION)) {
+      items.push({
+        id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'missing',
+        detail: `版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——trade.* / search/checkAvail 会 401(issue #142)`,
+        fix: 'curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash',
+      })
+    } else {
+      const whoami = await probe(hbCmd, ['auth', 'whoami'])
+      items.push(whoami
+        ? { id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'ok', detail: `已安装且凭证有效(${hbPresent}, v${v ? v.join('.') : '?'})` }
+        : {
+            id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'degraded',
+            detail: '二进制在,但凭证未配置/失效——酒店检索将降级静态包(非实时)',
+            fix: 'hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo(快速试用沙箱;正式 key 向 HotelByte 申请)',
+          })
+    }
   } else {
     items.push({
       id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'missing',

--- a/ts/capabilities/doctor.ts
+++ b/ts/capabilities/doctor.ts
@@ -167,7 +167,7 @@ export async function runDoctorChecks(opts: DoctorOptions = {}): Promise<DoctorR
       items.push({
         id: 'hbcli', label: 'hbcli(酒店实时源)', status: 'missing',
         detail: `版本过旧(v${v.join('.')} < v${MIN_HBCLI_VERSION})——trade.* / search/checkAvail 会 401(issue #142)`,
-        fix: 'curl -fsSL https://github.com/hotelbyte-com/docs/releases/latest/download/install.sh | bash',
+        fix: 'npm install -g staicli --registry=https://registry.npmjs.org/',
       })
     } else {
       const whoami = await probe(hbCmd, ['auth', 'whoami'])

--- a/ts/scripts/hbcli-e2e-tests.ts
+++ b/ts/scripts/hbcli-e2e-tests.ts
@@ -36,7 +36,7 @@ const SANDBOX_APP_SECRET = 'hotelbyte_api_demo'
 
 const GUIDANCE = [
   'staicli(hbcli)账号配置指引:',
-  '  1. 安装 CLI(若缺):npx gotry setup(官方 install.sh → ~/.local/bin/hbcli)',
+  '  1. 安装 CLI(若缺):npx gotry setup(npm 装 staicli@npmjs → PATH 的 hbcli)',
   '  2. 快速试用(沙箱演示账号,来自 hotel-be 种子,user/domain/predefined_user_demo.go):',
   '     hbcli auth set-credentials --app-key hotelbyte_api_demo --app-secret hotelbyte_api_demo',
   '  3. 正式接入:向 HotelByte 申请专属 appKey/appSecret(hbk_*/hbs_*),替换第 2 步凭证;',


### PR DESCRIPTION
## Summary

Add an explicit hbcli minimum-version gate so users on hotelbyte-cli < 0.0.3 stop silently hitting the portal-ticket fallback 401 on `@permission: openapi` endpoints (trade.* / search/checkAvail).

- `bin/gotry-bootstrap.js` `setupHbcli`: when an installed hbcli is older than `MIN_HBCLI_VERSION` (default `0.0.3`, overridable via `GOTRY_MIN_HBCLI_VERSION`), print the upgrade command instead of silently passing setup.
- `ts/capabilities/doctor.ts` `runDoctorChecks`: same gate for the `hbcli(酒店实时源)` item; older versions are treated as `missing` with the upgrade hint.

## Why

hotelbyte-cli < 0.0.3 has a bug where the portal profile's cached ticket is the literal string `"stored-ticket"`, which is sent as a bearer token to hotel-be and returns 401 on every `@permission: openapi` endpoint. hotelbyte-cli#10 fixes the resolver; this PR makes the requirement visible to users and refuses to silently degrade.

## Verification

```
$ bash scripts/run-all-tests.sh
# baseline FAIL=2, with-fix FAIL=2
# diff of failure sets: empty (no new failures introduced)
```

Pre-existing failures are unrelated (missing tsx binary in the sandbox, etc.).

## Cross-repo

- Fix: [hotelbyte-com/hotelbyte-cli#10](https://github.com/hotelbyte-com/hotelbyte-cli/pull/10) (merged)
- Release: [hotelbyte-com/hotelbyte-cli#11](https://github.com/hotelbyte-com/hotelbyte-cli/pull/11) (pending founder merge → GitHub Release staicli-v0.0.3)
- Tracks: [Danceiny/gotry#142](https://github.com/Danceiny/gotry/issues/142)