### PR TITLE
fix(packaging): make vendored payload install-order invariant

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "extension/",
     "ts/package.json",
     "ts/dsh-runtime/vendor/dsh-map-tools",
+    "!ts/dsh-runtime/vendor/dsh-map-tools/node_modules",
     "ts/scripts/map-tools-vendor-package-proof.ts",
     "cordis.gotry-patch.yml",
     "README.md",

--- a/ts/scripts/map-tools-vendor-package-proof.ts
+++ b/ts/scripts/map-tools-vendor-package-proof.ts
@@ -10,9 +10,10 @@
 
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import assert from 'node:assert/strict'
 
@@ -53,6 +54,55 @@ function vendorAggregate(root: string): { count: number; sha256: string } {
     digest.update('\0')
   }
   return { count: files.length, sha256: digest.digest('hex') }
+}
+
+function assertPackagingExcludesNodeModules(): void {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'gotry-pack-excl-'))
+  try {
+    const archiveTar = join(tempRoot, 'head.tar')
+    execFileSync('git', ['archive', '--format=tar', '--output', archiveTar, 'HEAD'], { cwd: repoRoot })
+    const checkoutDir = join(tempRoot, 'checkout')
+    mkdirSync(checkoutDir)
+    execFileSync('tar', ['-xf', archiveTar, '-C', checkoutDir])
+    copyFileSync(join(repoRoot, 'package.json'), join(checkoutDir, 'package.json'))
+
+    const vendorBinDir = join(checkoutDir, 'ts/dsh-runtime/vendor/dsh-map-tools/node_modules/.bin')
+    mkdirSync(vendorBinDir, { recursive: true })
+    for (const name of ['cordis', 'tsc', 'tsserver', 'vitest']) {
+      const binPath = join(vendorBinDir, name)
+      writeFileSync(binPath, '#!/usr/bin/env node\n')
+      chmodSync(binPath, 0o755)
+    }
+
+    const packDir = join(tempRoot, 'pack')
+    mkdirSync(packDir)
+    const packOutput = execFileSync('npm', [
+      'pack', '--ignore-scripts', '--json', '--pack-destination', packDir,
+    ], { cwd: checkoutDir, encoding: 'utf8' })
+    const packInfo = JSON.parse(packOutput) as Array<{ filename: string }>
+    assert.equal(packInfo.length, 1, 'temp npm pack must produce one artifact')
+    const tarball = join(packDir, packInfo[0].filename)
+    assert.ok(existsSync(tarball), `temp packed artifact missing: ${tarball}`)
+
+    const entries = execFileSync('tar', ['-tzf', tarball], { encoding: 'utf8' }).trimEnd().split('\n')
+    const nodeModulesEntries = entries.filter(path =>
+      path.startsWith('package/ts/dsh-runtime/vendor/dsh-map-tools/node_modules'),
+    )
+    assert.equal(
+      nodeModulesEntries.length, 0,
+      `npm pack must exclude vendor node_modules: found ${nodeModulesEntries.join(', ')}`,
+    )
+
+    const extractDir = join(tempRoot, 'extracted')
+    mkdirSync(extractDir)
+    execFileSync('tar', ['-xzf', tarball, '-C', extractDir])
+    const packedVendorRoot = join(extractDir, 'package/ts/dsh-runtime/vendor/dsh-map-tools')
+    const packedAggregate = vendorAggregate(packedVendorRoot)
+    assert.equal(packedAggregate.count, upstreamVendorFileCount, 'packed vendor file count drifted')
+    assert.equal(packedAggregate.sha256, adaptedVendorAggregateSha256, 'packed vendor aggregate drifted')
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
 }
 
 function assertAlpha3LockClosure(): { packages: number; version: string } {
@@ -159,6 +209,7 @@ const cleanInstalledBin = process.env.GOTRY_MAP_TOOLS_E2E_BIN
 const { packageRoot, proofRoot } = prepareProofPackage(cleanInstalledBin)
 
 try {
+  assertPackagingExcludesNodeModules()
   const lockedDsh = assertAlpha3LockClosure()
   const vendorRoot = join(packageRoot, 'ts/dsh-runtime/vendor/dsh-map-tools')
   const requiredFiles = [


### PR DESCRIPTION
## Problem and behavior

A prior `pnpm -C ts/dsh-runtime install` creates four ignored executable shims under the vendored `dsh-map-tools/node_modules/.bin`. Because the root package explicitly includes the vendor directory, those generated files could leak into a later npm tarball, making release contents depend on local install order.

This change adds a scoped `files` exclusion for the vendored `node_modules` tree and extends the existing package proof with an offline install-before-pack regression. The proof materializes tracked source with `git archive`, synthesizes the four pnpm shim paths in a temporary directory, runs real `npm pack --ignore-scripts`, and requires the packed vendor payload to remain the canonical 32 files with aggregate `32a893ff7a51799d2b8b8f246cbf6d094c3f6054e9086c0c8b0cb2da8606ccb1` and zero `vendor/node_modules` entries. Temporary data is removed in `finally`; the existing clean-installed-tarball path remains active.

Closes #257

## Validation

Final commit: `178cfecec483532e7c8031b3344ff314c9fb5608`

- Async ticket sweep: no pending JSON without deliverable, exit 0.
- `git diff origin/main...HEAD --check`: exit 0; changed files are exactly `package.json` and `ts/scripts/map-tools-vendor-package-proof.ts`.
- Node 22.23.2 with the located `/usr/local/bin/pnpm` 11.5.0 command: `CI=true pnpm -C ts/dsh-runtime install --frozen-lockfile --ignore-scripts`, exit 0; installer ended with pnpm v11.5.0.
- Node 24.20.0 with `/usr/local/bin/pnpm` 11.5.0: the same frozen install, exit 0; installer ended with pnpm v11.5.0.
- Clean real pack: 32 vendor files, canonical aggregate above, zero vendor `node_modules` paths.
- After frozen install generated `.bin/{cordis,tsc,tsserver,vitest}`: real pack still has 32 vendor files, the same aggregate, zero vendor `node_modules`; sorted vendor path list is byte-identical to clean pack.
- Mutation proof: temporarily removing the exclusion makes the focused proof exit 1 and reports exactly the four generated shim paths; restoring it makes the proof exit 0.
- Ordinary focused package proof: exit 0, `artifactMode=packed-unpacked-focused`.
- Fresh temporary consumer install plus `GOTRY_MAP_TOOLS_E2E_BIN`: exit 0, `artifactMode=clean-installed-tarball`.
- `cd ts && npx tsc --noEmit`: exit 0.
- `cd ts && npx tsx scripts/smoke.ts`: exit 0 with isolated temporary state root.
- `GOTRY_SESSION_LIVE=0 PATH=/opt/homebrew/opt/node@24/bin:$PATH ./scripts/run-all-tests.sh`: exit 0 on the final SHA; log ends `ALL SUITES GREEN` and §49b reports the canonical 32-file installed tarball.
- Independent scoped review: CLEAR / APPROVE; no correctness, cleanup, recursion, security, or portability finding.

## E2E classification

Packaging and artifact-integrity E2E. The burden of proof is a real `npm pack` before and after install pollution, tar path enumeration, canonical aggregate verification, and a fresh consumer install. This PR does not publish an npm package and makes no release claim.
