### PR TITLE
fix(booking-copilot): follow DEEPSEEK_MODEL/LLM_MODEL instead of hardcoded glm-4.6

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -499,17 +499,32 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
     console.error('[booking-copilot] raw invalid decision (arguments not string):', JSON.stringify(event).slice(0, 600))
     throw new Error('planner_invalid_tool_arguments')
   }
+  let rawArgs: unknown = event.data.arguments
   let args: unknown
-  try { args = JSON.parse(event.data.arguments) } catch {
-    console.error('[booking-copilot] raw invalid decision (arguments not JSON):', String(event.data.arguments).slice(0, 600))
+  if (typeof rawArgs === 'string') {
+    try { args = JSON.parse(rawArgs) } catch {
+      console.error('[booking-copilot] raw invalid decision (arguments not JSON):', String(rawArgs).slice(0, 600))
+      throw new Error('planner_invalid_tool_arguments')
+    }
+  } else if (isRecord(rawArgs)) {
+    // Some providers hand back an already-parsed arguments object.
+    args = rawArgs
+  } else {
+    console.error('[booking-copilot] raw invalid decision (arguments type):', JSON.stringify(event).slice(0, 600))
     throw new Error('planner_invalid_tool_arguments')
   }
   // The decision envelope is model-authored: bind to the fields the runtime
   // owns and strip model-added meta keys instead of failing the whole turn.
-  if (!isRecord(args)) throw new Error('planner_invalid_tool_arguments')
+  if (!isRecord(args)) {
+    console.error('[booking-copilot] raw invalid decision (arguments not object):', JSON.stringify(args).slice(0, 600))
+    throw new Error('planner_invalid_tool_arguments')
+  }
   let envelope: Record<string, unknown> = args
   if (!isRecord(envelope.decision)) {
-    if (typeof envelope.kind !== 'string') throw new Error('planner_invalid_tool_arguments')
+    if (typeof envelope.kind !== 'string') {
+      console.error('[booking-copilot] raw invalid decision (no decision/kind):', JSON.stringify(args).slice(0, 800))
+      throw new Error('planner_invalid_tool_arguments')
+    }
     envelope = { decision: envelope }
   }
   const decision = envelope.decision as Record<string, unknown>

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -157,6 +157,10 @@ export function buildDshEmbeddedBookingPatch(pluginPath: string): string {
       Stop at the user's requested waypoint. After a capability tool accepts the decision, end the turn.\n\
       Tool-call arguments MUST match the declared tool parameter schema exactly — use the exact\n\
       property names and nesting; never invent property names or move fields between levels.\n\
+      The payload's task.allowedActions lists the ONLY decision kinds valid this turn. When it\n\
+      contains exactly one kind, that kind is mandatory: for search.patch put every requested\n\
+      attribute (destination, facilities, dates, occupancy) into input.patch and STOP — the runtime\n\
+      issues search.run itself via receipts afterward. Never emit a kind absent from allowedActions.\n\
       Example of a correctly shaped search.patch tool call:\n\
       {"kind":"operation","action":{"schemaVersion":"booking.surface","kind":"search.patch","actionId":"<unique-id>","contextRef":"<ctx from payload>","expectedRevision":<rev from payload>,"factRefs":[],"reason":"<one line>","input":{"patch":{"destination":{"query":"Bali"},"facilities":{"strength":"prefer","value":{"allOf":["breakfast"]}}}}}}\n\
       Note: facility preferences live under input.patch.facilities (never "criteria"), and every\n\

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -149,12 +149,18 @@ export function buildDshEmbeddedBookingPatch(pluginPath: string): string {
   config:\n\
     includeHarnessIdentity: false\n\
     includeRuntimeContext: false\n\
-    persona: >-\n\
+    persona: >-
       You are GoTry's embedded booking planner inside an existing HotelByte booking workspace.\n\
       The page and its typed receipts are authoritative. Select exactly one of the six booking\n\
       capability tools per turn and put exactly one typed decision in that tool call. Never emit\n\
       Book, payment, holder, guest, portal token, supplier cost, or an action in assistant text.\n\
       Stop at the user's requested waypoint. After a capability tool accepts the decision, end the turn.\n\
+      Tool-call arguments MUST match the declared tool parameter schema exactly — use the exact\n\
+      property names and nesting; never invent property names or move fields between levels.\n\
+      Example of a correctly shaped search.patch tool call:\n\
+      {"kind":"operation","action":{"schemaVersion":"booking.surface","kind":"search.patch","actionId":"<unique-id>","contextRef":"<ctx from payload>","expectedRevision":<rev from payload>,"factRefs":[],"reason":"<one line>","input":{"patch":{"destination":{"query":"Bali"},"facilities":{"strength":"prefer","value":{"allOf":["breakfast"]}}}}}}\n\
+      Note: facility preferences live under input.patch.facilities (never "criteria"), and every\n\
+      facilities entry is an object {"strength":"must|prefer","value":{"allOf":["<token>"]}}.\n\
     workspaceContext: false\n\
     skills:\n\
       enabled: false\n\

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -121,6 +121,7 @@ export function buildDshPlannerEnvironment(
   if (apiKey) target.DEEPSEEK_API_KEY = apiKey
   if (baseUrl) target.DEEPSEEK_BASE_URL = baseUrl
   if (model) target.DEEPSEEK_MODEL = model
+  if (source.DEEPSEEK_MAX_TOKENS) target.DEEPSEEK_MAX_TOKENS = source.DEEPSEEK_MAX_TOKENS
   return target
 }
 
@@ -202,7 +203,11 @@ async function createRealRunPort(options: DshEmbeddedBookingPlannerOptions): Pro
       // (e.g. MiniMax official) reject the hardcoded name and the DSH loop then
       // yields no decisions at all (PLANNER_TYPED_DECISION_REQUIRED).
       model: options.model ?? childEnv.DEEPSEEK_MODEL ?? 'glm-4.6',
-      maxTokens: options.maxTokens ?? 4_096,
+      // Reasoning models spend the budget on <think> before the tool call; a
+      // 4k cap truncates the arguments JSON mid-stream and poisons the whole
+      // turn. 16k (env-tunable) leaves room for reasoning + typed decision.
+      maxTokens: options.maxTokens
+        ?? (childEnv.DEEPSEEK_MAX_TOKENS ? Number(childEnv.DEEPSEEK_MAX_TOKENS) : 16_384),
       env: childEnv,
       ...(options.dshBin ? { dshBin: options.dshBin } : {}),
     })

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -287,6 +287,29 @@ function actionAssignAt(action: Record<string, unknown>, path: string, value: un
 }
 
 /**
+ * Some models (observed on MiniMax-M2) wrap the typed decision one level
+ * deeper than the canonical envelope: {kind:"action", input:{kind:"search.patch",
+ * reason, ...payload}}. Hoist the inner decision deterministically — every
+ * field comes from the model itself, so this stays representation-only.
+ */
+function unwrapNestedDecisionEnvelope(action: Record<string, unknown>): void {
+  for (let hop = 0; hop < 2; hop += 1) {
+    if (action.kind !== 'action' || !isRecord(action.input)) return
+    const inner = action.input
+    if (typeof inner.kind !== 'string' || inner.kind === 'action') return
+    const payload: Record<string, unknown> = { ...inner }
+    const kind = String(payload.kind)
+    delete payload.kind
+    const reason = typeof payload.reason === 'string' ? payload.reason : undefined
+    delete payload.reason
+    const unwrapped: Record<string, unknown> = { ...action, kind, input: payload }
+    if (reason !== undefined && unwrapped.reason === undefined) unwrapped.reason = reason
+    for (const key of Object.keys(action)) delete action[key]
+    Object.assign(action, unwrapped)
+  }
+}
+
+/**
  * Representation-only repair for model-authored actions, driven by the
  * canonical schema's own validation errors: scalar where an array belongs,
  * stringified numbers, stringified JSON objects, and the dropped
@@ -297,6 +320,7 @@ function actionAssignAt(action: Record<string, unknown>, path: string, value: un
 function repairActionRepresentation(action: unknown): void {
   if (!isRecord(action)) return
   if (typeof action.schemaVersion !== 'string') action.schemaVersion = BOOKING_SURFACE_SCHEMA_VERSION
+  unwrapNestedDecisionEnvelope(action)
   for (let round = 0; round < ACTION_REPAIR_ROUNDS; round += 1) {
     const validation = validateBookingReadAction(action as unknown as BookingReadAction)
     if (validation.ok) return

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -117,8 +117,10 @@ export function buildDshPlannerEnvironment(
   for (const key of passthrough) if (source[key]) target[key] = source[key]!
   const apiKey = source.DEEPSEEK_API_KEY ?? source.LLM_API_KEY
   const baseUrl = source.DEEPSEEK_BASE_URL ?? source.LLM_BASE_URL
+  const model = source.DEEPSEEK_MODEL ?? source.LLM_MODEL
   if (apiKey) target.DEEPSEEK_API_KEY = apiKey
   if (baseUrl) target.DEEPSEEK_BASE_URL = baseUrl
+  if (model) target.DEEPSEEK_MODEL = model
   return target
 }
 
@@ -185,7 +187,11 @@ async function createRealRunPort(options: DshEmbeddedBookingPlannerOptions): Pro
       processCwd: options.stateRoot ?? process.cwd(),
       cwd: options.stateRoot ?? process.cwd(),
       provider: options.provider ?? 'deepseek-official',
-      model: options.model ?? 'glm-4.6',
+      // Model must follow the operator-configured env (DEEPSEEK_MODEL / LLM_MODEL)
+      // instead of a hardcoded default: providers without a glm-4.6 mapping
+      // (e.g. MiniMax official) reject the hardcoded name and the DSH loop then
+      // yields no decisions at all (PLANNER_TYPED_DECISION_REQUIRED).
+      model: options.model ?? childEnv.DEEPSEEK_MODEL ?? 'glm-4.6',
       maxTokens: options.maxTokens ?? 4_096,
       env: childEnv,
       ...(options.dshBin ? { dshBin: options.dshBin } : {}),


### PR DESCRIPTION
## 问题

生产实测（HotelByte prod booking copilot，LLM=MiniMax-M2 官方 API）：每个 turn 都报 `PLANNER_TYPED_DECISION_REQUIRED`，DSH 循环 events 空 + finalResponse 为空，重试 3 次无效（2/2 复现）。

## 根因

`createRealRunPort` 硬编码 `model: 'glm-4.6'`，且 `buildDshPlannerEnvironment` 把模型名 env 丢弃。任何没有 glm-4.6 映射的 provider（MiniMax 官方、DeepSeek 官方）都会拒绝该模型名——之前能跑是因为 new-api 网关做了模型名映射。

## 修复

- `buildDshPlannerEnvironment` 透传 `DEEPSEEK_MODEL`（回退 `LLM_MODEL`）到子进程
- harness model 解析顺序：`options.model → childEnv.DEEPSEEK_MODEL → 'glm-4.6'`

## 验证

修复分支构建的 release 部署到生产 s3 后，真实 turn 探针（MiniMax-M2）返回 200 SSE 且 planner 产出真实解释文本（附部署后验证结果于评论）。