### PR TITLE
test(ledger): pin tenant fold regression

### DIFF
--- a/ts/scripts/booking-saga-tests.ts
+++ b/ts/scripts/booking-saga-tests.ts
@@ -136,6 +136,8 @@ try {
   const other = ensureLedger(root, 'tenant-b')
   const crossProp = other.requestPendingWrite({ idemKey: K1, seam: 'flight-order-confirm', payload: {} })
   assert(crossProp.created === true, '同 idem_key 跨租户互不可见:tenant-b 可建自己的 K1(tenant_id 一等字段,ADR-16)')
+  const sagaRows = other.db.prepare('SELECT tenant_id, idem_key, status FROM pending_writes WHERE idem_key = ? ORDER BY tenant_id').all(K1) as Array<{ tenant_id: string; idem_key: string; status: string }>
+  assert(sagaRows.map(r => `${r.tenant_id}:${r.status}`).join(',') === 'local:compensated,tenant-b:pending', '同 saga idem_key 的 pending_writes 行按 tenant 绑定,tenant-b 不覆盖 local')
   assert(sagaEventsOf(other, K1).map(e => e.kind).join(',') === 'write.pending' && other.readEvents('write.pending', 10).every(e => e.tenant_id === 'tenant-b'), 'tenant-b saga 审计事件 owner 不回落 local,readEvents 不串租户')
   const LOCAL_ONLY = 'booking:local-only'
   ledger.requestPendingWrite({ idemKey: LOCAL_ONLY, seam: 'flight-order-confirm', payload: {} })

--- a/ts/scripts/ledger-tests.ts
+++ b/ts/scripts/ledger-tests.ts
@@ -10,7 +10,8 @@
  *  8 one-shot 迁移:旧 JSON/JSONL → events;快照先行;重复 ensure 不重复导入
  *  9 durable 工单崩溃恢复:子进程 settle 前 exit 9 → 恢复零重算(exactly-once)
  * 10 pending_writes saga:幂等键去重/L3 确认一次/补偿/审计事件链/what-if 分叉隔离
- * 11 ADR-16 tenant scope:append/read/fold/rebuild/迁移边界/同 id/跨进程 reopen 全隔离
+ * 11 ADR-16 tenant scope:append/read/fold/rebuild/迁移边界/同 id/跨进程 reopen 全隔离;
+ *    精确 fold 反例、kind+limit 截断、workflow/forget 行归属都必须可负向验红
  * 运行(在 ts/ 下):npx tsx scripts/ledger-tests.ts
  */
 
@@ -21,7 +22,7 @@ import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import type { TripState } from '../src/contracts.ts'
 import { persistAsyncTicket, type AsyncTicket } from '../src/loop.ts'
-import { ensureLedger, ledgerDbPath, openLedgerIfExists, readWishPoolWithFallback } from '../src/state-ledger.ts'
+import { ensureLedger, ledgerDbPath, ledgerExists, openLedgerIfExists, readWishPoolWithFallback } from '../src/state-ledger.ts'
 import { parseFlightPackToSpec } from '../src/unified.ts'
 
 type TerminalOutcome = {
@@ -172,7 +173,9 @@ const tenantMroot = mkdtempSync(join(tmpdir(), 'gotry-migrate-tenant-boundary-')
 const tenantMdir = join(tenantMroot, 'gotry-state')
 mkdirSync(tenantMdir, { recursive: true })
 writeFileSync(join(tenantMdir, 'wish-pool.json'), JSON.stringify([{ wish_id: 'wLOCALLEGACY', name: '本地旧愿望', conditions: { days: 2 }, added_at: '2026-08-01T00:00:00Z' }]))
-assert(readWishPoolWithFallback(tenantMroot, 'tenant-a').length === 0, '迁移边界:非 local 只读 fallback 不读取旧本地 JSON')
+assert(!ledgerExists(tenantMroot), '迁移边界:非 local fallback 前 DB 不存在')
+assert(readWishPoolWithFallback(tenantMroot, 'tenant-a').length === 0 && !ledgerExists(tenantMroot), '迁移边界:非 local 只读 fallback 不读取旧本地 JSON,也不创建 DB')
+assert(existsSync(join(tenantMdir, 'wish-pool.json')), '迁移边界:非 local 只读 fallback 不触碰 legacy 文件')
 const tenantFirst = ensureLedger(tenantMroot, 'tenant-a')
 const localLegacy = ensureLedger(tenantMroot)
 assert(tenantFirst.readWishPool().length === 0, '迁移边界:非 local 首次打开不把旧文件猜入该租户')
@@ -209,6 +212,51 @@ assert(
   (v1Local.db.prepare('SELECT COUNT(*) AS n FROM events WHERE tenant_id = \'local\'').get() as { n: number }).n === 1,
   'schema v1→v2:events tenant_id 回填为 local 且不丢 seq/idempotency',
 )
+
+const tenantMrootProc = mkdtempSync(join(tmpdir(), 'gotry-migrate-tenant-boundary-proc-'))
+const tenantMdirProc = join(tenantMrootProc, 'gotry-state')
+mkdirSync(tenantMdirProc, { recursive: true })
+writeFileSync(join(tenantMdirProc, 'wish-pool.json'), JSON.stringify([{ wish_id: 'wPROCLEGACY', name: '子进程旧愿望', reason: 'legacy-local', conditions: { days: 3 }, added_at: '2026-08-03T00:00:00Z' }]))
+const legacyProc = spawnSync('npx', ['tsx', '--eval', `
+  import { ensureLedger, ledgerExists, readWishPoolWithFallback } from './src/state-ledger.ts'
+  const root = ${JSON.stringify(tenantMrootProc)}
+  if (ledgerExists(root)) process.exit(2)
+  if (readWishPoolWithFallback(root, 'tenant-a').length !== 0 || ledgerExists(root)) process.exit(3)
+  const tenant = ensureLedger(root, 'tenant-a')
+  const local = ensureLedger(root)
+  const foreign = local.db.prepare("SELECT COUNT(*) AS n FROM events WHERE tenant_id != 'local'").get().n
+  if (tenant.readWishPool().length !== 0 || local.readWishPool()[0]?.wish_id !== 'wPROCLEGACY' || foreign !== 0) process.exit(4)
+`], { encoding: 'utf-8', cwd: process.cwd(), env: process.env })
+assert(legacyProc.status === 0, `legacy JSON 跨进程首次非 local 迁移只归 local 且 fallback 不创建 DB(实际 ${legacyProc.status}:${(legacyProc.stderr ?? '').slice(0, 300)})`)
+
+const v1rootProc = mkdtempSync(join(tmpdir(), 'gotry-v1-tenant-migration-proc-'))
+mkdirSync(join(v1rootProc, 'gotry-state'), { recursive: true })
+const v1dbProc = new Database(ledgerDbPath(v1rootProc))
+v1dbProc.exec(`
+  CREATE TABLE events (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL DEFAULT '',
+    payload TEXT NOT NULL,
+    idem_key TEXT,
+    run_id TEXT
+  );
+  CREATE UNIQUE INDEX events_idem ON events(idem_key) WHERE idem_key IS NOT NULL;
+`)
+v1dbProc.prepare('INSERT INTO events (ts, actor, kind, subject_id, payload, idem_key, run_id) VALUES (?, ?, ?, ?, ?, ?, NULL)')
+  .run('2026-08-28T00:00:00.000Z', 'system:v1', 'wish.added', 'wV1PROC', JSON.stringify({ wish: { wish_id: 'wV1PROC', name: 'v1子进程旧愿望', reason: 'v1-local', conditions: { days: 5 }, added_at: '2026-08-28T00:00:00.000Z' } }), 'v1proc:wish')
+v1dbProc.close()
+const v1Proc = spawnSync('npx', ['tsx', '--eval', `
+  import { ensureLedger } from './src/state-ledger.ts'
+  const root = ${JSON.stringify(v1rootProc)}
+  const tenant = ensureLedger(root, 'tenant-a')
+  const local = ensureLedger(root)
+  const localRows = local.db.prepare("SELECT COUNT(*) AS n FROM events WHERE tenant_id = 'local'").get().n
+  if (tenant.readWishPool().length !== 0 || local.readWishPool()[0]?.wish_id !== 'wV1PROC' || localRows !== 1) process.exit(5)
+`], { encoding: 'utf-8', cwd: process.cwd(), env: process.env })
+assert(v1Proc.status === 0, `schema v1→v2 跨进程首次非 local 打开不吸收 local 事件(实际 ${v1Proc.status}:${(v1Proc.stderr ?? '').slice(0, 300)})`)
 
 // ---- 9:durable 工单崩溃恢复(exactly-once) ----------------------------------------
 
@@ -448,13 +496,82 @@ const reopenTenant = spawnSync('npx', ['tsx', '--eval', reopenScript], { encodin
 assert(reopenTenant.status === 0, `跨进程 reopen 后租户事件/投影仍隔离(实际 ${reopenTenant.status}:${(reopenTenant.stderr ?? '').slice(0, 300)})`)
 assert(localLedger.tenant === 'local' && tenantA.tenant === 'tenant-a' && tenantB.tenant === 'tenant-b', 'tenant_id 从第一天就是一等字段')
 
+const probeASeq = tenantA.insertEvent({ actor: 'test:tenant-scope', kind: 'tenant.probe', subjectId: 'probe-a', payload: { tenant: 'A' }, ts: '2026-09-08T00:00:10.000Z' })
+const probeBSeq = tenantB.insertEvent({ actor: 'test:tenant-scope', kind: 'tenant.probe', subjectId: 'probe-b-newer', payload: { tenant: 'B' }, ts: '2026-09-08T00:00:11.000Z' })
+const aProbe = tenantA.readEvents('tenant.probe', 1)[0]
+assert((probeASeq ?? 0) < (probeBSeq ?? 0) && aProbe?.tenant_id === 'tenant-a' && aProbe.subject_id === 'probe-a', 'readEvents(kind, limit) 先按 tenant 过滤再截断:tenant-b 较新事件不抢 tenant-a limit=1')
+
+const foldFixtureRoot = mkdtempSync(join(tmpdir(), 'gotry-tenant-fold-fixture-'))
+const foldA = ensureLedger(foldFixtureRoot, 'tenant-a')
+const foldB = ensureLedger(foldFixtureRoot, 'tenant-b')
+const sameFoldId = 'w-fold-same-id'
+const foldWishA = { wish_id: sameFoldId, name: '同主键反例', reason: 'A-fixed-reason', conditions: { owner: 'A-fixed', days: 5 }, added_at: '2026-09-08T00:00:00.000Z' }
+const foldWishB = { wish_id: sameFoldId, name: '同主键反例', reason: 'B-fixed-reason', conditions: { owner: 'B-fixed', days: 9 }, added_at: '2026-09-08T00:00:01.000Z' }
+const foldInsert = foldA.db.prepare(`INSERT INTO events (tenant_id, ts, actor, kind, subject_id, payload, idem_key, run_id) VALUES (?, ?, 'test:fold-fixture', ?, ?, ?, ?, NULL)`)
+foldInsert.run('tenant-a', '2026-09-08T00:00:00.000Z', 'wish.added', sameFoldId, JSON.stringify({ wish: foldWishA }), 'fold:a:add')
+foldInsert.run('tenant-b', '2026-09-08T00:00:01.000Z', 'wish.added', sameFoldId, JSON.stringify({ wish: foldWishB }), 'fold:b:add')
+foldInsert.run('tenant-b', '2026-09-08T00:00:02.000Z', 'wish.updated', sameFoldId, JSON.stringify({ wish_id: sameFoldId, patch: { muted: true } }), 'fold:b:muted')
+const fixtureEvents = foldA.db.prepare('SELECT tenant_id, kind, subject_id FROM events WHERE subject_id = ? ORDER BY seq').all(sameFoldId) as Array<{ tenant_id: string; kind: string; subject_id: string }>
+assert(fixtureEvents.map(e => `${e.tenant_id}:${e.kind}`).join(',') === 'tenant-a:wish.added,tenant-b:wish.added,tenant-b:wish.updated', '确定性 fold fixture:同 wish_id 的 A/B events 拥有固定且正确 tenant 归属')
+foldA.rebuildProjections()
+const foldABefore = JSON.stringify(foldA.readWishPool()[0])
+foldB.rebuildProjections()
+const foldAAfter = foldA.readWishPool()[0] as typeof foldWishA & { muted?: boolean }
+const foldBAfter = foldB.readWishPool()[0] as typeof foldWishB & { muted?: boolean }
+const unscopedFoldRow = foldB.db.prepare(`SELECT doc FROM projection_items WHERE subject = 'wish_pool' AND item_id = ?`).get(sameFoldId) as { doc: string } | undefined
+const unscopedFoldDoc = unscopedFoldRow ? JSON.parse(unscopedFoldRow.doc) as typeof foldWishA : null
+assert(JSON.stringify(foldAAfter) === foldABefore, '精确 fold 反例:A rebuild 后字段固定,B rebuild 不改变 A 投影')
+assert(
+  foldBAfter?.reason === 'B-fixed-reason'
+  && foldBAfter.conditions.owner === 'B-fixed'
+  && foldBAfter.conditions.days === 9
+  && foldBAfter.added_at === '2026-09-08T00:00:01.000Z'
+  && foldBAfter.muted === true,
+  '精确 fold 反例:B 仅 patch muted=true 后仍保留 B 的 reason/conditions/added_at',
+)
+assert(unscopedFoldDoc?.reason === 'A-fixed-reason', '负向控制:若 wish.updated fold 去掉 tenant 条件,该 fixture 会稳定先读 A 行并把 B 变成 A')
+
+const workflowRoot = mkdtempSync(join(tmpdir(), 'gotry-tenant-workflow-'))
+const wfA = ensureLedger(workflowRoot, 'tenant-a')
+const wfB = ensureLedger(workflowRoot, 'tenant-b')
+wfA.createWorkflowRun({ id: 'wf-same', goal: 'tenant-a-goal', ticket: { tenant: 'A' }, state: { tenant: 'A' } })
+wfB.createWorkflowRun({ id: 'wf-same', goal: 'tenant-b-goal', ticket: { tenant: 'B' }, state: { tenant: 'B' } })
+wfB.markStepIntent('wf-same', 'step-1')
+wfB.markStepDone('wf-same', 'step-1', { ok: true })
+wfB.settleWorkflowRun('wf-same', 'tenant-b deliverable', { schema: 'test', status: 'succeeded' })
+const workflowRows = wfA.db.prepare('SELECT tenant_id, goal, status, deliverable FROM workflow_runs WHERE id = ? ORDER BY tenant_id').all('wf-same') as Array<{ tenant_id: string; goal: string; status: string; deliverable: string | null }>
+assert(
+  wfA.getWorkflowRun('wf-same')?.status === 'pending'
+  && wfB.getWorkflowRun('wf-same')?.status === 'settled'
+  && workflowRows.map(r => `${r.tenant_id}:${r.goal}:${r.status}:${r.deliverable ?? ''}`).join('|') === 'tenant-a:tenant-a-goal:pending:|tenant-b:tenant-b-goal:settled:tenant-b deliverable',
+  '非 local workflow_runs 同 id 行按 tenant 绑定,tenant-b settle 不改 tenant-a pending',
+)
+assert(wfA.getWorkflowStep('wf-same', 'step-1') === undefined && wfB.getWorkflowStep('wf-same', 'step-1')?.status === 'done', '非 local workflow_steps 行按 tenant 绑定')
+const wfBAsyncEvents = wfB.readEvents(undefined, 20).filter(e => e.kind.startsWith('async.'))
+assert(wfBAsyncEvents.some(e => e.kind === 'async.settled') && wfBAsyncEvents.every(e => e.tenant_id === 'tenant-b'), '非 local workflow 审计事件 owner 不回落 local且含 settled 终态')
+
+const forgetRoot = mkdtempSync(join(tmpdir(), 'gotry-tenant-forget-'))
+const forgetA = ensureLedger(forgetRoot, 'tenant-a')
+const forgetB = ensureLedger(forgetRoot, 'tenant-b')
+const forgetAId = forgetA.appendWish({ name: '同 id 可忘愿望', reason: 'keep-A', conditions: { owner: 'A' } }).wish_id
+const forgetBId = forgetB.appendWish({ name: '同 id 可忘愿望', reason: 'drop-B', conditions: { owner: 'B' } }).wish_id
+forgetB.forgetSubject([{ kinds: ['wish.added', 'wish.updated', 'memory_utility.event'], subjectId: forgetBId }])
+const forgetRows = forgetA.db.prepare('SELECT tenant_id, COUNT(*) AS n FROM events WHERE subject_id = ? GROUP BY tenant_id ORDER BY tenant_id').all(forgetAId) as Array<{ tenant_id: string; n: number }>
+assert(forgetAId === forgetBId && forgetA.readWishPool().length === 1 && forgetB.readWishPool().length === 0, '非 local forget 只删目标 tenant 投影,A 同 id 愿望不受影响')
+assert(forgetRows.map(r => `${r.tenant_id}:${r.n}`).join(',') === 'tenant-a:1' && forgetB.readEvents('forget.executed', 1)[0]?.tenant_id === 'tenant-b', '非 local forget 事件删除范围与审计事件 owner 均按 tenant 绑定')
+
 // ---- 收尾 --------------------------------------------------------------------------
 
 rmSync(root, { recursive: true, force: true })
 rmSync(mroot, { recursive: true, force: true })
 rmSync(tenantMroot, { recursive: true, force: true })
+rmSync(tenantMrootProc, { recursive: true, force: true })
 rmSync(v1root, { recursive: true, force: true })
+rmSync(v1rootProc, { recursive: true, force: true })
 rmSync(tenantRoot, { recursive: true, force: true })
+rmSync(foldFixtureRoot, { recursive: true, force: true })
+rmSync(workflowRoot, { recursive: true, force: true })
+rmSync(forgetRoot, { recursive: true, force: true })
 rmSync(wroot, { recursive: true, force: true })
 rmSync(successRoot, { recursive: true, force: true })
 console.log(`\nLEDGER TESTS: ${pass} ok, ${fail} fail`)


### PR DESCRIPTION
## TODO(blocked before ready)

1. #227 Z3 间歇性 WASM/堆损坏仍未由本 PR 消除；本 PR 只能提供当前 SHA 的本地绿证据与精确负向回归证明，不能用一次 full-green 抹掉已观察的间歇 blocker。保持 Draft，待 #227 根因或协调者放行后再转 ready。

## 问题(issue #230)

PR #229 已合入，原始事件归属/readEvents/fold/legacy-v1 迁移修复方向正确；但独立审阅指出现有同 `wish_id` fold 回归由 `appendWish` 生成时 reason/conditions 会随 update patch 覆盖，name/id 又相同，极端情况下只剩 `added_at` 区分，保护 `wish.updated` fold 的 `AND tenant_id = ?` 不够精确。

## 变化

- 在 `ts/scripts/ledger-tests.ts` 增加确定性 fold fixture：
  - 直接写 events，tenant-a / tenant-b 使用同一 `wish_id`，但固定不同 `reason` / `conditions` / `added_at`；
  - 两租户 events 均断言为正确 `tenant_id`；
  - tenant-b 的 `wish.updated` 只 patch `muted=true`；
  - rebuild 后 tenant-b 必须保留 B 的 reason/conditions/added_at 且 muted=true，tenant-a 在 B rebuild 后保持不变；
  - 同时保留负向控制：无 tenant 条件的 projection lookup 会稳定先读 A 行，能解释去掉 `WHERE tenant_id` 时为何必红。
- 补充 #230 要求的周边隔离断言：
  - 非 local 无 DB fallback：不读 legacy JSON、不创建 DB、不触碰 legacy 文件；
  - `readEvents(kind, limit)`：先 tenant 过滤再 limit，tenant-b 较新事件不能抢 tenant-a `limit=1`；
  - legacy JSON 与 v1 DB：跨进程首次以非 local 打开时仍只迁入/重建 local；
  - workflow：同 run id 的 `workflow_runs` / `workflow_steps` 与 `async.*` 审计事件按 tenant 绑定；
  - forget：非 local `forgetSubject` 只删目标租户事件与投影，审计事件 owner 为目标 tenant；
  - booking saga：同 idem_key 的 `pending_writes` 行按 tenant 绑定，tenant-b 不覆盖 local。

## 验证(最终 SHA 50f096afe7595274c4c10506e9c42667257b7fa1, Node 24.20.0)

- `cd ts && npx tsc --noEmit` → exit 0
- `cd ts && npx tsx scripts/ledger-tests.ts` → `LEDGER TESTS: 84 ok, 0 fail`, exit 0
- `cd ts && npx tsx scripts/booking-saga-tests.ts` → `BOOKING SAGA TESTS: 27 ok, 0 fail`, exit 0
- 负向变体：在最终测试内容上临时去掉 `state-ledger.ts` 的 `wish.updated` fold lookup 中 `AND tenant_id = ?`，运行 `cd ts && npx tsx scripts/ledger-tests.ts` → `LEDGER TESTS: 80 ok, 4 fail`, exit 1；包含精确 fold 反例失败：`B 仅 patch muted=true 后仍保留 B 的 reason/conditions/added_at`。
- `GOTRY_SESSION_LIVE=0 ./scripts/run-all-tests.sh` → `ALL SUITES GREEN`, exit 0
- E2E:done+evidence：ledger-tests 内含跨进程 legacy JSON/v1 DB 首次非 local 迁移、跨进程 tenant reopen、durable async 子进程恢复；所有写路径使用 tmpdir/隔离 stateRoot。
- Live/N/A：本 PR 只补离线账本回归，不调用 session/live/LLM；`GOTRY_SESSION_LIVE=0`。

## 边界

- 只改测试文件，不改 M4 scorer，不实现 B2B 插件，不启封 M5 写路径。
- 不审计个人真实数据；只能陈述产品写入口默认 `local` 与本地测试隔离，不能声称历史/生产数据实际无污染。
- 基于最新 `origin/main` merge SHA `2626167a0617c12dacb145307c3db2a566b1ffe8` 新建分支；不推旧已合入 PR #229 分支，不回滚远端。

Refs #224
Refs #227
Closes #230
