### PR TITLE
fix(deps): update qs to 6.16.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4068,8 +4068,8 @@ packages:
     resolution: {integrity: sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==}
     engines: {node: '>=22.12.0'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -7711,7 +7711,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -7899,7 +7899,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -8292,7 +8292,7 @@ snapshots:
       - utf-8-validate
       - yauzl
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/ts/dsh-runtime/pnpm-lock.yaml
+++ b/ts/dsh-runtime/pnpm-lock.yaml
@@ -9353,8 +9353,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -11059,7 +11059,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -11347,7 +11347,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -12240,7 +12240,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1


### PR DESCRIPTION
## 概述

将传递依赖 `qs` 由 6.15.3 升级到 6.16.0，修复 Dependabot 报告的 4 条告警。本 PR 为纯传递锁安全修复，不改产品 / 里程碑 / 债务状态。

## 告警与修复范围

- 4 条告警对应两个 GHSA：
  - GHSA-4mjr-xmp4-gh2g
  - GHSA-x5fp-wj9c-mxmx
- 两份 pnpm lock 均将 `qs` 由 6.15.3 → 6.16.0（根锁与 vendored dsh 锁）。

## 依赖链（transitive）

`@deepseek-ai/dsh-* -> @modelcontextprotocol/sdk@1.30.0 -> express@5.2.1/body-parser@2.3.0 -> qs`

## 锁迁移策略

- 常规 `pnpm` resolver 会导致约 13k 行无关漂移。
- 受控迁移：以 pnpm 生成的根锁 canonical record/integrity 为唯一源。
- dsh 精确变更：5 删 5 增。
- 参考：https://github.com/pnpm/pnpm/issues/9519

## architecture §11

N/A — 纯传递锁安全修复，不改产品 / 里程碑 / 债务状态。

## 证据（SHA 0c92f43）

- root frozen install — exit 0
- root + dsh audit — exit 0，No known vulnerabilities
- dsh fetch frozen — exit 0（497 entries）
- Node24 tsc — exit 0
- smoke — exit 0，SMOKE OK
- 总架构师同 SHA detached worktree full suite — exit 0
- 两个 qs6.16 PoC — exit 0：
  - `isBuffer` 非函数不再 TypeError
  - bracket-key comma arrayLimit 正确抛 RangeError

## 已知基线债务（非本 PR 引入）

dsh full frozen install 在 parent `293bbb6` 与 candidate `0c92f43` 都因既有 `vendor/dsh-map-tools` importer 缺 7 个 specifiers 而 `ERR_PNPM_OUTDATED_LOCKFILE`。该问题在父提交即已存在，不是本 PR 引入，单独 issue 跟踪。

## 关联 issue

#252 — https://github.com/Danceiny/gotry/issues/252（仅跟踪基线锁债务；本安全 PR 不混入该修复）
