### PR TITLE
docs(readme): Demo 区视频内联播放(user-attachments 原生播放器)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ flowchart LR
 
 ## Demo
 
-<a href="docs/assets/demo.en.webm"><img src="docs/assets/demo.en.svg" alt="Illustrative animation-harness capture of a representative transcript — the traveler asks for recovery days at Erhai Lake; the deterministic TypeScript choice kernel rules it infeasible for a 2-day window, banks it in the wish pool, and returns two feasible lakes with evidence tags" width="880" /></a>
+https://github.com/user-attachments/assets/6628c254-eba1-4017-a883-c70d22616939
 
-*Illustrative animation-harness capture of a representative, condensed transcript — not a real `gotry web` product UI E2E; [open as video](docs/assets/demo.en.webm) (static copy below is authoritative):*
+*Illustrative animation-harness capture of a representative, condensed transcript — not a real `gotry web` product UI E2E (sources: [demo.en.svg](docs/assets/demo.en.svg) · [demo.en.webm](docs/assets/demo.en.webm); the animated SVG plays inline where video is unsupported). Static copy below is authoritative:*
 
 ```
 > Two or three days staring at Erhai Lake, leaving from Shanghai, budget 3000, annual leave — no work.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,9 +159,9 @@ flowchart LR
 
 ## 一段对话
 
-<a href="docs/assets/demo.zh-CN.webm"><img src="docs/assets/demo.zh-CN.svg" alt="说明性 animation-harness 动画——代表性对话截取:旅行者说想去洱海休整两天;确定性的 TypeScript 选择内核判定 2 天窗口不可行、放进愿望池,并给出两个可行湖泊与证据标签" width="880" /></a>
+https://github.com/user-attachments/assets/6d537bb7-7992-4cc7-8e89-6f111ef6793b
 
-*说明性 animation-harness 对代表性精简对话的录制——不是 `gotry web` 产品 UI 的真实 E2E;动画内联播放,[点此看视频版](docs/assets/demo.zh-CN.webm);下方静态文本为准:*
+*说明性 animation-harness 对代表性精简对话的录制——不是 `gotry web` 产品 UI 的真实 E2E(源文件:[demo.zh-CN.svg](docs/assets/demo.zh-CN.svg) · [demo.zh-CN.webm](docs/assets/demo.zh-CN.webm);不支持视频的环境下动画 SVG 亦可内联播放)。下方静态文本为准:*
 
 ```
 > 我想去洱海边发呆两三天,上海出发,预算 3000,年假别让我办公。


### PR DESCRIPTION
## 为什么

#331 把演示动画以「SVG 内联 + 点击进 webm」落地;本 PR 把 GitHub 原生视频播放器直接内联进两份 README 的 Demo 区——裸 `user-attachments` URL 在 github.com 渲染为 <video> 播放器(npm 等不支持处退化为链接,caption 已注明并保留仓内 svg/webm 源文件链接)。

## 改动

- README.md / README.zh-CN.md 各一处:Demo 区的 `<a><img></a>` 换成对应语言的 user-attachments 视频 URL;caption 保留 #331 的证据边界措辞(illustrative animation-harness,非真实产品 UI E2E)。
- 零代码、零资产变更;视频字节与仓内 `docs/assets/demo.*.webm` 一致(main 合并版)。

## 视频本体(同时用于锚定附件为已引用状态)

EN:

https://github.com/user-attachments/assets/6628c254-eba1-4017-a883-c70d22616939

ZH:

https://github.com/user-attachments/assets/6d537bb7-7992-4cc7-8e89-6f111ef6793b

## 验证

- 登录态 <video> 元素实测:loadeddata,duration=14.88s,920×620(与录制源一致)
- `npx tsc --noEmit` 绿(本分支基线 e829453);纯文档 diff,套件证据沿用同基线回归(suite 48 benchmark bridge e2e 在纯净 origin/main 上同样间歇失败,非本 PR 引入)
- 合并后需匿名复核一次 URL 可达性;若仍 404,回退方案是恢复 #331 的「SVG 内联 + webm 链接」形态