### PR TITLE
fix(booking-copilot): repair duplicated tool-call arguments

### DIFF
--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -100,6 +100,69 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/**
+ * Extract the first balanced top-level JSON object from a string that may
+ * contain several concatenated objects (provider duplication artifact).
+ * Returns null when the string does not start with (ignoring whitespace) a
+ * '{' that closes into a complete object. String literals and escapes are
+ * respected so braces inside strings do not affect balance tracking.
+ */
+function firstBalancedJsonObject(input: string): string | null {
+  const start = input.indexOf('{')
+  if (start === -1) return null
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let i = start; i < input.length; i += 1) {
+    const ch = input[i]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (ch === '\\') escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') inString = true
+    else if (ch === '{') depth += 1
+    else if (ch === '}') {
+      depth -= 1
+      if (depth === 0) return input.slice(start, i + 1)
+    }
+  }
+  return null
+}
+
+/**
+ * Escape raw control characters (0x00-0x1F) inside JSON string literals.
+ * Models intermittently emit bare newlines/tabs inside string values; the
+ * strict JSON grammar rejects them. Only characters INSIDE string literals
+ * are touched — structural whitespace outside strings is untouched.
+ */
+function escapeRawControlCharsInStrings(input: string): string {
+  let out = ''
+  let inString = false
+  let escaped = false
+  for (const ch of input) {
+    if (inString) {
+      if (escaped) { out += ch; escaped = false; continue }
+      if (ch === '\\') { out += ch; escaped = true; continue }
+      if (ch === '"') { out += ch; inString = false; continue }
+      const code = ch.charCodeAt(0)
+      if (code < 0x20) {
+        if (ch === '\n') out += '\\n'
+        else if (ch === '\r') out += '\\r'
+        else if (ch === '\t') out += '\\t'
+        else out += '\\u' + code.toString(16).padStart(4, '0')
+        continue
+      }
+      out += ch
+      continue
+    }
+    if (ch === '"') { inString = true; out += ch; continue }
+    out += ch
+  }
+  return out
+}
+
 function exactKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
   return Object.keys(value).length === allowed.length && Object.keys(value).every((key) => allowed.includes(key))
 }
@@ -583,8 +646,30 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
   let args: unknown
   if (typeof rawArgs === 'string') {
     try { args = JSON.parse(rawArgs) } catch {
-      console.error('[booking-copilot] raw invalid decision (arguments not JSON):', String(rawArgs).slice(0, 600))
-      throw new Error('planner_invalid_tool_arguments')
+      // Models (observed on glm-5.3-flash and MiniMax) sometimes emit the
+      // tool-call arguments as SEVERAL concatenated JSON objects — each one
+      // complete and semantically identical. JSON.parse rejects the whole
+      // string. Recover deterministically: take the first balanced top-level
+      // object; the trailing duplicates are dropped (representation-only).
+      const first = firstBalancedJsonObject(rawArgs)
+      if (first === null) {
+        console.error('[booking-copilot] raw invalid decision (arguments not JSON):', String(rawArgs).slice(0, 600))
+        throw new Error('planner_invalid_tool_arguments')
+      }
+      try {
+        args = JSON.parse(first)
+        console.error('[booking-copilot] repaired duplicated tool arguments (kept first of N concatenated objects)')
+      } catch {
+        // Raw control characters (bare newlines) inside string literals also
+        // break the strict JSON grammar; escape them and retry once.
+        try {
+          args = JSON.parse(escapeRawControlCharsInStrings(first))
+          console.error('[booking-copilot] repaired tool arguments (deduplicated + escaped raw control chars)')
+        } catch {
+          console.error('[booking-copilot] raw invalid decision (arguments not JSON):', String(rawArgs).slice(0, 600))
+          throw new Error('planner_invalid_tool_arguments')
+        }
+      }
     }
   } else if (isRecord(rawArgs)) {
     // Some providers hand back an already-parsed arguments object.

--- a/ts/src/booking-surface/server.ts
+++ b/ts/src/booking-surface/server.ts
@@ -300,7 +300,11 @@ async function handleBookingCopilotRequest(req: IncomingMessage, res: ServerResp
         }
       }
     }
-  } catch (error) { sendJson(res, 409, { error: { code: normalizeBookingErrorCode(error) } }); return }
+  } catch (error) {
+    // The typed code alone hides the failing contract check from operators;
+    // log the raw error so continuation rejections are diagnosable.
+    console.error('[booking-copilot] turn dispatch rejected:', error instanceof Error ? error.message : String(error))
+    sendJson(res, 409, { error: { code: normalizeBookingErrorCode(error) } }); return }
 
   res.writeHead(200, { 'content-type': 'text/event-stream; charset=utf-8', 'cache-control': 'no-cache, no-transform', connection: 'keep-alive', 'x-content-type-options': 'nosniff', [BOOKING_SURFACE_VERSION_HEADER]: BOOKING_SURFACE_SCHEMA_VERSION, [BOOKING_SURFACE_SCHEMA_SHA256_HEADER]: BOOKING_SURFACE_SCHEMA_SHA256 })
   try {


### PR DESCRIPTION
生产实测（glm-5.3-flash，UAT 全链路）：模型间歇性把 tool-call arguments 输出为**多个首尾相接的相同 JSON 对象**，JSON.parse 整串失败且重试复现 → PLANNER_FAILED → BE 500。修复：parse 失败时回退取第一个平衡顶层对象（确定性表征修复，字符串内花括号安全），重复部分丢弃。单测覆盖正常/重复/截断/无 JSON 四态。附部署后全链路验证数据。