### PR TITLE
test(channels): cover Dida routing order

### DIFF
--- a/ts/scripts/channel-registry-tests.ts
+++ b/ts/scripts/channel-registry-tests.ts
@@ -3,7 +3,8 @@
  * docs/design/tool-orchestration-design.md §2/§3;全离线,隔离 tmp stateRoot):
  *  1. 注册表封闭性:id 唯一/quotaClass·tier·intent 闭集/静态包不可路由
  *  2. 意图顺位:证据级降序(官方API > 会话 > 网页兜底),同 tier 按效率
- *  3. routingAdvice:down 通道被排除/发起通道被排除/limit 截断;hit 即恢复
+ *  3. routingAdvice:down 通道被排除/发起通道被排除/limit 截断;hit 即恢复;
+ *     Dida down 时推进到下一个健康酒店通道
  *  4. noteChannelVerdict 映射:needs-setup→down/hit→清除/miss·error→不动/cooldown 过期
  *  5. persona 路由卡:确定性渲染,含改道规则与意图顺位行
  *  6. JSONL 持久面:record/readLatest 往返 + 坏行容忍 + limitDays 过滤
@@ -54,7 +55,7 @@ console.log('1. 注册表封闭性 OK')
 resetChannelHealth()
 assert.deepEqual(channelsForIntent('search-flight').map(c => c.id), ['flyai', 'session:ctrip-flight', 'web-read'], '机票顺位')
 assert.deepEqual(channelsForIntent('search-train').map(c => c.id), ['flyai', 'session:12306-train', 'web-read'], '火车顺位')
-assert.deepEqual(channelsForIntent('search-hotel').map(c => c.id), ['flyai', 'hbcli-hotel', 'session:ctrip-hotel', 'web-read'], '酒店顺位')
+assert.deepEqual(channelsForIntent('search-hotel').map(c => c.id), ['flyai', 'hbcli-hotel', 'session:ctrip-hotel', 'session:dida-portal', 'web-read'], '酒店完整顺位(Dida 登记后仍钉全序)')
 assert.deepEqual(channelsForIntent('weather').map(c => c.id), ['open-meteo'], '单通道意图')
 console.log('2. 意图顺位(证据级 > 效率)OK')
 
@@ -71,7 +72,17 @@ assert.ok(!excl.alternatives.some(a => a.channel === 'session:ctrip-flight'), '�
 assert.equal(routingAdvice('search-flight', { limit: 1, now: NOW }).alternatives.length, 1, 'limit 截断')
 noteChannelVerdict('flyai', 'hit', { now: NOW })
 assert.equal(routingAdvice('search-flight', { now: NOW }).alternatives[0]!.channel, 'flyai', 'hit 即恢复(#107:补 key 不被陈旧状态锁死)')
-console.log('3. routingAdvice(down 排除/发起排除/limit/hit 恢复)OK')
+
+// Dida 已是酒店 session 通道的一员:#297 后先让更高顺位通道不可用,证明 Dida
+// 成为当前首选；再把 Dida 标 down,必须推进到注册表中的后继 web-read。
+resetChannelHealth()
+for (const channel of ['flyai', 'hbcli-hotel', 'session:ctrip-hotel']) {
+  noteChannelVerdict(channel, 'needs-setup', { now: NOW })
+}
+assert.equal(routingAdvice('search-hotel', { now: NOW }).alternatives[0]!.channel, 'session:dida-portal', '前三个酒店通道 down 后 Dida 升为首荐')
+noteChannelVerdict('session:dida-portal', 'needs-login', { now: NOW })
+assert.equal(routingAdvice('search-hotel', { now: NOW }).alternatives[0]!.channel, 'web-read', 'Dida down 后推进到后继健康酒店通道')
+console.log('3. routingAdvice(down 排除/发起排除/limit/hit 恢复 + Dida down→后继)OK')
 
 // 4. noteChannelVerdict 映射闭集
 resetChannelHealth()

--- a/ts/scripts/smoke.ts
+++ b/ts/scripts/smoke.ts
@@ -27,7 +27,7 @@ async function main() {
   const variables: Record<string, () => string> = {}
   // pre-execute 监听器捕获:账号会话授权闸(RFC 支柱④进代码)在 apply() 里经 ctx.on 挂注册表
   type PreDecision = { kind: 'allow' | 'deny' | 'ask'; reason?: string }
-  const preExecutes: Array<(exec: { name?: string }, next: () => Promise<PreDecision>) => Promise<PreDecision>> = []
+  const preExecutes: Array<(exec: { name?: string; kind?: string }, next: () => Promise<PreDecision>) => Promise<PreDecision>> = []
   const ctx = {
     tools: { register: (t: unknown) => registered.push(t as ToolLike) },
     systemPrompt: { variable: (name: string, provider: () => string) => { variables[name] = provider } },


### PR DESCRIPTION
## TODO before ready

1. Wait for the remaining Node 24 full-regression CI job to finish green.
2. Keep Draft until root makes the final review/merge decision.

## Regression and fix

After Dida joined the hotel channel registry, the focused test still asserted the old complete order and made every unrelated full-suite run fail. This test-only patch keeps the complete ordering assertion and adds the new registered channel:

`flyai -> hbcli-hotel -> session:ctrip-hotel -> session:dida-portal -> web-read`

It also proves the health projection instead of only checking membership: with the three higher-order hotel channels down, Dida becomes the first recommendation; once Dida is marked `needs-login`/down, routing advances to the next healthy channel, `web-read`.

The newly merged #311 smoke cases passed `kind: "flight"` to a fixture whose local type still allowed only `name`. The second file changes only that fixture type to include `kind?: string`; runtime consent logic and assertions are untouched.

Actual Claude Code session `31a08a92-1f5e-44e2-aae6-412298175cba` was assigned first, but its initial turn exhausted 10 retries (503 then 429) with zero model output/edits. One serial resume produced no output or edits and was stopped when supervision was directed to use the authorized native fallback. This two-file mechanical patch is therefore explicitly supervisor-authored, not represented as Claude output.

## Current head evidence

Head: `3e1df78767db7dca7f325384bc546754a55a65f7`  
Base: `491bf0fbe8bacc1c54060ebed12b6ddc90ea8905`

Dependencies were installed independently from both committed locks:

- root `npm ci --ignore-scripts --no-audit --no-fund --strict-peer-deps=true --legacy-peer-deps=false` — exit 0, 576 packages.
- `ts/` same command — exit 0, 575 packages.

Node v24.20.0:

- `cd ts && npx tsx scripts/channel-registry-tests.ts` — exit 0; all 8 sections, including complete hotel order and Dida-down successor.
- `cd ts && npx tsc --noEmit` — exit 0.
- `cd ts && GOTRY_SESSION_LIVE=0 npx tsx scripts/smoke.ts` — exit 0, `SMOKE OK`; live session transport not invoked.
- `git diff --check` — exit 0.
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" GOTRY_SESSION_LIVE=0 bash scripts/run-all-tests.sh` — serial exit 0, `ALL SUITES GREEN`; 2026-09-10 01:27:38–01:35:45 +0400; log 81,551 bytes; SHA-256 `a5349e85c8a902abb32f35b14d0f4da79d1afd5a6e01e3dc5b72bb3a22d2a563`.

This corrects deterministic tests for behavior already on main. It does not prove Dida live login, supplier inventory, milestone entry, or a release.

Fixes #313
