### PR TITLE
fix(booking-copilot): bring greedy invented-key pruning, occupancy repair and plugin validation to main

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -422,7 +422,9 @@ function repairActionRepresentation(action: unknown): void {
         const current = actionValueAt(action, pathPart)
         if (typeof current === 'string' && current.trim().startsWith('{')) {
           try { actionAssignAt(action, pathPart, JSON.parse(current)); mutated = true } catch { /* leave for validation */ }
-        } else if (current === undefined || current === null) {
+        } else if (current === undefined || current === null || current === '') {
+          // Empty input is a meaningful shape for zero-argument actions
+          // (e.g. search.run's SearchRunInput: maxProperties 0).
           actionAssignAt(action, pathPart, {})
           mutated = true
         }

--- a/ts/src/booking-surface/dsh-plugin.js
+++ b/ts/src/booking-surface/dsh-plugin.js
@@ -7,7 +7,8 @@
  * the sole executor after the parent adapter validates the canonical action.
  */
 
-import { dshBookingActionSchemaForKind } from './canonical-schema.js'
+import Ajv2020 from 'ajv/dist/2020.js'
+import { canonicalBookingSurfaceSchema, dshBookingActionSchemaForKind } from './canonical-schema.js'
 
 export const name = 'gotry-embedded-booking'
 export const inject = ['tools']
@@ -50,6 +51,12 @@ function toolDefinition(toolName, capabilityId, actionKinds) {
     kind: { type: 'string', const: 'operation' },
     action: { oneOf: actionKinds.map(actionSchema) },
   })
+  const parameters = closedObject({
+    decision: {
+      oneOf: [operationDecision, questionDecision, explanationDecision, terminalDecision, errorDecision],
+    },
+  })
+  const validateArgs = new Ajv2020({ allErrors: true, strict: false }).compile(parameters)
   return Object.freeze({
     name: toolName,
     description: `Emit exactly one typed ${capabilityId} decision for the existing Booking workspace. This capability never books, pays, edits holder/guest data, or calls a supplier.`,
@@ -69,6 +76,15 @@ function toolDefinition(toolName, capabilityId, actionKinds) {
       },
     },
     async execute(args) {
+      // Native self-correction boundary: when the model's tool call violates
+      // the canonical decision schema, throw with the exact Ajv errors. The
+      // dsh agent loop feeds tool failures back to the model as tool results,
+      // so the model repairs its own shape inside the same turn — no schema
+      // knowledge duplicated outside this plugin.
+      if (!validateArgs(args)) {
+        const errors = (validateArgs.errors ?? []).map((e) => `${e.instancePath || '/'}: ${e.message}`).join('; ')
+        throw new Error(`decision_schema_violation: ${errors}`)
+      }
       const decision = args.decision
       return {
         accepted: true,


### PR DESCRIPTION
将已在 UAT 实测验证的三个修复从 fix/booking-copilot-self-repair(3b88560) 合并分支带回 main：①贪心发明键剪枝（schema 拒绝的键确定性删除）；②occupancy 无 adults 项丢弃；③dsh-plugin 原生 Ajv 校验（校验失败由 dsh agent loop 回喂模型自修复）。与 UAT 已部署构建(3b88560)内容一致。