### PR TITLE
fix(state-cli): 拒绝无整数部分的小数 rebuild 序号

### DIFF
--- a/ts/scripts/state-cli-tests.ts
+++ b/ts/scripts/state-cli-tests.ts
@@ -196,6 +196,8 @@ const strictCases: Array<{ name: string; args: string[]; pattern: RegExp }> = [
   { name: '非 log 的 limit', args: ['stats', parseRoot, '--limit', '3'], pattern: /stats 不支持 --limit/ },
   { name: '单横杠未知选项', args: ['stats', parseRoot, '-x'], pattern: /未知选项 -x/ },
   { name: 'rebuild 小数 seq', args: ['rebuild', '1.5'], pattern: /toSeq 必须是非负整数:1\.5/ },
+  { name: 'rebuild 省略整数位小数 seq', args: ['rebuild', '.5'], pattern: /toSeq 必须是非负整数:\.5/ },
+  { name: 'rebuild 正号省略整数位小数 seq', args: ['rebuild', '+.5'], pattern: /toSeq 必须是非负整数:\+\.5/ },
   { name: 'rebuild 负数 seq', args: ['rebuild', '-1'], pattern: /toSeq 必须是非负整数:-1/ },
   { name: '非法 seq', args: ['rewind', parseRoot, '1.5'], pattern: /seq 必须是非负整数/ },
   { name: '负数 seq', args: ['rewind', parseRoot, '-3'], pattern: /seq 必须是非负整数/ },
@@ -209,9 +211,12 @@ for (const c of strictCases) {
 }
 const numericParent = mkdtempSync(join(tmpdir(), 'gotry-cli-numeric-parent-'))
 const numericRoot = join(numericParent, '1.5')
+const dotNumericRoot = join(numericParent, '.5')
 const numericMig = cli(['migrate', '--state-root', numericRoot])
 const numericRebuild = cli(['rebuild', '--state-root', numericRoot, '1'])
-assert(numericMig.status === 0 && numericRebuild.status === 0, '数字样式 root 通过 --state-root 明示仍可用')
+const dotNumericMig = cli(['migrate', '--state-root', dotNumericRoot])
+const dotNumericRebuild = cli(['rebuild', '--state-root', dotNumericRoot, '1'])
+assert(numericMig.status === 0 && numericRebuild.status === 0 && dotNumericMig.status === 0 && dotNumericRebuild.status === 0, '数字/小数样式 root 通过 --state-root 明示仍可用')
 
 // local-only:非 local 的 tick/export/whatif 必须在 mkdir/openDb/solve/写文件前拒绝。
 const guardRoot = mkdtempSync(join(tmpdir(), 'gotry-cli-guard-'))

--- a/ts/scripts/state-cli.ts
+++ b/ts/scripts/state-cli.ts
@@ -112,7 +112,7 @@ function parseSequence(raw: string, label: string): number {
 }
 
 function looksLikeNumeric(raw: string): boolean {
-  return /^[+-]?\d/.test(raw)
+  return /^[+-]?(?:\d|\.\d)/.test(raw)
 }
 
 function rootAndArgs(cmd: string, positional: string[], explicitRoot?: string): { root: string; args: string[] } {


### PR DESCRIPTION
TODO

1. #227 的间歇 Z3 故障尚未排除。
2. #242 的主干地图插件加载回归使全栈失败；基础修复后需在新的最终 SHA 重验。

`rebuild .5` 和 `rebuild +.5` 曾被当成状态目录。现在它们在参数解析阶段按非法序号拒绝；显式 `--state-root <目录/.5>` 仍保留目录语义。仅修改 state-cli 及对应行为回归。Fixes #241。

验证绑定 `606d1d2728e5beddcae1f7d72d109ddbc6794e03`，Node 24.20.0：

- `cd ts && npx tsx scripts/state-cli-tests.ts`：49/49，exit 0；独立审阅环境复验通过。
- `cd ts && npx tsc --noEmit`：exit 0；独立复验通过。
- `GOTRY_SESSION_LIVE=0 ./scripts/run-all-tests.sh`：exit 1，保留 #242 的地图插件和 planner E2E 失败。

E2E：真实 CLI 子进程验证非法小数在 IO 前拒绝、隔离目录保持不变、显式小数样式目录可迁移/重建；现有 local tick 与 tenant 参数正负路径同时通过。
