### PR TITLE
docs(readme): 二轮精简——Tools 拆 docs/tools.md,QS/Consent/Status 压成摘要

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,45 +106,9 @@ Architecture, five layers:
 
 ## Tools
 
-The GoTry plugin exposes its tools in groups:
+The plugin's 23 registered tools come in groups: **realtime retrieval** (Fliggy official channel + your own Chrome session, physically read-only) · **inventory & catalog** · the **deterministic decision engine** (`gotry_feasibility_check`; explicit flight chains via Z3) · **memory & reachability** · **artifacts** · async work-order status · the **fact gate** · **general external** search · **`gotry_doctor` self-check**.
 
-| Group | Tool | What it does |
-|---|---|---|
-| **Realtime retrieval (OTA/official, read-only)** | `gotry_flyai_search` | Live flight/train/hotel quotes via the Fliggy official channel (masked hotel prices upstream; exhausted anonymous trial quota degrades as `needs-setup` with key guidance, never silent retries) |
-| | `gotry_session_search` | Ctrip flights **and hotels** + 12306 trains + Dida supplier-portal hotel rates on the **user's own Chrome session** (consent-gated, physically read-only; `kind` = flight/hotel/train; unknown kinds fail closed) |
-| | `gotry_session_login` | Login bootstrap: auto-detects existing login first; otherwise opens the login entry in the user's Chrome (**zero terminal**) |
-| | `gotry_weather_check` | Open-Meteo forecast ≤16 d + historical climate baseline |
-| | `gotry_flight_verify` | OpenSky ADS-B live flight observation (three-valued) |
-| | `gotry_skeleton_check` | OpenFlights 168-hub-pair connectivity (three-valued) |
-| **Inventory & catalog** | `gotry_hotel_search` | hotel-byte realtime bridge (asks for missing check-in/check-out dates), with clearly labeled static results when the supplier is unavailable |
-| | `gotry_anything_search` | mixed city/hotel/POI catalog (hotel-be Anything) |
-| **Decision engine** | `gotry_feasibility_check` | Registered path: deterministic TypeScript candidate enumeration/evaluation and per-candidate verdicts |
-| **Memory & reachability** | `gotry_motivation_save` | Persist motivation profile (evidence mandatory, anti-fabrication) |
-| | `gotry_wish_pool_add` / `gotry_wish_pool_list` | "next departure" wish pool + 0..1 conditional recall |
-| | `gotry_companion_save` · `gotry_trip_log` | companion profile / travel timeline |
-| **Artifacts** | `gotry_artifacts_list` / `gotry_artifacts_read` | Discover & read generated artifacts (async deliverables + working-dir markdown) as a read-only, line-numbered view scoped to `stateRoot` + the session working dir; >2 MB / out-of-root / unsupported extension → `ok: false` + `hint`. See [user guide](docs/user-guide.md) |
-| **Factuality gate** | `gotry_fact_gate` | Pre-delivery gate for itinerary artifacts — see [fact gate](#how-it-works) above |
-| **General external** | `gotry_web_search` · `gotry_video_subtitle` · `gotry_github_search` · `gotry_agent_reach` | web / subtitles / GitHub / all-channel external info (via Agent-Reach) |
-| **Self-check** | `gotry_doctor` | Read-only health check by default; explicit `action: "repair"` shows a scoped plan, requests approval, runs the same idempotent installers as `doctor --fix` / web onboarding, then rechecks before reporting. Browser-store installs, credentials, and Node upgrades stay user actions. Report lands in `gotry-state/doctor-report.md` |
-
-> **Channel routing**: retrieval tools stay flat (no hidden dispatch); the persona routing card and the `routing` suggestions attached to failed search results come from one channel registry (official API > user session > web fallback, filtered by per-session channel health) that returns an **ordered suggestion list** — the model or user chooses the next tool; the registry itself never dispatches, executes, or falls back.
-
-```mermaid
-flowchart LR
-  I["Intent + failed channel"] --> R["channel registry<br/>routingAdvice()"]
-  R -->|"ordered alternatives[]<br/>tier / efficiency / health filtered"| A["routing suggestions<br/>tool · channel · why"]
-  A --> M{"Model or user<br/>chooses next tool"}
-  M --> F["gotry_flyai_search"]
-  M --> C["gotry_session_search"]
-  M --> W["gotry_web_search · Agent-Reach"]
-  R -.-> N["Registry does not dispatch,<br/>execute, or fall back"]
-  classDef api fill:#2ea04322,stroke:#2ea043,color:#2ea043;
-  classDef sess fill:#1f6feb22,stroke:#1f6feb,color:#1f6feb;
-  classDef web fill:#6e768122,stroke:#6e7681,color:#6e7681;
-  class F api;
-  class C sess;
-  class W web;
-```
+Retrieval tools stay flat — no hidden dispatch: a channel registry returns an **ordered suggestion list** (official API > user session > web fallback, filtered by per-session channel health), and the model or user chooses the next tool. Per-tool contracts, the routing diagram, web onboarding behavior, and the operator script surface: [`docs/tools.md`](docs/tools.md) (Chinese-first).
 
 ## Demo
 
@@ -205,13 +169,9 @@ npx @danceiny/gotry web
 | Headless one-shot | `npx @danceiny/gotry "Two recovery days from Shenzhen, budget 3000"` | scripts / CI / targeted debugging → stdout |
 | Dependency doctor | `npx @danceiny/gotry doctor` (`--fix` to repair) | optional channels misbehaving: checks extension / Agent-Reach / hbcli / FlyAI key / sidebar / calendar / map tools, prints exact repair guidance, writes `gotry-state/doctor-report.md` |
 
-Requires Node ≥ 22.15. LLM credentials are managed by your dsh host UI — gotry itself never asks for or echoes them; OpenAI-compatible endpoints (MiniMax / relays / self-hosted gateways) are handled by the dsh model configuration. First cold start takes 6–15 s; if port `:3080` is taken, free it first; unexpected exits leave evidence in `gotry-state/incidents.jsonl` (nothing silent).
+Requires Node ≥ 22.15. LLM credentials are managed by your dsh host UI — gotry itself never asks for or echoes them; OpenAI-compatible endpoints (MiniMax / relays / self-hosted gateways) are handled by the dsh model configuration. First cold start takes 6–15 s; if port `:3080` is taken, free it first; unexpected exits leave evidence in `gotry-state/incidents.jsonl`.
 
-> **Registries & where you run it** — any npm-compatible registry (npmjs, npmmirror, an internal mirror) works as long as the package is synced there; if a mirror's `latest` lags behind, pin an exact version, e.g. `npx @danceiny/gotry@0.0.1-rc.22 web`. One exception: **inside the gotry repo** (or any project whose package.json is named `@danceiny/gotry`), bare-name `npx @danceiny/gotry …` fails with `sh: gotry: command not found` — use the source entry `./gotry web` instead.
-
-> **Per-launch onboarding (`gotry web`, issues #258/#267)** — an eligible interactive launch offers an optional-capability check at most once: `y` runs the same idempotent installers as `doctor --fix` and reports each gap as `installed` / `needs-user-action` / `unavailable` with a concrete reason; `n` skips straight to web. CI, benchmark, non-TTY, `GOTRY_SETUP_SKIP=1`, and `GOTRY_ONBOARDING_SKIP=1` never prompt and never install; nothing installs during `postinstall` or in a detached background task. This is a deterministic M4 UX proof — it does not satisfy #20 real repeat-cohort evidence.
-
-> **Operator scripts (repo-side, read-only)** — nightly cost accounting has a single source of truth in `ts/data/llm-price-table.json` (PR-only changes; unknown models fail closed; `price-drift-watch.ts` reports drift, never auto-applies); `build-metrics-report.ts` aggregates fact-gate/channel/incident sidecars into one markdown report; `channel-probe.ts` runs cron-driven read-only channel probes whose `down`/recovery events feed routing advice, doctor, and wish recall.
+> **Where you run it** — any npm-compatible registry works as long as the package is synced (pin an exact version if a mirror's `latest` lags). Inside the gotry repo itself, bare-name `npx @danceiny/gotry …` fails with `sh: gotry: command not found` — use the source entry `./gotry web`. An eligible interactive launch may offer a one-time optional-capability check (`y` runs the same installers as `doctor --fix`, `n` skips; CI / non-TTY never prompt, never install). Onboarding details and the repo-side operator scripts (cost table / metrics report / channel probe): [`docs/tools.md`](docs/tools.md).
 
 ### Developer source install
 
@@ -228,12 +188,12 @@ The source entry and the npm package resolve the same 230-package DeepSeek Harne
 
 The account-session channel reads realtime hotel/flight data from **your own logged-in Chrome**, under four hard rules:
 
-1. **Login happens on the external website.** GoTry never offers, fills, or collects any password / SMS code / cookie value. It only answers one boolean question — "does a login-ticket cookie exist" (reads cookie **names** only, zero values touched). Existing logins are auto-detected with zero popups.
-2. **Consent card, once per session.** The first account-session use pops a runtime approval card; approval holds for the session, a refusal revokes it (no repeat prompting). Master switch `sessionAccess: ask|allow|off` at any time.
-3. **Physically read-only.** A ReadGuard aborts all write requests at the network layer — ordering/payment is unreachable in transport. The agent never touches credentials or captchas; on a captcha it stops and hands control back to you.
-4. **Never hijacks your browser.** Retrieval/login always open their own dedicated tab; the login page is brought to front and stays with you; routine test runs never open browser windows.
+1. **Login happens on the external website** — GoTry never offers, fills, or collects any password / SMS code / cookie value; it answers one boolean question — "does a login-ticket cookie exist" (cookie **names** only).
+2. **Consent card, once per session** — approval holds for the session, refusal revokes it; master switch `sessionAccess: ask|allow|off` at any time.
+3. **Physically read-only** — a ReadGuard aborts all write requests at the network layer; a captcha stops the agent and hands control back to you.
+4. **Never hijacks your browser** — retrieval/login open their own dedicated tab; routine test runs never open browser windows.
 
-One-time prerequisite: the [GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) Chrome extension — one-click on the Chrome Web Store, auto-updates, no setup wizard, no unpacked loading. When an account-session tool first needs it, the dsh host UI surfaces the store URL as a clickable link; until installed, tools return `needs-extension` with that URL and spend nothing. The extension passively forwards the site's own search responses — read-only by construction; cookie values never leave the browser.
+One-time prerequisite: the [GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) Chrome extension (one-click, auto-updates, no setup wizard) — until installed, tools return `needs-extension` with the store link and spend nothing.
 
 ## Trustworthy by Construction
 
@@ -252,28 +212,22 @@ Current release: **v0.0.1-rc.22** (npm `latest`; the `rc` dist-tag points at rc.
 
 **Working today**:
 
-- **Deterministic choice kernel** — ordinary candidate enumeration, `evaluateChoice`, true-cost checks, per-candidate verdicts, and recommendation
-- **Explicit flight-chain Z3 path** — `solveUnified` handles the separate multi-leg constraint path; solver calls are gated by a single shared Context, serialized sessions, and the #227 local native-cleanup barrier
-- **Bounded ground-transfer slice (#341)** — explicit origin/destination coordinates with `mode=driving` delegate through the registered `map_driving_route` tool; only an exact static `taxi` transfer may receive route-estimated minutes (its static price stays `[static-pack:estimate]`); live traffic, transit/rail, and fares remain outside this slice
-- **Realtime retrieval** — flights/trains/hotels (Fliggy official channel), destination/hotel catalogs, weather, live flight observation, route connectivity; realtime prices can overwrite solver prices (`GOTRY_REALTIME_PRICING=1`); exhausted FlyAI anonymous trial quota is classified `needs-setup` with key guidance (no blind retries)
-- **Account-session search** — Ctrip flights **and hotels** + 12306 trains + Dida supplier-portal hotel rates on your own Chrome (hotels: real logged-in prices via passive sniffing; trains: public left-ticket query); facts are typed and invocation-bound — recognized empty is the sole negative fact, malformed rows record none, and the list API contributes no price; no live-availability claim beyond that
-- **Dependency doctor** — `npx @danceiny/gotry doctor` (CLI) / `gotry_doctor` (in-chat): read-only by default; explicit repair shows a scoped plan, asks once, runs the existing idempotent installers, and reports from a post-install recheck. Manual items stay manual; LLM keys stay with the dsh host
-- **Extension install on demand** — [GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) is offered as a clickable link when an account-session tool first needs it (one-click install + auto-update); no setup wizard
-- **Memory & reachability** — motivation profile / wish pool / companions / travel timeline, persisted by the tenant-scoped SQLite ledger; English solve output via `GOTRY_LOCALE=en`
-- **M4 lifecycle evidence collector** — explicit opt-in CLI for planning-flow observations: isolated `stateRoot`, mandatory consent + HMAC key; exports feed the #223 scorer as candidate/synthetic only, never manual attestation
-- **Routed turn budgets** — a deterministic, zero-LLM router classifies every turn (quick / sync / deep-planning); time is the only budget: quick/sync turns converge to an answer, deep-planning hands off to a persisted background ticket (`gotry_turn_handoff.v1`, ETA ≈1h) collected by `scripts/turn-handoff-collect.ts` and queryable via the read-only `gotry_turn_handoff_list`; exercised end-to-end through a packaged consumer install in CI
-- **Ledger admin & tenant repair plan** — `ts/scripts/state-cli.ts` parses fail-closed (unknown/duplicate/invalid options never touch the state root); `repair-plan` inventories and dry-runs only on a temporary DB copy — apply/migration/rollback remain numbered follow-ups on #254
-- **Flight/hotel anchor field fingerprint ([#363](https://github.com/Danceiny/gotry/issues/363), parent [#273](https://github.com/Danceiny/gotry/issues/273))** — anchored flight rows are re-tokenized for `flight_no` and must equal `fact.flight_no`; anchored hotel rows must literally contain `fact.destination` + `fact.check_in` + `fact.check_out`; any drift fails closed as `fact_anchor_unknown`. The field fingerprint complements — never replaces — whole-line strict comparison and the existing price classifications; the registered `gotry_fact_gate` execute gains no new path. Deterministic isolated evidence only; does not close #273 or open M5/M6
-- **Recent fail-closed hardening** — malformed supplier responses (#279 Ctrip session, #352 FlyAI), policy-anchor full-content fingerprint (#359), booking-planner repair (#282), strict duplicate tool-call repair (#327), safe-dispatch diagnostics (#329), IANA timezone contract (#343), persistent home-city default (#338), subagent/jobs id guard (#194), Node ≥22.15 build compatibility (#265). Deterministic, isolated evidence each — none of these open M4/M5/M6 gates. Full trail: [CHANGELOG.md](CHANGELOG.md)
+- **Deterministic choice kernel + explicit flight-chain Z3 path** — ordinary candidate enumeration, `evaluateChoice`, true-cost checks, per-candidate verdicts and recommendation; multi-leg flight chains go through the separate `solveUnified` Z3 path
+- **Realtime + account-session retrieval** — flights/trains/hotels (Fliggy official channel), catalogs, weather, live flight observation, route connectivity, plus Ctrip flights & hotels / 12306 trains / Dida supplier-portal rates on your own Chrome (consent-gated, physically read-only, typed invocation-bound facts; no live-availability claim beyond observed runs); realtime prices can overwrite solver prices (`GOTRY_REALTIME_PRICING=1`)
+- **Dependency doctor & extension on demand** — `npx @danceiny/gotry doctor` / `gotry_doctor`: read-only by default, scoped repair on approval via the same idempotent installers; the Session Bridge extension is offered as a clickable link when first needed (no setup wizard)
+- **Memory & reachability** — motivation profile / wish pool / companions / travel timeline on the tenant-scoped SQLite ledger; English solve output via `GOTRY_LOCALE=en`
+- **Routed turn budgets** — a deterministic, zero-LLM router classifies every turn (quick / sync / deep-planning); deep-planning hands off to a persisted background ticket (`gotry_turn_handoff.v1`, ETA ≈1h) instead of dying mid-stream
+- **M4 lifecycle evidence collector** — explicit opt-in CLI, isolated `stateRoot`, mandatory consent + HMAC key; exports feed the #223 scorer as candidate/synthetic only
+- **Recent slices & fail-closed hardening** — bounded ground-transfer slice (#341), flight/hotel anchor field fingerprint (#363), malformed supplier responses (#279/#352), policy-anchor fingerprint (#359), booking-planner & duplicate-call repairs (#282/#327), safe-dispatch diagnostics (#329), IANA timezone contract (#343), home-city default (#338), subagent/jobs id guard (#194), ledger CLI & read-only repair plan (#254), Node ≥22.15 builds (#265). Deterministic, isolated evidence each — none open M4/M5/M6 gates. Full trail: [CHANGELOG.md](CHANGELOG.md)
 
 **Open limitations** (honest list):
 
-- **M3 Exit not closed** — engineering & distribution are ready, but real seed-user evidence (50–200 person cohort) has not been accumulated; automated tests prove contracts and formulas, not business pass
-- **M4→M6 gates remain evidence-bound** — the scorer hardening (#238), opt-in lifecycle collector (#248), tenant CLI, and Z3/map stability foundations are on main, but no real `observed_private` N≥5 repeat cohort has landed; M5 Entry additionally requires supplier agreement/internal authorization (#136), M6 requires #137's P6 approval and a signed real pilot. Local or fixture proof — including the #258/#267 web-onboarding UX proof and the Node 26 dist gate — never opens these real gates
+- **M3 Exit not closed** — the real 50–200 seed-user cohort evidence is not yet accumulated; automated tests prove contracts and formulas, not business pass
+- **M4→M6 gates remain evidence-bound** — no real `observed_private` N≥5 repeat cohort has landed; M5 awaits #136 supplier authorization, M6 awaits #137 P6 approval + a signed pilot; local/fixture proof never opens these gates
 - **Hotel session adapters** — Ctrip-hotel / Meituan logged-in surfaces await real login-state backfill; flights are done
-- **#272 live evidence remains open** — #335 only hardens deterministic offline summary selection; authorized live browser/session calibration and packaged connected/degraded evidence remain outstanding
-- **Interface language** — English covers the deterministic solve-output layer; the dsh host UI and dialogue surface belong to the host / calibration samples
-- **External benchmark generalization** — every frozen external run to date remains diagnostic-only (no score, no uplift claim); the round-by-round engineering ledger lives in [`docs/evaluation/benchmark-environment-bridge.md`](docs/evaluation/benchmark-environment-bridge.md)
+- **#272 live evidence remains open** — only deterministic offline summary hardening (#335) has landed
+- **Interface language** — English covers the deterministic solve-output layer; the dsh host UI and dialogue surface belong to the host
+- **External benchmark generalization** — every frozen external run to date is diagnostic-only (no score, no uplift); round-by-round ledger: [`docs/evaluation/benchmark-environment-bridge.md`](docs/evaluation/benchmark-environment-bridge.md)
 - **Booking** — nothing bookable ships today; M5 opens only through WriteGate and the booking-saga FSM
 
 <details>
@@ -345,6 +299,7 @@ Program-level context: [`docs/gotry-master-outline.md`](docs/gotry-master-outlin
 | [`docs/gotry-product-design.md`](docs/gotry-product-design.md) | Product design: main loop, transparency, whole-cost model |
 | [`docs/roadmap.md`](docs/roadmap.md) | M0–M6 timeline & current position |
 | [`docs/user-guide.md`](docs/user-guide.md) | End-user guide |
+| [`docs/tools.md`](docs/tools.md) | Tool reference: per-tool contracts, channel routing, onboarding, operator scripts (Chinese-first) |
 | [`docs/data-sources.md`](docs/data-sources.md) | Data sources & evidence-chain policy |
 | [`docs/ops/extension-privacy.md`](docs/ops/extension-privacy.md) | Session Bridge extension privacy |
 | [`docs/research/kimi-postmortem.md`](docs/research/kimi-postmortem.md) | A real AI-travel-planning failure postmortem (cautionary tale) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,45 +106,9 @@ stateDiagram-v2
 
 ## 工具
 
-六组共 22 个:
+插件的 23 个注册工具分组为:**实时检索**(飞猪官方通道 + 你本人登录态 Chrome,物理只读)· **库存与目录** · **确定性判定引擎**(`gotry_feasibility_check`;显式航班链走 Z3)· **记忆与触达** · **产物** · 异步工单状态 · **事实闸** · **通用外部**检索 · **`gotry_doctor` 自检**。
 
-| 组 | 工具 | 干什么 |
-|---|---|---|
-| **实时检索(OTA/官方只读)** | `gotry_flyai_search` | 机票/火车/酒店实时报价(飞猪官方通道;酒店价格为上游打码展示;匿名试用额度达限归类 `needs-setup` 并带配 key 指引,不盲重试) |
-| | `gotry_session_search` | 在**用户本人登录态**里查携程机票/酒店 + 12306 火车 + Dida 供应商门户酒店实时价(kind=flight/hotel/train;授权后,物理只读;未知 kind fail closed) |
-| | `gotry_session_login` | 登录引导:自动检测已登录与否,未登录才在用户 Chrome 弹登录入口(**零终端**) |
-| | `gotry_weather_check` | Open-Meteo 预报≤16 天 + 历史气候基线 |
-| | `gotry_flight_verify` | OpenSky ADS-B 航班实时观测(三值) |
-| | `gotry_skeleton_check` | OpenFlights 168 对枢纽通航性(三值) |
-| **库存与目录** | `gotry_hotel_search` | hotel-byte 实时桥(缺入住/退房日期先追问),供应商不可用时降级为明确标注的静态结果 |
-| | `gotry_anything_search` | 城市/酒店/地标混合目录(hotel-be Anything) |
-| **判定引擎** | `gotry_feasibility_check` | 注册工具路径:确定性的 TypeScript 候选枚举/评估与逐候选判决 |
-| **记忆与触达** | `gotry_motivation_save` | 动机画像落盘(evidence 强制,反幻觉) |
-| | `gotry_wish_pool_add` / `gotry_wish_pool_list` | 「下一次出发」愿望池 + 0..1 条件召回 |
-| | `gotry_companion_save` · `gotry_trip_log` | 同行人档案 / 旅行时间线 |
-| **产物** | `gotry_artifacts_list` / `gotry_artifacts_read` | 发现与查看已生成的产物(异步交付 + 工作目录 markdown),行号文件视图,只读 |
-| **事实闸** | `gotry_fact_gate` | 行程产物交付前闸——见上文[工作原理](#工作原理)中的定义 |
-| **通用外部** | `gotry_web_search` · `gotry_video_subtitle` · `gotry_github_search` · `gotry_agent_reach` | 网页/字幕/GitHub/全渠道外部信息(经 Agent-Reach) |
-| **自检** | `gotry_doctor` | 默认只读体检。显式 `action: "repair"` 时展示范围计划、请求批准,复用 `doctor --fix` / web onboarding 的同一套幂等安装器,并以安装后复检判定结果;浏览器商店安装、凭证与 Node 升级仍由用户处理。报告落 `gotry-state/doctor-report.md` |
-
-> **通道路由**:检索工具面保持平铺(无隐藏派发);persona 路由卡与检索失败结果内附的 `routing` 建议来自单一通道注册表(官方 API > 用户会话 > 网页兜底,按会话健康面过滤)——注册表只返回**有序建议列表**,由模型或用户选择下一工具;注册表自身不派发、不执行,也不自动兜底。
-
-```mermaid
-flowchart LR
-  I["意图 + 失败通道"] --> R["通道注册表<br/>routingAdvice()"]
-  R -->|"有序 alternatives[]<br/>按层级 / 效率 / 健康态过滤"| A["routing 建议<br/>tool · channel · why"]
-  A --> M{"模型或用户<br/>选择下一工具"}
-  M --> F["gotry_flyai_search"]
-  M --> C["gotry_session_search"]
-  M --> W["gotry_web_search · Agent-Reach"]
-  R -.-> N["注册表不派发、<br/>不执行,也不自动兜底"]
-  classDef api fill:#2ea04322,stroke:#2ea043,color:#2ea043;
-  classDef sess fill:#1f6feb22,stroke:#1f6feb,color:#1f6feb;
-  classDef web fill:#6e768122,stroke:#6e7681,color:#6e7681;
-  class F api;
-  class C sess;
-  class W web;
-```
+检索工具面保持平铺、无隐藏派发:通道注册表只返回**有序建议列表**(官方 API > 用户会话 > 网页兜底,按会话健康面过滤),由模型或用户选择下一工具。逐工具契约、路由图、web onboarding 行为与运维脚本面:[`docs/tools.md`](docs/tools.md)。
 
 ## 一段对话
 
@@ -205,13 +169,9 @@ npx @danceiny/gotry web
 | headless 一问一答 | `npx @danceiny/gotry "我想从深圳休整两天,预算 3000"` | 脚本 / CI / 定向调试 → stdout |
 | 依赖体检 | `npx @danceiny/gotry doctor`(`--fix` 补装) | 可选渠道不好使时:体检扩展 / Agent-Reach / hbcli / FlyAI key / sidebar / calendar / 地图工具,逐项给精确修复指引,报告落 `gotry-state/doctor-report.md` |
 
-前置:Node ≥ 22.15。LLM 凭证由 dsh 宿主 UI 配,OpenAI 兼容端点(MiniMax/中转/自建网关)走 dsh 的模型设置。首启 6–15 秒属正常冷启动;`:3080` 被占先腾端口;异常退出会留证据到 `gotry-state/incidents.jsonl`(不静默)。
+前置:Node ≥ 22.15。LLM 凭证由 dsh 宿主 UI 配,OpenAI 兼容端点(MiniMax/中转/自建网关)走 dsh 的模型设置;首启 6–15 秒属正常冷启动;`:3080` 被占先腾端口;异常退出留证据到 `gotry-state/incidents.jsonl`(不静默)。
 
-> **registry 兼容与运行位置** —— 命令与 registry 无关:npmjs / npmmirror / 公司内部镜像等任何 npm 兼容源都行,只要该源已同步本包;镜像 `latest` 滞后时钉精确版本,如 `npx @danceiny/gotry@0.0.1-rc.22 web`。一个例外:**在 gotry 仓库根**(或任何 package.json 同名为 `@danceiny/gotry` 的项目里)跑裸名 npx 会报 `sh: gotry: command not found`——仓内请走源码入口 `./gotry web`。
-
-> **每次启动的 onboarding(`gotry web`,#258/#267)** —— 符合条件的交互式启动最多询问一次可选能力检查:`y` 复用 `doctor --fix` 的同一套幂等安装器,并逐项报告 `installed` / `needs-user-action` / `unavailable`(附具体原因);`n` 直接进 web。CI、benchmark、非 TTY、`GOTRY_SETUP_SKIP=1`、`GOTRY_ONBOARDING_SKIP=1` 下不询问也不安装;`postinstall` 与 detached 后台任务里永远零安装。这是确定性隔离测试支撑的 M4 UX 证明——**不计入 #20 真实复购 cohort 证据**。
-
-> **运维脚本(仓内,只读)** —— nightly 成本核算的唯一事实源是 `ts/data/llm-price-table.json`(只经 PR 变更;未知模型 fail-closed 不猜价;`price-drift-watch.ts` 只报告漂移、永不自动 apply);`build-metrics-report.ts` 把事实闸/通道/事故 sidecar 聚合成一份 markdown 报告;`channel-probe.ts` 以 cron 驱动只读通道探测,产出的 `down`/恢复事件直接供路由建议、doctor 与愿望池召回消费。
+> **运行位置** —— 任何 npm 兼容 registry 皆可(镜像 `latest` 滞后时钉精确版本)。在 gotry 仓内跑裸名 `npx @danceiny/gotry …` 会报 `sh: gotry: command not found`——请走源码入口 `./gotry web`。符合条件的交互式启动可能提供一次可选能力检查(`y` 复用 `doctor --fix` 的幂等安装器,`n` 跳过;CI / 非 TTY 不询问也不安装)。onboarding 细节与仓内运维脚本(成本表 / 指标报告 / 通道探针)见 [`docs/tools.md`](docs/tools.md)。
 
 ### 开发者源码安装
 
@@ -226,14 +186,14 @@ node scripts/build-dist.mjs                       # 构建 JS runtime
 
 ## 账号会话:授权与隐私
 
-账号会话通道用**你本人已登录的 Chrome**读酒店/机票实时数据,为此立了四条 hard 规则:
+账号会话通道用**你本人已登录的 Chrome**读酒店/机票实时数据,四条 hard 规则:
 
-1. **登录在外部网站完成** —— gotry 从不提供、不代填、不收集任何密码/验证码/cookie 值。它只回答一个布尔问题:"登录票据 cookie 存在吗"(只读**名字**,0 值过手)。已登录会被自动识别,零弹窗。
-2. **授权卡,每会话一次** —— 首次动用账号会话弹运行时审批卡;批准后会话内记住,拒绝即本会话吊销,不再打扰。总闸 `sessionAccess: ask|allow|off` 随时可关。
-3. **物理只读** —— ReadGuard 在网络层中止一切写请求(下单/支付在传输层不可达);agent 永不接触凭证与验证码,遇验证码立即停、交还给你。
-4. **绝不劫持你的浏览器** —— 检索/登录只开自己的独立标签页,登录页置前台、留在你那;例行动测试永不自动开浏览器窗。
+1. **登录在外部网站完成** —— gotry 从不提供、不代填、不收集任何密码/验证码/cookie 值;只回答一个布尔问题(只读 cookie **名字**)。
+2. **授权卡,每会话一次** —— 批准后会话内记住,拒绝即本会话吊销;总闸 `sessionAccess: ask|allow|off` 随时可关。
+3. **物理只读** —— ReadGuard 在网络层中止一切写请求;遇验证码立即停、交还给你。
+4. **绝不劫持你的浏览器** —— 检索/登录只开独立标签页;例行测试永不自动开浏览器窗。
 
-前置(一次性):[GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) Chrome 应用商店一键装(自动更新,无 setup wizard,不需手动加载已解压扩展)。账号会话工具首次需要扩展时,**由 dsh 宿主 UI 把商店 URL 作为可点链接渲染**;未安装时工具返回 `needs-extension` 并附上链接,不消耗执行配额。扩展只被动转发站点自己发出的检索响应——构造上只读,cookie 值永不离开浏览器。
+前置(一次性):[GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) Chrome 商店一键装(自动更新,无 setup wizard);未安装时工具返回 `needs-extension` 并附商店链接,不消耗执行配额。
 
 ## 构造上可信
 
@@ -252,28 +212,22 @@ node scripts/build-dist.mjs                       # 构建 JS runtime
 
 **今天可用**(全栈回归全绿;每项都有确定性测试):
 
-- **确定性选择内核** —— 普通候选枚举、`evaluateChoice`、真成本检查、逐候选判决与推荐
-- **显式航班链 Z3 路径** —— `solveUnified` 处理独立的多段约束路径;求解调用由单一共享 Context、串行会话与 #227 本地 native 清理屏障把守
-- **有界地面接驳切片(#341)** —— 显式起讫坐标 + `mode=driving` 走注册的 `map_driving_route` 公共工具;只有精确静态 `taxi` 接驳可拿路径估算分钟数(静态价仍标 `[静态包:估算]`);实时路况、公交轨交与车费不在这条切片内
-- **实时检索** —— 机票/火车/酒店(飞猪官方通道)、目的地/酒店目录、天气、航班观测、通航性校验;实时票价可覆写求解价(`GOTRY_REALTIME_PRICING=1`);飞猪匿名试用额度达限归类 `needs-setup` 并带配 key 指引(不盲重试)
-- **账号会话检索** —— 你本人登录态查携程机票/酒店 + 12306 火车 + Dida 供应商门户酒店实时价(酒店:被动嗅探登录态真实价;火车:公开余票查询面);事实全部 typed 且绑定单次调用——可识别空是唯一负事实,malformed 行零记录,列表接口不提供价格;不作超出此口径的实时可售声明
-- **依赖体检** —— `npx @danceiny/gotry doctor`(CLI)/ `gotry_doctor`(对话内工具):默认只读;显式修复展示范围计划、请求一次批准、调用既有幂等安装器,并按安装后复检逐项报告。需人工配置的项目保持人工,LLM key 仍归 dsh 宿主管
-- **扩展按需装** —— [GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) 由 dsh 宿主 UI 在账号会话工具首次需要时以可点链接给出(Chrome 商店一键装 + 自动更新);gotry 不跑 setup wizard
-- **记忆与触达** —— 动机画像 / 愿望池 / 同行人 / 旅行时间线,由租户作用域 SQLite 账本持久化;英文求解输出一键切换(`GOTRY_LOCALE=en`)
-- **M4 lifecycle 证据采集器** —— 显式 opt-in CLI 记录 planning flow:隔离 `stateRoot`、consent 与 HMAC key 必需;导出只作为 #223 scorer 的 candidate/synthetic 输入,绝不生成人工签核
-- **按任务路由的回合预算** —— 每轮由确定性路由器(零 LLM)分类 quick / sync / deep-planning;时间是唯一预算:quick/sync 收敛作答,deep-planning 转后台落 `gotry_turn_handoff.v1` 工单(ETA 约 1 小时)而不是让会话流死掉;工单由 `scripts/turn-handoff-collect.ts` 后台收集结算,经只读工具 `gotry_turn_handoff_list` 可查;经打包消费者安装的 E2E 在 CI 里实测
-- **账本管理 CLI 与租户修复计划** —— `ts/scripts/state-cli.ts` 解析 fail-closed(未知/重复/非法选项不碰 state root);`repair-plan` 只在临时 DB 副本上盘点与 dry-run——apply/迁移/回滚仍是 #254 的编号后续
-- **航班/酒店锚点字段指纹([#363](https://github.com/Danceiny/gotry/issues/363),父 [#273](https://github.com/Danceiny/gotry/issues/273))** —— 带锚点的航班行从渲染文本重新抽取 `flight_no` token,必须严格等于 `fact.flight_no`;酒店行必须逐字包含 `fact.destination` + `fact.check_in` + `fact.check_out`;任一漂移即 `fact_anchor_unknown` fail-closed。字段指纹补位而不替代整行严格比对与既有价格分类;`gotry_fact_gate` 注册执行面无新增路径。确定性隔离证据;不关闭 #273,也不打开 M5/M6
-- **近期 fail-closed 加固** —— 供应商 malformed 响应(#279 携程会话、#352 FlyAI)、政策锚点全文指纹(#359)、booking planner 修复(#282)、严格重复工具调用修复(#327)、安全派发诊断(#329)、IANA 时区合同(#343)、常住地软默认(#338)、子代理/jobs id 安全闸(#194)、Node ≥22.15 构建兼容(#265)。每项均为确定性隔离证据——均不打开 M4/M5/M6 gate。完整轨迹见 [CHANGELOG.md](CHANGELOG.md)
+- **确定性选择内核 + 显式航班链 Z3 路径** —— 普通候选枚举/`evaluateChoice`/真成本检查/逐候选判决与推荐;多段航班链走独立的 `solveUnified` Z3 路径
+- **实时 + 账号会话检索** —— 机票/火车/酒店(飞猪官方通道)、目录、天气、航班观测、通航性校验;外加你本人登录态 Chrome 上的携程机票/酒店、12306 火车、Dida 供应商门户实时价(授权闸 + 物理只读 + typed 调用绑定事实;不作超出观测口径的实时可售声明);实时票价可覆写求解价(`GOTRY_REALTIME_PRICING=1`)
+- **依赖体检与扩展按需装** —— `npx @danceiny/gotry doctor` / `gotry_doctor`:默认只读,批准后按既有幂等安装器做范围修复;Session Bridge 扩展在首次需要时以可点链接给出(无 setup wizard)
+- **记忆与触达** —— 动机画像 / 愿望池 / 同行人 / 旅行时间线,由租户作用域 SQLite 账本持久化;`GOTRY_LOCALE=en` 切英文求解输出
+- **按任务路由的回合预算** —— 确定性零 LLM 路由器分类 quick / sync / deep-planning;deep-planning 转后台落 `gotry_turn_handoff.v1` 工单(ETA 约 1 小时)而不是让会话流死掉
+- **M4 lifecycle 证据采集器** —— 显式 opt-in、隔离 `stateRoot`、consent + HMAC key 必需;导出只作为 #223 scorer 的 candidate/synthetic 输入
+- **近期切片与 fail-closed 加固** —— 有界地面接驳(#341)、航班/酒店锚点字段指纹(#363)、供应商 malformed 响应(#279/#352)、政策锚点全文指纹(#359)、booking planner 与重复调用修复(#282/#327)、安全派发诊断(#329)、IANA 时区合同(#343)、常住地软默认(#338)、子代理/jobs id 安全闸(#194)、账本 CLI 与只读修复计划(#254)、Node ≥22.15 构建兼容(#265)。每项均为确定性隔离证据——均不打开 M4/M5/M6 gate。完整轨迹见 [CHANGELOG.md](CHANGELOG.md)
 
 **已知限制**(诚实清单):
 
-- **M3 Exit 未关闭** —— 工程与分发面就绪,但真实种子用户证据(50–200 人 cohort)尚未积累;自动化测试证明的是合同与公式,不是 business pass
-- **M4→M6 真实证据门仍开放** —— scorer 加严(#238)、opt-in lifecycle collector(#248)、租户 CLI 与 Z3/地图稳定性基座已在 main,但 #20 所需真实 `observed_private` N≥5 repeat cohort 仍未落地;M5 仍等待 #136 的供应协议/内部授权,M6 仍等待 #137 的 P6 批准与真实签约试点。本地或 fixture 证明——包括 #258/#267 web onboarding UX 证明与 Node 26 dist 闸——永不打开这些真实 gate
+- **M3 Exit 未关闭** —— 真实种子用户证据(50–200 人 cohort)尚未积累;自动化测试证明的是合同与公式,不是 business pass
+- **M4→M6 真实证据门仍开放** —— 真实 `observed_private` N≥5 repeat cohort 未落地;M5 等 #136 供应协议/内部授权,M6 等 #137 的 P6 批准与签约试点;本地或 fixture 证明永不打开这些 gate
 - **酒店会话适配** —— 携程酒店/美团登录态面等实测回填;机票已通
-- **#272 实时证据仍开放** —— #335 只加固了确定性离线摘要选择;授权的真实浏览器/会话校准与打包形态 connected/degraded 证据仍未完成
+- **#272 实时证据仍开放** —— 仅落地确定性离线摘要加固(#335)
 - **界面语言** —— 英文仅覆盖求解确定性输出层;dsh 宿主界面与对话面属宿主/校准件
-- **外部 benchmark 泛化** —— 迄今所有冻结外部运行均仅 diagnostic(无分数、无 uplift 声明);逐轮工程台账见 [`docs/evaluation/benchmark-environment-bridge.md`](docs/evaluation/benchmark-environment-bridge.md)
+- **外部 benchmark 泛化** —— 迄今所有冻结外部运行均仅 diagnostic(无分数、无 uplift 声明);逐轮台账见 [`docs/evaluation/benchmark-environment-bridge.md`](docs/evaluation/benchmark-environment-bridge.md)
 - **预订** —— 今天没有任何可下单路径;M5 只经 WriteGate 与 booking-saga 状态机启封
 
 <details>
@@ -345,6 +299,7 @@ npx tsx scripts/evaluation-cadence-tests.ts    # 确定性节奏策略/planner
 | [`docs/gotry-product-design.md`](docs/gotry-product-design.md) | 产品设计:主循环 · 透明机制 · 全成本模型 |
 | [`docs/roadmap.md`](docs/roadmap.md) | M0–M6 时间线与当前位置 |
 | [`docs/user-guide.md`](docs/user-guide.md) | 终端用户使用指南 |
+| [`docs/tools.md`](docs/tools.md) | 工具参考面:逐工具契约 · 通道路由 · onboarding · 运维脚本 |
 | [`docs/data-sources.md`](docs/data-sources.md) | 数据源与证据链政策 |
 | [`docs/ops/extension-privacy.md`](docs/ops/extension-privacy.md) | Session Bridge 扩展隐私 |
 | [`docs/research/kimi-postmortem.md`](docs/research/kimi-postmortem.md) | 一次真实 AI 旅行规划失败复盘(反面教材) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@
 | [tech-strategy.md](tech-strategy.md) | 技术选型与半年迭代路线(M2–M4):选型矩阵/评测/决策登记 |
 | [data-sources.md](data-sources.md) | 唯一数据源权威面:领域矩阵/新鲜度/证据链契约 |
 | [user-guide.md](user-guide.md) | 终端用户使用指南 |
+| [tools.md](tools.md) | 工具参考面:23 个注册工具的分组与逐工具契约/通道路由/web onboarding/运维脚本面 |
 | [release-notes.md](release-notes.md) | 逐版本发布决策(「为什么」,人写决策面) |
 | [tokens.md](tokens.md) | token 唯一权威面:npm 2FA/发布机制/渠道获取表 |
 | [decisions-needed.md](decisions-needed.md) | 待创始人拍板的决策队列 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -565,6 +565,7 @@ Issue #338 当前形态:写入 patch 接受 `homeCity` 与 optional `homeCityEvi
 | `tech-strategy.md` | 技术选型与半年迭代路线(M2–M4):选型矩阵/评测体系/分工/持续优化回路/决策登记 |
 | `tokens.md` | **token 唯一权威面**:npm 三路径(web会话/granular bypass/OIDC)+ agent-reach 8 渠道获取表 + 统一 .env 存放 |
 | `user-guide.md` | 面向使用者的上手指南(dsh 形态用法) |
+| `tools.md` | **工具参考面**:23 个注册工具分组与逐工具契约/降级行为 + 通道路由(注册表只建议不派发)+ web onboarding(#258/#267)与运维脚本面 |
 | `release-notes.md` | 发版记录(按版本归档,最新在上) |
 | `decisions-needed.md` | 待创始人拍板的决策清单 |
 | [`debt-archive.md`](debt-archive.md) | 已清偿债务存档(追加式留证;开着的债与工作面只在本文 §10.1) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,75 @@
+# GoTry 工具参考面
+
+> 定位:gotry-tools 插件 23 个注册工具的分组、逐工具契约与降级行为的唯一参考面;根 README 双语只留组级摘要与指针。
+> 状态:living
+> 上游:[`architecture.md`](architecture.md)(系统权威面)、[`design/tool-orchestration-design.md`](design/tool-orchestration-design.md)(通道注册表设计)、AGENTS.md(仓库契约)
+> 下游:根 `README.md` / `README.zh-CN.md`(摘要 + 指针)、[`user-guide.md`](user-guide.md)(终端用户叙事)
+
+## 速览
+
+- 工具面**平铺**:无隐藏派发;通道选择由注册表产出**有序建议列表**,模型或用户挑下一工具,注册表自身不派发、不执行、不兜底。
+- 检索全部**只读**:账号会话通道物理只读(ReadGuard 网络层闸),写操作不在这条面内。
+- 降级**如实换标签**:估算绝不冒充实时;供应商不可用即显式降级。
+- 工具数量以代码注册表(`ts/src/index.ts`)为准;本表与代码同步演进。
+
+## 工具分组
+
+| 组 | 工具 | 契约 |
+|---|---|---|
+| **实时检索(OTA/官方,只读)** | `gotry_flyai_search` | 机票/火车/酒店实时报价,飞猪官方通道;酒店价格为上游打码展示(真实价以 jumpUrl 页面为准,打码价保 `priceRaw` 原值、数字价恒 0,防「¥7xx 截成 7 伪装真价」);匿名试用额度达限归类 `needs-setup` 并带配 key 指引,不盲重试 |
+| | `gotry_session_search` | 在**用户本人登录态 Chrome** 里查携程机票/酒店 + 12306 火车 + Dida 供应商门户酒店实时价。`kind` = flight/hotel/train,省略默认 flight,query 包裹参数走 query-first 选择,未知/畸形 kind fail closed;全部形态授权闸后物理只读。酒店 = `kind:"hotel"` + 可选 `cityId`,被动嗅探登录态真实价;火车 = `kind:"train"`,12306 公开余票查询面(车次/时刻/座位可用性,列表接口无价格)。火车事实 typed 且绑定单次调用:查询日期为宿主捕获的调用权威、须与精确响应 URL 绑定;可识别空是唯一负事实,malformed/transport/未知座位行零记录,`canWebBuy=Y` 不替代可识别可用座位 |
+| | `gotry_session_login` | 登录引导:先自动检测既有登录;未登录才在用户 Chrome 弹登录入口(**零终端**) |
+| | `gotry_weather_check` | Open-Meteo 预报 ≤16 天 + 历史气候基线 |
+| | `gotry_flight_verify` | OpenSky ADS-B 航班实时观测(三值) |
+| | `gotry_skeleton_check` | OpenFlights 168 对枢纽通航性校验(三值) |
+| **库存与目录** | `gotry_hotel_search` | hotel-byte 实时桥;需提供有效入住/退房日期,缺失时先追问;供应商不可用时降级为明确标注的静态结果 |
+| | `gotry_anything_search` | 城市/酒店/地标混合目录(hotel-be Anything) |
+| **判定引擎** | `gotry_feasibility_check` | 注册工具路径:确定性的 TypeScript 候选枚举/评估与逐候选判决;显式多段航班链走独立的 `solveUnified` Z3 路径 |
+| **记忆与触达** | `gotry_motivation_save` | 动机画像落盘(evidence 强制,反幻觉);支持 typed `homeCity` 常住地软默认(#338),显式当前行程出发地优先,原点永不从 IP/语言/时区/历史/模型猜测推断 |
+| | `gotry_wish_pool_add` / `gotry_wish_pool_list` | 「下一次出发」愿望池 + 0..1 条件召回;召回可被指名通道宕机否证 |
+| | `gotry_companion_save` · `gotry_trip_log` | 同行人档案 / 旅行时间线 |
+| **产物** | `gotry_artifacts_list` / `gotry_artifacts_read` | 发现与查看已生成产物(异步交付 + 工作目录 markdown):只读、带行号的文件视图;公开 `./client` adapter 按 runtime `block` 渲染自定义 list/read 卡,路径可点,读卡显示 source 身份与内容版本。范围 = `stateRoot` + 会话工作目录(排除 `node_modules`/`.git`),仅文本扩展名(`md/txt/json/jsonl/csv/log/yaml/yml`);>2 MB / 越界 / 符号链接逃逸 / 不支持扩展名 → `ok: false` + `hint` |
+| **异步工单** | `gotry_turn_handoff_list` | 只读查询 deep-planning 后台工单(`gotry_turn_handoff.v1`,ETA 约 1 小时)的状态与交付物 |
+| **事实闸** | `gotry_fact_gate` | 行程产物交付前闸:每条可下单 claim(航班号/车次/时刻/机场/价格/政策)必须回溯到 exact-date 工具结果,否则 blocked。航班/铁路 claim 分开归类;事实锚点带指纹,政策行全文比对(#359),航班/酒店锚点行字段级指纹(#363),篡改或未知锚点一律 fail closed |
+| **通用外部** | `gotry_web_search` · `gotry_video_subtitle` · `gotry_github_search` · `gotry_agent_reach` | 网页 / 字幕 / GitHub / 全渠道外部信息(经 Agent-Reach) |
+| **自检** | `gotry_doctor` | 默认只读体检(扩展 / Agent-Reach / hbcli / FlyAI key / sidebar / dsh-calendar / dsh-map-tools / dsh-tool-ask-user)。显式 `action: "repair"`:先展示可自动修复项与范围,请求批准,复用 `doctor --fix` / web onboarding 同一套幂等安装器,以安装后复检判定结果;浏览器商店安装、凭证/API key、profile、包重装与 Node 升级仍由用户处理;拒绝、取消或无审批通道时零执行。报告落 `gotry-state/doctor-report.md`(侧栏工作台可预览) |
+
+另有随包交付的 MIT 地图工具 payload(`map_geocode` / `map_poi_search` / `map_*_route` 等,dsh-map-tools 系),不引入与锁定家族冲突的外部 npm peer;地面接驳切片(#341)经注册的公共 `map_driving_route` 委托,仅精确静态 `taxi` 接驳可拿路径估算分钟数,静态价仍标 `[静态包:估算]`。
+
+## 通道路由
+
+检索工具面保持平铺(无隐藏派发);persona 路由卡与检索失败结果内附的 `routing` 建议**由通道注册表单一生成**(官方 API > 用户会话 > 网页兜底,按会话健康面过滤)。注册表返回有序建议列表,由模型或用户选择下一工具;注册表自身不自动派发、不执行,也不自动兜底。
+
+```mermaid
+flowchart LR
+  I["意图 + 失败通道"] --> R["通道注册表<br/>routingAdvice()"]
+  R -->|"有序 alternatives[]<br/>按层级 / 效率 / 健康态过滤"| A["routing 建议<br/>tool · channel · why"]
+  A --> M{"模型或用户<br/>选择下一工具"}
+  M --> F["gotry_flyai_search"]
+  M --> C["gotry_session_search"]
+  M --> W["gotry_web_search · Agent-Reach"]
+  R -.-> N["注册表不派发、<br/>不执行,也不自动兜底"]
+  classDef api fill:#2ea04322,stroke:#2ea043,color:#2ea043;
+  classDef sess fill:#1f6feb22,stroke:#1f6feb,color:#1f6feb;
+  classDef web fill:#6e768122,stroke:#6e7681,color:#6e7681;
+  class F api;
+  class C sess;
+  class W web;
+```
+
+## web 启动 onboarding(#258/#267)
+
+每次符合条件的 `gotry web` 启动在进 web 前可做一次可选能力检查:逐 launch 评估一次、最多问一次,无跨 launch 持久化「已问过」标记;复用 `doctor --fix` 的同一套幂等安装器,不建第二套安装器。
+
+- **交互式 TTY + 存在可自动安装缺口**(hbcli 二进制 / Agent-Reach `.venv` / dsh-better-sidebar)→ 恰好问一次「现在配置?(y/N)」。`y` 安装并逐项报告三类结果:`installed`(本机自动装好)/ `needs-user-action`(Chrome 商店扩展、hbcli 登录、FlyAI key、calendar profile——绝不伪装成已自动化)/ `unavailable`(如随包插件缺失 → 重装 gotry)。`n` 直接进 web。部分失败不阻塞 web,显示重试命令 `npx @danceiny/gotry doctor --fix`;后续运行不会重装已健康项。
+- **交互式 TTY,无可自动安装缺口但有其他缺口**(如 Windows 无自动安装面,或仅凭证/key/重装类)→ 不询问、不安装,渲染分类后的 `needs-user-action` / `unavailable` 行与具体原因,然后进 web。
+- **完全健康** → 静默。
+- **零询问、零安装、web 照常启动**的条件:CI、benchmark、非 TTY、`GOTRY_SETUP_SKIP=1`、`GOTRY_ONBOARDING_SKIP=1`(或 `--no-onboarding`)。`postinstall` 与 detached 后台任务里永远零安装。
+
+这是确定性隔离测试支撑的 M4 UX 证明;**不计入 #20 真实复购 cohort 证据**。
+
+## 运维脚本面(仓内,只读)
+
+- **成本核算**:`ts/data/llm-price-table.json`(schema `gotry_llm_price_table_v2`)是 nightly 成本核算的唯一事实源;新增模型或换中转 = 对该文件提 PR(peak 保守上界);未知模型 **fail-closed 不猜价**。漂移监测 `npx tsx ts/scripts/price-drift-watch.ts`(默认离线对照 baseline,`--fetch` 拉官方页)只报告、**永不自动 apply**。
+- **指标报告**:`npx tsx ts/scripts/build-metrics-report.ts [--state-root <root>] [--out report.md] [--days 7]` 把事实闸 verdict 分布与 blocked 率、通道 down/cooldown、事故面、桥延迟(对 500 ms 复审预算)等 sidecar 聚合成一份只读 markdown;零新依赖、零 LLM,state root 只读,只有 `--out` 落一个文件(在 state root 之外)。
+- **通道探针**:`npx tsx ts/scripts/channel-probe.ts --state-root <root>` 以 cron/loopx 驱动一轮只读探测(可无头探测的通道:hbcli whoami / open-meteo / opensky;session 面跳过,FlyAI 默认跳过以保共享匿名额度),把 `down` / `'ok'` 恢复事件追加进 `channel-health.jsonl`——路由建议与 doctor 零改动消费;愿望池召回用同一事实面否证指名已宕通道。无驻留进程。


### PR DESCRIPTION
## 为什么

创始人:README 还是太长——Tools 全表不必在首页,Quick Start / Consent and Privacy / Project Status 都偏长。「先精简一轮,不能精简的再拆文件」。

## 改了什么(英 31.3K 字符,较本轮前 -18%,较最初 56.7K 累计 -45%;中文同步)

**拆文件**
- 新增 [`docs/tools.md`](docs/tools.md)(中文优先,按 docs/README.md 规范带头部块 + 速览):23 个注册工具的完整分组表(逐工具契约/降级行为,补回了上轮压掉的细节与此前漏掉的 `gotry_turn_handoff_list`)、通道路由 mermaid、web onboarding 全量行为(#258/#267)、运维脚本面(成本表/指标报告/通道探针)。已注册进 `docs/README.md` 总索引与 `architecture.md` §12 文档地图。
- README 的 Tools 节收成两段:组级摘要 + 「注册表只建议不派发」合同一句话 + 指针。路由块与 mermaid 随迁。

**再压缩(内容全部保留在 tools.md / CHANGELOG / 原 issue)**
- Quick Start:三个 blockquote(registry / onboarding / 运维脚本)收成一段「Where you run it」;保留仓内裸名 npx 失败这一真坑与「CI/非 TTY 不询问不安装」承诺。
- Consent and Privacy:四条 hard rule 各压一行,扩展前置压成一句;四条规则本身(只读、授权、不碰凭证、不劫持浏览器)一条不少。
- Project Status:「Working today」13 条 → 7 条单行(内核+Z3 / 实时+会话检索 / doctor+扩展 / 记忆 / 回合预算 / M4 采集器 / 近期加固汇总),issue 链接全部保留;「Open limitations」7 条全部压成单行。

证据边界照例全保留:demo 说明性录制声明、横评 qualitative 声明、不声称实时可售 / 不开 M4–M6 gate 的口径原样。

## 验证

- `tsc --noEmit` 分支 HEAD 绿
- `gh api markdown`(gfm)双语渲染正常;全部相对链接(含新 tools.md)逐一 existence 检查过
- 全栈回归后台运行中,结果贴评论(suite 48 在 main 上有已知负载敏感 flake,与本改动无关)

Docs-only;不改系统形态/状态/债务,architecture.md §11 六状态面无需同步(§12 文档地图按引用纪律同提交更新)。