### PR TITLE
docs(readme): 三轮精简再砍近半——全书短句化,开篇句去 bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Body and soul — more travel, less tourism.**
 > *身体和灵魂,更多旅行,更少旅游。*
 
-GoTry is an AI travel agent for **"departure to next departure."** You tell it where you want to go and why; it interviews you about your working hours and existing bookings, then hands you a deterministic itinerary verdict — ordinary candidate choices are enumerated and evaluated by the TypeScript kernel, while explicit flight-chain cases use the Z3 solver, not model guesses.
+GoTry is an AI travel agent for **"departure to next departure."** You say where and why; it interviews you about your working window, then hands you a deterministic verdict — ordinary choices are enumerated and evaluated by a TypeScript kernel, explicit flight chains by Z3. No model guesses.
 
 [![GitHub Stars](https://img.shields.io/github/stars/Danceiny/gotry?style=social)](https://github.com/Danceiny/gotry/stargazers)
 [![CI](https://github.com/Danceiny/gotry/actions/workflows/ci.yml/badge.svg)](https://github.com/Danceiny/gotry/actions/workflows/ci.yml)
@@ -14,21 +14,18 @@ GoTry is an AI travel agent for **"departure to next departure."** You tell it w
 [![Node](https://img.shields.io/badge/node-%E2%89%A5%2022.15-blue)](https://www.npmjs.com/package/@danceiny/gotry)
 [![Docs](https://img.shields.io/badge/docs-architecture.md-blue)](docs/architecture.md)
 
-**[What GoTry Does](#what-gotry-does)** · **[How It Works](#how-it-works)** · **[Tools](#tools)** · **[Demo](#demo)** · **[Benchmark](#how-mainstream-ai-answers-the-same-trip)** · **[Quick Start](#quick-start)** · **[Consent and Privacy](#consent-and-privacy)** · **[Trustworthy by Construction](#trustworthy-by-construction)** · **[Project Status](#project-status)** · **[Roadmap](#roadmap)** · **[For AI Agents](#for-ai-agents)** · **[Documentation](#documentation)** · **[License](#license)** · **[Star History](#star-history)**
-
-> **Tip for newcomers:** one command is enough to feel the difference — `npx @danceiny/gotry web`, open `http://127.0.0.1:3080`, and say *"I want three relaxing days in Dali."* The agent interviews you first; then the solver, not the model, decides what is feasible. Full walkthrough: [`docs/user-guide.md`](docs/user-guide.md).
+**[What it does](#what-gotry-does)** · **[How it works](#how-it-works)** · **[Demo](#demo)** · **[Benchmark](#how-mainstream-ai-answers-the-same-trip)** · **[Quick start](#quick-start)** · **[Privacy](#consent-and-privacy)** · **[Status](#project-status)** · **[Roadmap](#roadmap)** · **[Docs](#documentation)**
 
 ## What GoTry Does
 
-GoTry turns "I want to go somewhere" into "can I — and how, at what true cost?" When the answer is "not this weekend," the destination is caught in a wish pool with its conditions instead of being dropped.
+Turns "I want to go somewhere" into "can I — how, at what true cost?" If the answer is "not this weekend," the destination waits in a wish pool with explicit recall conditions instead of being dropped.
 
-- **For travelers** — a conversational planner that asks the questions that actually matter (working window, booked resources, departure city, budget), then returns a verdict per destination: feasible or not, why, and the **smallest change that makes it feasible**.
-- **For agent builders** — a working example of an agent where the LLM only listens, translates, and explains. Ordinary candidate decisions follow deterministic TypeScript enumeration, evaluation, and choice; the separate explicit flight-chain path uses Z3. Every deliverable number carries a provenance tag; write operations are gated by design.
-- **Evidence built in** — an estimate never poses as realtime. Tags are attached by the render layer, never by the model, and switch honestly on degradation. Bookable claims that cannot trace to an exact-date tool result are blocked before delivery.
+- **For travelers** — a planner that asks what actually matters (working window, departure city, budget), then answers per destination: feasible or not, why, and the **smallest change that makes it feasible**.
+- **For agent builders** — the LLM only listens, translates, and explains; the kernel enumerates, evaluates, chooses. Every delivered number carries a provenance tag; writes are gated by design.
 
 ## How It Works
 
-One planning pass is a pipeline. The model owns the two language-heavy ends; the ordinary choice path is deterministic TypeScript, while the explicit flight-chain path uses Z3:
+The model owns the language ends; deterministic code owns the numbers:
 
 ```mermaid
 flowchart LR
@@ -62,28 +59,7 @@ flowchart LR
   class E,F,G,H,I gate;
 ```
 
-Vocabulary you will meet in a GoTry answer:
-
-- **Evidence tag** — `[skeleton:openflights]` route existence verified against the public route database; `[realtime:...]` pulled live from an API seconds ago; `[static-pack:estimate]` a researched estimate — not realtime, verify before booking. On degradation the tag switches honestly.
-- **Door-to-door true cost** — the ticket price plus what the trip actually takes from you: real duration across time zones, the early-wake penalty, transfers, and the energy you land with.
-- **Wish pool** — "next departure" storage. An infeasible dream is saved with explicit conditions (e.g. "5+ days, off-season") and recalled when they can be met.
-- **Fact gate** — pre-delivery check on itinerary artifacts: every bookable claim (flight no. / train code / time / airport / price / policy) must trace to an exact-date tool result; unverifiable means blocked — never presented as a verified plan. Flight and rail claims are classified separately; fact anchors are fingerprinted, and prices/policies fail closed on tampering or drift ([#273](https://github.com/Danceiny/gotry/issues/273) and linked issues). No live supplier availability or M5/M6 admission is claimed.
-
-The wish pool lifecycle:
-
-```mermaid
-stateDiagram-v2
-  direction LR
-  [*] --> Interviewed: motivation captured (evidence mandatory)
-  Interviewed --> Feasible: deterministic choice verdict — feasible
-  Interviewed --> Wished: infeasible today
-  Wished --> Wished: recall vetoed — named channel down
-  Wished --> Recalled: conditions met — window · budget · season
-  Recalled --> Interviewed: re-solve with realtime data
-  Feasible --> [*]: fact-gated delivery
-```
-
-Architecture, five layers:
+Architecture — the sync path from chat through the kernel to the fact gate, plus the state/async control plane and the read-only data layer:
 
 <a href="docs/assets/gotry-system-architecture.en.html">
   <picture>
@@ -93,28 +69,17 @@ Architecture, five layers:
   </picture>
 </a>
 
-> Generated from [`docs/assets/gotry-system-architecture.en.archify.json`](docs/assets/gotry-system-architecture.en.archify.json) with [archify](https://github.com/tt-a1i/archify) (showcase validation 0 errors/0 warnings + automated browser containment pass). Open [`docs/assets/gotry-system-architecture.en.html`](docs/assets/gotry-system-architecture.en.html) locally for the interactive version — guided views, pan/zoom, relationship tracing. English labels; the Chinese-labelled twin ([`gotry-system-architecture.html`](docs/assets/gotry-system-architecture.html)) matches the authoritative [`docs/architecture.md`](docs/architecture.md).
-
-| Layer | Module | Role |
-|---|---|---|
-| L2 | `ts/src/index.ts` (dsh plugin) + `bin/gotry-inner.js` | Tool registry, time-anchor & memory-brief variables; execute isolation + consent gate + per-turn tool budget + process guards; launcher-owned dsh child process-group cleanup |
-| L3 | `ts/src/unified.ts` | ordinary candidate enumeration/evaluation/choice; `solveUnified` is the separate flight-chain Z3 path. `py/gotry_feasibility/` is a historical comparison oracle only, with zero product/runtime/toolchain dependency |
-| L4 | `ts/capabilities/effect.ts` · `hbcli.ts` · `skeleton-check.ts` | effect interpreter (backoff retry / circuit breaker / mock interpreter) + realtime inventory bridge + OpenFlights skeleton (three-valued semantics) |
-| L5 | loopx governance | objective / gates / evidence / quota |
-
-> Full ADRs / evolution / debt ledger: [`docs/architecture.md`](docs/architecture.md) (Chinese — English versions planned for v0.1.0).
+> Interactive version: [`docs/assets/gotry-system-architecture.en.html`](docs/assets/gotry-system-architecture.en.html) (archify, showcase-validated). Layers: L2 dsh plugin · L3 `ts/src/unified.ts` kernel · L4 effect interpreter + realtime bridges · L5 loopx governance. ADRs: [`docs/architecture.md`](docs/architecture.md) (Chinese).
 
 ## Tools
 
-The plugin's 23 registered tools come in groups: **realtime retrieval** (Fliggy official channel + your own Chrome session, physically read-only) · **inventory & catalog** · the **deterministic decision engine** (`gotry_feasibility_check`; explicit flight chains via Z3) · **memory & reachability** · **artifacts** · async work-order status · the **fact gate** · **general external** search · **`gotry_doctor` self-check**.
-
-Retrieval tools stay flat — no hidden dispatch: a channel registry returns an **ordered suggestion list** (official API > user session > web fallback, filtered by per-session channel health), and the model or user chooses the next tool. Per-tool contracts, the routing diagram, web onboarding behavior, and the operator script surface: [`docs/tools.md`](docs/tools.md) (Chinese-first).
+23 registered tools in groups: realtime retrieval (Fliggy official channel + your own Chrome session, read-only) · catalog · decision engine · memory · artifacts · fact gate · external search · `gotry_doctor` self-check. No hidden dispatch — a channel registry returns an ordered suggestion list; the model or user chooses. Per-tool contracts: [`docs/tools.md`](docs/tools.md) (Chinese-first).
 
 ## Demo
 
 https://github.com/user-attachments/assets/6628c254-eba1-4017-a883-c70d22616939
 
-*Illustrative animation-harness capture of a representative, condensed transcript — not a real `gotry web` product UI E2E (sources: [demo.en.svg](docs/assets/demo.en.svg) · [demo.en.webm](docs/assets/demo.en.webm); the animated SVG plays inline where video is unsupported). Static copy below is authoritative:*
+*Illustrative animation-harness capture of a condensed transcript — not a real `gotry web` product UI E2E (sources: [SVG](docs/assets/demo.en.svg) · [webm](docs/assets/demo.en.webm)):*
 
 ```
 > Two or three days staring at Erhai Lake, leaving from Shanghai, budget 3000, annual leave — no work.
@@ -134,11 +99,11 @@ Engine verdict:
 [static-pack:estimate] G7315/G7316 priced on Jul–Aug off-season rates
 ```
 
-> Tag guide: `[skeleton:openflights]` — "this route can be flown" verified against the public route database; `[realtime:...]` — pulled live seconds ago; `[static-pack:estimate]` — off-season estimate, **verify before booking**. Tags are attached by the render layer, never by the model.
+> Tags: `[skeleton:openflights]` route verified against the public route DB · `[realtime:...]` pulled live seconds ago · `[static-pack:estimate]` estimate — **verify before booking**. Attached by the render layer, never the model.
 
 ## How Mainstream AI Answers the Same Trip
 
-GoTry's product persona is calibrated against evidence, not taste: the same real three-week multi-country workation prompt — with planted traps (no year given, a vague "some seaside town called Wan-xx", an ambiguity the user already resolved) — is fed verbatim to mainstream assistants, their answers archived word-for-word, and scored against a ground-truth rubric. Transcripts, rubric, and the contract feedback: [`docs/persona-bench/`](docs/evaluation/persona-bench/).
+The same real multi-country workation prompt — with planted traps (no year given, a vague "Wan-xx", an already-resolved ambiguity) — goes verbatim to mainstream assistants; answers are archived word-for-word and scored against a ground-truth rubric ([`docs/evaluation/persona-bench/`](docs/evaluation/persona-bench/)).
 
 | Dimension | Generic chat assistant (Kimi, 13 real turns) | OTA agent (Fliggy open platform, single turn) | GoTry contract |
 |---|---|---|---|
@@ -149,86 +114,47 @@ GoTry's product persona is calibrated against evidence, not taste: the same real
 | Structure completeness | △ decent comparison table only at turn 13 | ✓✓ full skeleton in one turn — completeness is table stakes | verified completeness (fact gate) |
 | Persona in one line | erudite but stateless chatter — the user ends up doing four jobs | a flawless-brochure OTA clerk — every section ends in a price table | trusted travel engineer: interview first, the solver decides, infeasible says infeasible |
 
-> **Evidence boundary:** this is a qualitative comparison, not a scorecard or performance claim. The Kimi and Fliggy columns summarize archived real-world transcripts with different protocols (13 turns versus one turn). The GoTry column summarizes repository behavior contracts and deterministic/fixture evidence; it is not a comparable real-world benchmark result. No ranking, uplift, or numerical positioning is asserted. Comparable benchmark evidence would require the same prompt, models, channel conditions, sample sizes, rubric, and published scoring.
+> **Evidence boundary:** a qualitative comparison, not a scorecard. The Kimi/Fliggy columns summarize archived transcripts (13 turns vs one); the GoTry column summarizes repository behavior contracts. No ranking or uplift is asserted.
 
-**Single best finding: two unrelated products derived their weekdays from the 2025 calendar.** Calendar grounding has to be a product mechanism (anchor card, assert once, never recompute) — not model luck. Cautionary deep-dive: [`docs/research/kimi-postmortem.md`](docs/research/kimi-postmortem.md).
+Single best finding: two unrelated products derived their weekdays from the 2025 calendar — calendar grounding must be a mechanism, not model luck ([postmortem](docs/research/kimi-postmortem.md)).
 
 ## Quick Start
 
-### npm (recommended)
-
 ```bash
-npx @danceiny/gotry web
-# → open http://127.0.0.1:3080 and chat: "I want three relaxing days in Dali"
-# LLM key & model: handled by the dsh host UI; nothing for gotry to ask on the CLI
+npx @danceiny/gotry web        # → http://127.0.0.1:3080
+npx @danceiny/gotry doctor     # optional-channel health check (--fix to repair)
+npx @danceiny/gotry "Two recovery days from Shenzhen, budget 3000"   # headless one-shot
 ```
 
-| Entry | Command | When |
-|---|---|---|
-| Web chat (recommended) | `npx @danceiny/gotry web` | multi-turn planning with visualized reasoning → `:3080` |
-| Headless one-shot | `npx @danceiny/gotry "Two recovery days from Shenzhen, budget 3000"` | scripts / CI / targeted debugging → stdout |
-| Dependency doctor | `npx @danceiny/gotry doctor` (`--fix` to repair) | optional channels misbehaving: checks extension / Agent-Reach / hbcli / FlyAI key / sidebar / calendar / map tools, prints exact repair guidance, writes `gotry-state/doctor-report.md` |
-
-Requires Node ≥ 22.15. LLM credentials are managed by your dsh host UI — gotry itself never asks for or echoes them; OpenAI-compatible endpoints (MiniMax / relays / self-hosted gateways) are handled by the dsh model configuration. First cold start takes 6–15 s; if port `:3080` is taken, free it first; unexpected exits leave evidence in `gotry-state/incidents.jsonl`.
-
-> **Where you run it** — any npm-compatible registry works as long as the package is synced (pin an exact version if a mirror's `latest` lags). Inside the gotry repo itself, bare-name `npx @danceiny/gotry …` fails with `sh: gotry: command not found` — use the source entry `./gotry web`. An eligible interactive launch may offer a one-time optional-capability check (`y` runs the same installers as `doctor --fix`, `n` skips; CI / non-TTY never prompt, never install). Onboarding details and the repo-side operator scripts (cost table / metrics report / channel probe): [`docs/tools.md`](docs/tools.md).
-
-### Developer source install
-
-```bash
-git clone https://github.com/Danceiny/gotry && cd gotry
-npm ci && npm --prefix ts ci                      # pinned root/TS closure
-node scripts/build-dist.mjs                       # build the JS runtime
-./gotry web                                       # in-repo entry, same UX
-```
-
-The source entry and the npm package resolve the same 230-package DeepSeek Harness `0.1.5-alpha.1` closure (exact direct dependencies; publish preverify rejects omissions, mixed versions, and ranges). Source runs keep their state under `ts/dsh-runtime/gotry-state/`; benchmark opt-in and npm-package runs use the invocation directory for isolation.
+Node ≥ 22.15. LLM keys live in the dsh host UI (OpenAI-compatible endpoints included) — gotry never asks for or echoes them. Any npm-compatible registry works; pin an exact version if a mirror's `latest` lags. Inside this repo use the source entry `./gotry web` (bare-name npx fails there). Eligible launches may offer a one-time capability check; CI / non-TTY never prompts, never installs. Onboarding details + operator scripts: [`docs/tools.md`](docs/tools.md). Source install: `npm ci && npm --prefix ts ci && node scripts/build-dist.mjs` — the same pinned DSH `0.1.5-alpha.1` closure as the npm package.
 
 ## Consent and Privacy
 
-The account-session channel reads realtime hotel/flight data from **your own logged-in Chrome**, under four hard rules:
+The account-session channel reads realtime data from **your own logged-in Chrome**, under four hard rules:
 
-1. **Login happens on the external website** — GoTry never offers, fills, or collects any password / SMS code / cookie value; it answers one boolean question — "does a login-ticket cookie exist" (cookie **names** only).
-2. **Consent card, once per session** — approval holds for the session, refusal revokes it; master switch `sessionAccess: ask|allow|off` at any time.
-3. **Physically read-only** — a ReadGuard aborts all write requests at the network layer; a captcha stops the agent and hands control back to you.
-4. **Never hijacks your browser** — retrieval/login open their own dedicated tab; routine test runs never open browser windows.
+1. **Login happens on the external website** — no passwords, SMS codes, or cookie values; cookie *names* only.
+2. **Consent card, once per session** — refusal revokes it; master switch `sessionAccess: ask|allow|off`.
+3. **Physically read-only** — a ReadGuard aborts writes at the network layer; a captcha stops the agent.
+4. **Never hijacks your browser** — dedicated tabs only; tests never open windows.
 
-One-time prerequisite: the [GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) Chrome extension (one-click, auto-updates, no setup wizard) — until installed, tools return `needs-extension` with the store link and spend nothing.
+One-time prerequisite: the [GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) extension (one-click, auto-updates) — until installed, tools return `needs-extension` with the store link and spend nothing.
 
 ## Trustworthy by Construction
 
-1. **The model translates; deterministic code decides.** The LLM never produces feasibility verdicts or arithmetic. Ordinary candidate verdicts come from TypeScript enumeration/evaluation/choice; explicit flight-chain constraints use `solveUnified` and Z3 against the extracted facts.
-2. **Every number carries a source tag** — attached by the render layer, never the model. Tags switch honestly on degradation; an estimate never poses as realtime.
-3. **No write path exists.** Booking/payment-class tools must pass WriteGate before any implementation ships; the future booking seam is already pinned by the `booking_saga_fsm.v1` edge table.
-4. **Login never touches credentials.** Login happens on the external website; GoTry reads cookie names only; consent is asked once per session and revocable.
-5. **Retrieval is physically read-only.** A ReadGuard aborts write requests at the network layer; a captcha stops the agent and hands control back to you.
-6. **Unverifiable means blocked.** The fact gate refuses to deliver any itinerary whose bookable claims cannot trace to exact-date tool results — it is never presented as a verified plan. Anchored fact/policy rows are fingerprinted against the registered facts, so edited or unknown anchors fail closed.
-7. **Prices fail closed.** Unknown models get no guessed price; the price table changes only by PR; the drift monitor reports, never auto-applies.
-8. **Your data is yours.** Product state lives under `gotry-state/`; validation paths use isolated state roots and never write the founder's real product data.
+1. **The model translates; code decides** — no LLM feasibility verdicts or arithmetic.
+2. **Every number carries a source tag** — attached by the render layer, switched honestly on degradation.
+3. **No write path exists** — booking/payment tools must pass WriteGate before they ship.
+4. **Unverifiable means blocked** — the fact gate never lets an untraceable claim ship as "verified"; anchors are fingerprinted.
+5. **Prices fail closed** — unknown model, no guessed price; the price table changes only by PR.
+6. **Your data is yours** — state under `gotry-state/`; tests run on isolated roots.
 
 ## Project Status
 
-Current release: **v0.0.1-rc.22** (npm `latest`; the `rc` dist-tag points at rc.20. Registry pull-verified 2026-09-09 against a mirror: npx install, bin resolution, and `web` startup all pass). Evaluation is at Phase 0 foundation — deterministic contracts, validators, and a cadence policy; no external benchmark scores, no spend, no uplift claims. The M4→M6 program plan is a living task graph in [`docs/design/milestone-delivery-plan.md`](docs/design/milestone-delivery-plan.md) (it records the `hotelbyte-cli` first-supplier decision for M5 contract preparation, but opens no gates); public execution and debt ownership follow [the #270 ledger contract](docs/ops/external-pr-workflow.md) §0.
+**v0.0.1-rc.22** (npm `latest`; registry pull-verified 2026-09-09). Evaluation is at Phase 0 — deterministic contracts and validators; no external scores, no uplift claims.
 
-**Working today**:
+**Working today**: deterministic choice kernel + explicit Z3 flight-chain path · realtime + account-session retrieval (typed, invocation-bound facts) · dependency doctor with scoped, approved repair · memory (motivation / wish pool / companions / timeline) on the tenant-scoped ledger · routed turn budgets with deep-planning handoff tickets · M4 opt-in evidence collector. Recent fail-closed slices: #279/#352 malformed responses, #359/#363 anchor fingerprints, #341 ground transfer, #343 IANA timezones, #338 home-city default, #254/#265/#282/#327/#329/#194 — full trail in [CHANGELOG.md](CHANGELOG.md).
 
-- **Deterministic choice kernel + explicit flight-chain Z3 path** — ordinary candidate enumeration, `evaluateChoice`, true-cost checks, per-candidate verdicts and recommendation; multi-leg flight chains go through the separate `solveUnified` Z3 path
-- **Realtime + account-session retrieval** — flights/trains/hotels (Fliggy official channel), catalogs, weather, live flight observation, route connectivity, plus Ctrip flights & hotels / 12306 trains / Dida supplier-portal rates on your own Chrome (consent-gated, physically read-only, typed invocation-bound facts; no live-availability claim beyond observed runs); realtime prices can overwrite solver prices (`GOTRY_REALTIME_PRICING=1`)
-- **Dependency doctor & extension on demand** — `npx @danceiny/gotry doctor` / `gotry_doctor`: read-only by default, scoped repair on approval via the same idempotent installers; the Session Bridge extension is offered as a clickable link when first needed (no setup wizard)
-- **Memory & reachability** — motivation profile / wish pool / companions / travel timeline on the tenant-scoped SQLite ledger; English solve output via `GOTRY_LOCALE=en`
-- **Routed turn budgets** — a deterministic, zero-LLM router classifies every turn (quick / sync / deep-planning); deep-planning hands off to a persisted background ticket (`gotry_turn_handoff.v1`, ETA ≈1h) instead of dying mid-stream
-- **M4 lifecycle evidence collector** — explicit opt-in CLI, isolated `stateRoot`, mandatory consent + HMAC key; exports feed the #223 scorer as candidate/synthetic only
-- **Recent slices & fail-closed hardening** — bounded ground-transfer slice (#341), flight/hotel anchor field fingerprint (#363), malformed supplier responses (#279/#352), policy-anchor fingerprint (#359), booking-planner & duplicate-call repairs (#282/#327), safe-dispatch diagnostics (#329), IANA timezone contract (#343), home-city default (#338), subagent/jobs id guard (#194), ledger CLI & read-only repair plan (#254), Node ≥22.15 builds (#265). Deterministic, isolated evidence each — none open M4/M5/M6 gates. Full trail: [CHANGELOG.md](CHANGELOG.md)
-
-**Open limitations** (honest list):
-
-- **M3 Exit not closed** — the real 50–200 seed-user cohort evidence is not yet accumulated; automated tests prove contracts and formulas, not business pass
-- **M4→M6 gates remain evidence-bound** — no real `observed_private` N≥5 repeat cohort has landed; M5 awaits #136 supplier authorization, M6 awaits #137 P6 approval + a signed pilot; local/fixture proof never opens these gates
-- **Hotel session adapters** — Ctrip-hotel / Meituan logged-in surfaces await real login-state backfill; flights are done
-- **#272 live evidence remains open** — only deterministic offline summary hardening (#335) has landed
-- **Interface language** — English covers the deterministic solve-output layer; the dsh host UI and dialogue surface belong to the host
-- **External benchmark generalization** — every frozen external run to date is diagnostic-only (no score, no uplift); round-by-round ledger: [`docs/evaluation/benchmark-environment-bridge.md`](docs/evaluation/benchmark-environment-bridge.md)
-- **Booking** — nothing bookable ships today; M5 opens only through WriteGate and the booking-saga FSM
+**Open limitations**: M3 Exit open (no real 50–200 cohort yet) · M4→M6 evidence-bound (#136/#137 gates; fixture proof never opens them) · Ctrip-hotel/Meituan session adapters pending · #272 live evidence open · English covers the solve-output layer only · external runs diagnostic-only · nothing bookable today (M5 via WriteGate only).
 
 <details>
 <summary>Deeper engineering state (ledger contracts / evidence contracts / milestone stance)</summary>
@@ -251,61 +177,36 @@ timeline
   M6 : B2B embedding — zero-kernel-diff sponsor plugin
 ```
 
-| # | Milestone | Scope | Status |
-|---|---|---|---|
-| M0 | Deterministic pipeline | dual engine implementations + real data packs + reconciliation | ✅ |
-| M1 | Agent form established | LLM in the loop; chat as interface; gates as choice cards | ✅ |
-| M2 | Realtime data | hotelbyte bridge + flight sources; evidence chain switches to realtime tags | ✅ |
-| M3 | MVP | minimal web face + 50–200 seed users (Erhai / Phuket scenarios) | **← current — evidence open** |
-| M4 | Memory & "next departure" | six-layer memory C-end domain; paired-cohort value evidence + explicit lifecycle collector | founder-authorized parallel; real N≥5 cohort open |
-| M5 | Transaction loop | WriteGate in production; booking / payment / refunds; first supplier target: `hotelbyte-cli` | entry-gated: M4 Exit + supplier protocol |
-| M6 | B2B embedding | traveler principal / sponsor plugin with measured zero-kernel-diff proof | entry-gated: M5 Exit + P6 founder review |
-
-The single authoritative timeline — entry/exit conditions, deliverables, and gates per milestone — is [`docs/roadmap.md`](docs/roadmap.md).
+Authoritative timeline with entry/exit gates: [`docs/roadmap.md`](docs/roadmap.md).
 
 ## Verify
 
 ```bash
-./scripts/run-all-tests.sh                     # full-stack suite (pure TS, no Python needed)
-cd ts
-npx tsx scripts/evaluation-contract-tests.ts   # evaluation Phase 0 contracts (offline)
-npx tsx scripts/evaluation-cadence-tests.ts    # deterministic cadence policy/planner
+./scripts/run-all-tests.sh    # full-stack suite (pure TS)
 ```
 
-The suite covers golden engines, dialogue replay, cross-process async work-orders, plugin smoke, realtime bridges, fatal incident observation and process guards, i18n, memory domain, the M4 lifecycle collector, the Z3 concurrency gate, the fact gate, and a packaged-consumer turn-deadline E2E, among others; the authoritative section list is whatever `scripts/run-all-tests.sh` enumerates. The packaged Web retry/cancel proof (#289) runs from `ts/` via `GOTRY_SESSION_LIVE=0 npx --no-install tsx scripts/issue-289-web-retry-e2e.ts` (needs Node 24 + local Chrome; reviewable artifacts land under `.omx/artifacts/issue-289-web-retry-e2e/`). The live session benchmark (`npx tsx scripts/sf-live-benchmark.ts --golden=static`) is opt-in, requires your connected Chrome session, and never runs in CI. For PRs, local final-SHA evidence is required; CI is additional signal, not a substitute.
+Packaged web retry/cancel proof (#289): `GOTRY_SESSION_LIVE=0 npx --no-install tsx scripts/issue-289-web-retry-e2e.ts` from `ts/`. The live session benchmark is opt-in and never runs in CI. PRs require local final-SHA evidence; CI is additional signal.
 
 ## Contributing
 
-Branch off latest `main` (`feat/ · fix/ · docs/ · chore/`), run local final-SHA typecheck + full regression, then open a Pull Request. Project process requires PR review for `main`; do not infer that GitHub branch protection has been configured. CI runs typecheck + all suites on Node 22/24 and the focused dist compatibility proof on Node 22/24/26; it is additional signal, not a replacement for local evidence. A maintainer chooses a repository-allowed merge method after checking the reviewed exact head and records the destination SHA. **Red tests never merge.** Full guide: [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports / feature suggestions: use the issue templates (search existing issues first).
+Branch off latest `main` (`feat/ · fix/ · docs/ · chore/`), keep typecheck + full regression green, open a PR. **Red tests never merge.** Guide: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## For AI Agents
 
-If you are an agent working in this repository, [`AGENTS.md`](AGENTS.md) is the binding contract — read it first. In brief:
-
-- **Sweep async work orders on entry**: `ts/gotry-state/async/*.json` without a matching `.deliverable.md` → `cd ts && npx tsx scripts/async-collect.ts <id>`.
-- **Layer discipline**: arithmetic only in the evaluate layer of `model.ts` / `unified.py`; solving only in `unified.ts` / `unified.py`; `engine.*` / `journey.*` are deprecated compatibility layers — new code must not call them. Any side change requires the full-stack regression.
-- **Never write shared state**: `ts/dsh-runtime/gotry-state/` is the founder's real product data; validate write paths with an isolated `stateRoot` only.
-- **State-sync discipline**: any commit changing the system's shape/state/debt must sync the six state faces of `architecture.md` §11 in the same commit; stage only named files — never `git add -A`.
-
-Program-level context: [`docs/gotry-master-outline.md`](docs/gotry-master-outline.md). Technical authority: [`docs/architecture.md`](docs/architecture.md).
+[`AGENTS.md`](AGENTS.md) is the binding contract: sweep async work orders on entry · arithmetic only in the evaluate layer, solving only in `unified.*` · never write shared state (`ts/dsh-runtime/gotry-state/`) · sync the six state faces of `architecture.md` §11 in the same commit · stage named files only, no `git add -A`.
 
 ## Documentation
 
 | Document | Purpose |
 |---|---|
-| [`docs/README.md`](docs/README.md) | Docs conventions & full index (taxonomy, naming, lifecycle) |
-| [`docs/architecture.md`](docs/architecture.md) | System, ADRs, evolution, debt ledger (Chinese, authoritative) |
-| [`docs/gotry-master-outline.md`](docs/gotry-master-outline.md) | Program master outline & reuse matrix |
-| [`docs/gotry-product-design.md`](docs/gotry-product-design.md) | Product design: main loop, transparency, whole-cost model |
+| [`docs/architecture.md`](docs/architecture.md) | System, ADRs, evolution, debt (Chinese, authoritative) |
 | [`docs/roadmap.md`](docs/roadmap.md) | M0–M6 timeline & current position |
 | [`docs/user-guide.md`](docs/user-guide.md) | End-user guide |
-| [`docs/tools.md`](docs/tools.md) | Tool reference: per-tool contracts, channel routing, onboarding, operator scripts (Chinese-first) |
+| [`docs/tools.md`](docs/tools.md) | Tool reference: contracts, routing, onboarding (Chinese-first) |
 | [`docs/data-sources.md`](docs/data-sources.md) | Data sources & evidence-chain policy |
-| [`docs/ops/extension-privacy.md`](docs/ops/extension-privacy.md) | Session Bridge extension privacy |
-| [`docs/research/kimi-postmortem.md`](docs/research/kimi-postmortem.md) | A real AI-travel-planning failure postmortem (cautionary tale) |
-| [`docs/evaluation/persona-bench/`](docs/evaluation/persona-bench/) | Agent-persona benchmark — same real-trip prompt answered by mainstream AIs: transcripts, scoring rubric, and the persona it shapes |
 | [`docs/release-notes.md`](docs/release-notes.md) | Release decisions per version (the "why") |
-| [`CHANGELOG.md`](CHANGELOG.md) | Machine-derived changelog (Keep a Changelog + Conventional Commits) |
+| [`CHANGELOG.md`](CHANGELOG.md) | Machine-derived changelog |
+| [`docs/README.md`](docs/README.md) | Docs conventions & full index |
 
 ## License
 
@@ -325,4 +226,4 @@ Program-level context: [`docs/gotry-master-outline.md`](docs/gotry-master-outlin
 
 **Built with**: DeepSeek Harness 0.1.5-alpha.1 (root-pinned) · Cordis · Z3 (WASM) · loopx (pipx) · hotelbyte-cli · Agent-Reach v1.5.0 · OpenFlights · TypeScript
 
-**Version baseline: `v0.0.1-rc.22` (npm `latest`).** The authoritative verification gates for the current checkout are enumerated by `scripts/run-all-tests.sh`; release flow: `scripts/publish-npm.sh`.
+**Version baseline: `v0.0.1-rc.22` (npm `latest`).** Verification gates: `scripts/run-all-tests.sh`; release flow: `scripts/publish-npm.sh`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 > **身体和灵魂,更多旅行,更少旅游。**
 > *Body and soul — more travel, less tourism.*
 
-**GoTry 是「从出发到下一次出发」的 AI 旅行 Agent**:你用一句话说想去哪、为什么想出发;它先问清楚你的工作窗口和已订资源,再给你一份确定性的行程判决——普通候选由 TypeScript 内核枚举并评估,显式航班链路径才使用 Z3,不是模型猜的。
+**GoTry 是「从出发到下一次出发」的 AI 旅行 Agent**:你说想去哪、为什么想出发;它先问清你的工作窗口,再给你一份确定性判决——普通候选由 TypeScript 内核枚举评估,显式航班链路径用 Z3,不是模型猜的。
 
 [![GitHub Stars](https://img.shields.io/github/stars/Danceiny/gotry?style=social)](https://github.com/Danceiny/gotry/stargazers)
 [![CI](https://github.com/Danceiny/gotry/actions/workflows/ci.yml/badge.svg)](https://github.com/Danceiny/gotry/actions/workflows/ci.yml)
@@ -14,21 +14,18 @@
 [![Node](https://img.shields.io/badge/node-%E2%89%A5%2022.15-blue)](https://www.npmjs.com/package/@danceiny/gotry)
 [![Docs](https://img.shields.io/badge/docs-architecture.md-blue)](docs/architecture.md)
 
-**[它做什么](#它做什么)** · **[工作原理](#工作原理)** · **[工具](#工具)** · **[一段对话](#一段对话)** · **[同题横评](#与主流-ai-同题横评产品人格从哪来)** · **[快速开始](#快速开始)** · **[账号会话:授权与隐私](#账号会话授权与隐私)** · **[构造上可信](#构造上可信)** · **[状态与限制](#状态与限制)** · **[路线图](#路线图)** · **[给 AI Agent](#给-ai-agent)** · **[文档](#文档)** · **[License](#license)** · **[Star History](#star-history)**
-
-> **新读者提示**:一条命令就能感受差别——`npx @danceiny/gotry web`,打开 `http://127.0.0.1:3080`,说一句「我想去大理躺三天」。Agent 会先访谈你;然后由求解器(而非模型)判定什么可行。完整走查见 [`docs/user-guide.md`](docs/user-guide.md)。
+**[它做什么](#它做什么)** · **[工作原理](#工作原理)** · **[一段对话](#一段对话)** · **[同题横评](#与主流-ai-同题横评产品人格从哪来)** · **[快速开始](#快速开始)** · **[隐私](#账号会话授权与隐私)** · **[状态](#状态与限制)** · **[路线图](#路线图)** · **[文档](#文档)**
 
 ## 它做什么
 
-GoTry 把「想去哪」变成「能不能——怎么去、真实代价是多少」。当答案是「这周末不行」时,目的地连同成行条件进愿望池接住,而不是被丢掉。
+把「想去哪」变成「能不能——怎么去、真实代价是多少」。答案是「这周末不行」时,目的地带显式召回条件进愿望池,而不是被丢掉。
 
-- **给旅行者** —— 一个先问对人问题(工作窗口/已订资源/出发城市/预算)的对话规划器,然后逐目的地给判决:可行/不可行、为什么、以及**让它可行的最小改动**。
-- **给 Agent 工程师** —— 一个「LLM 只负责听懂、翻译、解释」的落地样本:普通候选沿确定性的 TypeScript 枚举、评估、选择路径;独立的显式航班链路径使用 Z3。交付物里每个数字都带来源标签,写操作从设计上就是被闸住的。
-- **证据内建** —— 估算绝不冒充实时。标签由渲染层附加、模型无权染指;降级时标签如实更换。回溯不到 exact-date 工具结果的可下单 claim,交付前就被拦下。
+- **给旅行者** —— 先问对人问题(工作窗口 / 出发城市 / 预算),再逐目的地回答:可行与否、为什么、**让它可行的最小改动**。
+- **给 Agent 工程师** —— LLM 只负责听懂、翻译、解释;内核负责枚举、评估、选择。交付的每个数字带来源标签;写操作从设计上被闸住。
 
 ## 工作原理
 
-一次规划是一条流水线:模型只占语言密集的两端;普通候选路径由确定性的 TypeScript 内核处理,显式航班链路径使用 Z3:
+模型只占语言密集的两端,数值全部归确定性代码:
 
 ```mermaid
 flowchart LR
@@ -62,28 +59,7 @@ flowchart LR
   class E,F,G,H,I gate;
 ```
 
-在 GoTry 的回答里会遇到的词汇:
-
-- **证据标签** —— `[骨架:openflights]` 航线存在性经公开航线库校验;`[实时API:...]` 刚从实时接口拉回数秒;`[静态包:估算]` 调研估算——非实时,下单前请核实。降级时标签如实更换。
-- **门到门全成本** —— 票价之外,这段旅程真正从你身上拿走的东西:跨时区的真实时长、早起惩罚、接驳、落地时的精力余额。
-- **愿望池** —— 「下一次出发」的存储。装不下的憧憬带显式条件(如「5 天+、淡季」)入池,条件满足时被召回。
-- **事实闸** —— 行程产物交付前闸:每条可下单 claim(航班号/时刻/机场/价格/政策)必须回溯到 exact-date 工具结果;回溯不到即 blocked——绝不宣称「已验证方案」。航班与铁路 claim 分开归类;事实锚点带指纹,价格/政策在篡改或漂移时一律 fail closed([#273](https://github.com/Danceiny/gotry/issues/273) 及关联 issue)。不声称实时可售,也不构成 M5/M6 入场证据。
-
-愿望池生命周期:
-
-```mermaid
-stateDiagram-v2
-  direction LR
-  [*] --> 已访谈: 动机落盘(evidence 强制)
-  已访谈 --> 可行: 确定性选择判决——可行
-  已访谈 --> 愿望池: 今天装不下
-  愿望池 --> 愿望池: 召回被否——指名通道宕机
-  愿望池 --> 已召回: 条件满足——窗口 · 预算 · 淡季
-  已召回 --> 已访谈: 带实时数据重新求解
-  可行 --> [*]: 事实闸交付
-```
-
-架构五层:
+架构——同步主链从对话经内核到事实闸,外加状态与异步控制面、只读数据层:
 
 <a href="docs/assets/gotry-system-architecture.html">
   <picture>
@@ -93,28 +69,17 @@ stateDiagram-v2
   </picture>
 </a>
 
-> 由 [`docs/assets/gotry-system-architecture.archify.json`](docs/assets/gotry-system-architecture.archify.json) 经 [archify](https://github.com/tt-a1i/archify) 生成(showcase 校验:9/9 构件检查 + 浏览器实测)。本地打开 [`docs/assets/gotry-system-architecture.html`](docs/assets/gotry-system-architecture.html) 可得交互版——引导视图 · 缩放平移 · 关系追踪。同步主链明确区分普通 TypeScript 候选枚举/评估/选择,以及独立的显式航班链 `solveUnified` Z3 路径。
-
-| 层 | 模块 | 角色 |
-|---|---|---|
-| L2 | `ts/src/index.ts`(dsh 插件) | 注册 21 工具,挂时间锚点/记忆 brief 变量;execute 异常隔离 + 授权闸 + 每轮工具预算 + 进程护栏 |
-| L3 | `ts/src/unified.ts` | 普通候选枚举/评估/选择; `solveUnified` 是独立航班链 Z3 路径。`py/gotry_feasibility/` 仅是历史对照 oracle,与产品/运行时/工具链零依赖 |
-| L4 | `ts/capabilities/effect.ts` · `hbcli.ts` · `skeleton-check.ts` | 效应解译层(退避重试/断路器/mock 解译器)+ 实时库存桥 + OpenFlights 骨架(三值语义) |
-| L5 | loopx 治理面 | objective / gates / evidence / quota |
-
-> 完整 ADR / 演进 / 债务清单:[`docs/architecture.md`](docs/architecture.md)(英文版计划 v0.1.0)。
+> 交互版:[`docs/assets/gotry-system-architecture.html`](docs/assets/gotry-system-architecture.html)(archify 生成,showcase 校验通过)。分层:L2 dsh 插件 · L3 `ts/src/unified.ts` 内核 · L4 效应解译 + 实时桥 · L5 loopx 治理。ADR:[`docs/architecture.md`](docs/architecture.md)。
 
 ## 工具
 
-插件的 23 个注册工具分组为:**实时检索**(飞猪官方通道 + 你本人登录态 Chrome,物理只读)· **库存与目录** · **确定性判定引擎**(`gotry_feasibility_check`;显式航班链走 Z3)· **记忆与触达** · **产物** · 异步工单状态 · **事实闸** · **通用外部**检索 · **`gotry_doctor` 自检**。
-
-检索工具面保持平铺、无隐藏派发:通道注册表只返回**有序建议列表**(官方 API > 用户会话 > 网页兜底,按会话健康面过滤),由模型或用户选择下一工具。逐工具契约、路由图、web onboarding 行为与运维脚本面:[`docs/tools.md`](docs/tools.md)。
+23 个注册工具分组:实时检索(飞猪官方通道 + 你本人登录态 Chrome,只读)· 目录 · 判定引擎 · 记忆 · 产物 · 事实闸 · 外部检索 · `gotry_doctor` 自检。无隐藏派发——通道注册表只返回有序建议列表,由模型或用户选择。逐工具契约:[`docs/tools.md`](docs/tools.md)。
 
 ## 一段对话
 
 https://github.com/user-attachments/assets/6d537bb7-7992-4cc7-8e89-6f111ef6793b
 
-*说明性 animation-harness 对代表性精简对话的录制——不是 `gotry web` 产品 UI 的真实 E2E(源文件:[demo.zh-CN.svg](docs/assets/demo.zh-CN.svg) · [demo.zh-CN.webm](docs/assets/demo.zh-CN.webm);不支持视频的环境下动画 SVG 亦可内联播放)。下方静态文本为准:*
+*说明性 animation-harness 对精简对话的录制——不是 `gotry web` 产品 UI 的真实 E2E(源文件:[SVG](docs/assets/demo.zh-CN.svg) · [webm](docs/assets/demo.zh-CN.webm)):*
 
 ```
 > 我想去洱海边发呆两三天,上海出发,预算 3000,年假别让我办公。
@@ -134,11 +99,11 @@ GoTry: 收到。先把约束记下来——
 [静态包:估算] G7315/G7316 价格按 7-8 月淡季估算
 ```
 
-> 标签导读:`[骨架:openflights]`——"这条航线能飞"已被公开航线数据校验;`[实时API:*]`——刚从实时接口拉回的当下数据;`[静态包:估算]`——淡季档估算,**订前核实**。标签由渲染层附加,模型无权染指。
+> 标签:`[骨架:openflights]` 航线经公开航线库校验 · `[实时API:*]` 刚从实时接口拉回 · `[静态包:估算]` 估算,**订前核实**。标签由渲染层附加,模型无权染指。
 
 ## 与主流 AI 同题横评(产品人格从哪来)
 
-GoTry 的产品人格不靠拍脑袋:同一段真实的跨国 workation 行程 prompt(埋了考点——不给年份、模糊指代「万xx」、用户已自行消解的歧义)逐字投喂各家主流 AI,回答逐字存档、对照地面真值打分,再反向校准行为契约。transcript、评分卡与契约反哺:[`docs/persona-bench/`](docs/evaluation/persona-bench/README.md)。
+同一段真实的跨国 workation prompt(埋了考点:不给年份、模糊指代「万xx」、用户已自行消解的歧义)逐字投喂各家主流 AI,回答逐字存档、对照地面真值打分([`docs/evaluation/persona-bench/`](docs/evaluation/persona-bench/README.md))。
 
 | 维度 | 通用助手(Kimi,真实 13 轮) | OTA Agent(飞猪开放平台,单轮) | GoTry 契约 |
 |---|---|---|---|
@@ -149,86 +114,47 @@ GoTry 的产品人格不靠拍脑袋:同一段真实的跨国 workation 行程 p
 | 结构完整性 | △ 第 13 轮才长出像样的对比表 | ✓✓ 单轮骨架最全——完整是基本盘 | 验证过的完整(事实闸) |
 | 人格一句话 | 博学但无状态的聊天者——用户被迫干四份工 | 版式完美的 OTA 导购——每段止于价格表 | 可信赖的行程工程师:访谈先行、求解器判决、不可行明说 |
 
-> **证据边界:**这是定性比较,不是分数表或性能声明。Kimi 与飞猪两列来自存档的真实世界 transcript,协议并不对称(Kimi 13 轮、飞猪单轮)。GoTry 一列总结仓库行为契约与确定性/fixture 证据,不是可比的真实世界 benchmark 结果。这里不主张排名、提升或数值定位。可比 benchmark 需要相同 prompt、模型、通道条件、样本量、评分规约与公开评分。
+> **证据边界:**这是定性比较,不是分数表。Kimi/飞猪两列来自存档 transcript(13 轮 vs 单轮);GoTry 一列是仓库行为契约。不主张排名或提升。
 
-**单条最有价值的发现:两家互不相关的产品,要自己算的星期全落在 2025 年历上**——日历锚定必须是产品机制(锚点卡、一次断言、永不重算),不是模型运气。反面教材全文:[`docs/research/kimi-postmortem.md`](docs/research/kimi-postmortem.md)。
+单条最有价值的发现:两家互不相关的产品,星期全落在 2025 年历上——日历锚定必须是产品机制,不是模型运气([复盘全文](docs/research/kimi-postmortem.md))。
 
 ## 快速开始
 
-### npm(推荐)
-
 ```bash
-npx @danceiny/gotry web
-# → 浏览器打开 http://127.0.0.1:3080,说「我想去大理躺三天」
-# LLM key & 模型:由 dsh 宿主 UI 配;gotry 在 CLI 层完全不出声,不要求也不回显任何凭证
+npx @danceiny/gotry web        # → 浏览器打开 http://127.0.0.1:3080
+npx @danceiny/gotry doctor     # 可选渠道体检(--fix 补装)
+npx @danceiny/gotry "我想从深圳休整两天,预算 3000"   # headless 一问一答
 ```
 
-| 入口 | 命令 | 什么时候用 |
-|---|---|---|
-| Web 对话(推荐) | `npx @danceiny/gotry web` | 持续多轮规划,看推理可视化 → `:3080` |
-| headless 一问一答 | `npx @danceiny/gotry "我想从深圳休整两天,预算 3000"` | 脚本 / CI / 定向调试 → stdout |
-| 依赖体检 | `npx @danceiny/gotry doctor`(`--fix` 补装) | 可选渠道不好使时:体检扩展 / Agent-Reach / hbcli / FlyAI key / sidebar / calendar / 地图工具,逐项给精确修复指引,报告落 `gotry-state/doctor-report.md` |
-
-前置:Node ≥ 22.15。LLM 凭证由 dsh 宿主 UI 配,OpenAI 兼容端点(MiniMax/中转/自建网关)走 dsh 的模型设置;首启 6–15 秒属正常冷启动;`:3080` 被占先腾端口;异常退出留证据到 `gotry-state/incidents.jsonl`(不静默)。
-
-> **运行位置** —— 任何 npm 兼容 registry 皆可(镜像 `latest` 滞后时钉精确版本)。在 gotry 仓内跑裸名 `npx @danceiny/gotry …` 会报 `sh: gotry: command not found`——请走源码入口 `./gotry web`。符合条件的交互式启动可能提供一次可选能力检查(`y` 复用 `doctor --fix` 的幂等安装器,`n` 跳过;CI / 非 TTY 不询问也不安装)。onboarding 细节与仓内运维脚本(成本表 / 指标报告 / 通道探针)见 [`docs/tools.md`](docs/tools.md)。
-
-### 开发者源码安装
-
-```bash
-git clone https://github.com/Danceiny/gotry && cd gotry
-npm ci && npm --prefix ts ci                      # 锁定的 root/TS 依赖闭包
-node scripts/build-dist.mjs                       # 构建 JS runtime
-./gotry web                                       # 仓内入口,与 npm 形态同 UX
-```
-
-源码入口与 npm 包解析同一组 230 个精确直接依赖的 DSH `0.1.5-alpha.1` closure(publish preverify 拒绝漏钉、混版和 range)。源码运行状态落在 `ts/dsh-runtime/gotry-state/`;benchmark opt-in 与 npm 包运行用调用目录隔离。
+前置 Node ≥ 22.15。LLM key 由 dsh 宿主 UI 配(OpenAI 兼容端点同),gotry 不问也不回显。任何 npm 兼容 registry 皆可;镜像 `latest` 滞后时钉精确版本。仓内请走源码入口 `./gotry web`(裸名 npx 在仓内会失败)。符合条件的启动可能提供一次可选能力检查;CI / 非 TTY 不询问、不安装。onboarding 细节与运维脚本:[`docs/tools.md`](docs/tools.md)。源码安装:`npm ci && npm --prefix ts ci && node scripts/build-dist.mjs`——与 npm 包同一组钉死的 DSH `0.1.5-alpha.1` closure。
 
 ## 账号会话:授权与隐私
 
-账号会话通道用**你本人已登录的 Chrome**读酒店/机票实时数据,四条 hard 规则:
+账号会话通道用**你本人已登录的 Chrome** 读实时数据,四条 hard 规则:
 
-1. **登录在外部网站完成** —— gotry 从不提供、不代填、不收集任何密码/验证码/cookie 值;只回答一个布尔问题(只读 cookie **名字**)。
-2. **授权卡,每会话一次** —— 批准后会话内记住,拒绝即本会话吊销;总闸 `sessionAccess: ask|allow|off` 随时可关。
-3. **物理只读** —— ReadGuard 在网络层中止一切写请求;遇验证码立即停、交还给你。
-4. **绝不劫持你的浏览器** —— 检索/登录只开独立标签页;例行测试永不自动开浏览器窗。
+1. **登录在外部网站完成** —— 不碰密码、验证码、cookie 值;只读 cookie **名字**。
+2. **授权卡,每会话一次** —— 拒绝即吊销;总闸 `sessionAccess: ask|allow|off`。
+3. **物理只读** —— ReadGuard 在网络层中止写请求;遇验证码立即停。
+4. **绝不劫持你的浏览器** —— 只开独立标签页;测试永不自动开窗。
 
-前置(一次性):[GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) Chrome 商店一键装(自动更新,无 setup wizard);未安装时工具返回 `needs-extension` 并附商店链接,不消耗执行配额。
+前置(一次性):[GoTry Session Bridge](https://chromewebstore.google.com/detail/gotry-session-bridge/oeajpiccmonococjcegddlooeeohlbgd) 扩展(一键装、自动更新);未安装时工具返回 `needs-extension` 并附链接,不消耗配额。
 
 ## 构造上可信
 
-1. **模型只翻译,确定性代码才判决** —— LLM 永远不产出可行性判决与算术;普通候选由 TypeScript 枚举/评估/选择路径处理,显式航班链约束由 `solveUnified` 和 Z3 基于抽取事实计算。
-2. **每个数字带来源标签** —— 由渲染层附加,模型无权染指;降级时如实更换,估算绝不冒充实时。
-3. **不存在写路径** —— 预订/支付类工具必须先过 WriteGate 才允许实现;未来的预订缝已被 `booking_saga_fsm.v1` 边表钉住。
-4. **登录永不碰凭证** —— 登录发生在外部网站;gotry 只读 cookie 名;授权每会话问一次、可吊销。
-5. **检索物理只读** —— ReadGuard 在网络层中止写请求;验证码让 agent 停下、把控制权交还给你。
-6. **回溯不到就是 blocked** —— 事实闸拒绝交付任何可下单 claim 无法回溯到 exact-date 工具结果的行程——绝不宣称「已验证方案」。锚定的事实/政策行与注册事实做指纹比对,篡改或未知锚点一律 fail closed。
-7. **价格 fail-closed** —— 未知模型不猜价;价表只经 PR 变更;漂移监测只报告、永不自动 apply。
-8. **你的数据是你的** —— 产品状态在 `gotry-state/`;自动化测试与 smoke 用隔离 state root,永不写创始人的真实产品数据。
+1. **模型只翻译,代码才判决** —— LLM 不产出可行性判决与算术。
+2. **每个数字带来源标签** —— 渲染层附加,降级如实更换。
+3. **不存在写路径** —— 预订/支付类工具必须先过 WriteGate。
+4. **回溯不到就是 blocked** —— 无法回溯到 exact-date 工具结果的 claim 绝不交付为「已验证」;锚点带指纹。
+5. **价格 fail-closed** —— 未知模型不猜价;价表只经 PR 变更。
+6. **你的数据是你的** —— 状态在 `gotry-state/`;测试用隔离 state root。
 
 ## 状态与限制
 
-当前版本:**v0.0.1-rc.22**(npm `latest`;`rc` dist-tag 指 rc.20;2026-09-09 镜像 registry 回拉实测:npx 安装 / bin 解析 / web 启动全通)。评测处于 Phase 0 基座——确定性合同、校验器与节奏策略;无外部 benchmark 分数、无花费、无 uplift 声明。M4→M6 程序计划是 [`docs/design/milestone-delivery-plan.md`](docs/design/milestone-delivery-plan.md) 里的活任务图(记录了 M5 合同准备的 `hotelbyte-cli` 首选供应商决策,但不打开任何 gate);公开执行与债务归属按 [#270 台账合同](docs/ops/external-pr-workflow.md) §0。
+当前版本:**v0.0.1-rc.22**(npm `latest`;2026-09-09 镜像 registry 回拉实测通过)。评测处于 Phase 0——确定性合同与校验器;无外部分数、无 uplift 声明。
 
-**今天可用**(全栈回归全绿;每项都有确定性测试):
+**今天可用**:确定性选择内核 + 显式 Z3 航班链路径 · 实时 + 账号会话检索(typed、调用绑定事实)· 依赖体检(批准后范围修复)· 记忆(动机 / 愿望池 / 同行人 / 时间线)落租户作用域账本 · 按任务路由的回合预算(deep-planning 转后台工单)· M4 opt-in 证据采集器。近期 fail-closed 切片:#279/#352 malformed 响应、#359/#363 锚点指纹、#341 地面接驳、#343 IANA 时区、#338 常住地、#254/#265/#282/#327/#329/#194——完整轨迹见 [CHANGELOG.md](CHANGELOG.md)。
 
-- **确定性选择内核 + 显式航班链 Z3 路径** —— 普通候选枚举/`evaluateChoice`/真成本检查/逐候选判决与推荐;多段航班链走独立的 `solveUnified` Z3 路径
-- **实时 + 账号会话检索** —— 机票/火车/酒店(飞猪官方通道)、目录、天气、航班观测、通航性校验;外加你本人登录态 Chrome 上的携程机票/酒店、12306 火车、Dida 供应商门户实时价(授权闸 + 物理只读 + typed 调用绑定事实;不作超出观测口径的实时可售声明);实时票价可覆写求解价(`GOTRY_REALTIME_PRICING=1`)
-- **依赖体检与扩展按需装** —— `npx @danceiny/gotry doctor` / `gotry_doctor`:默认只读,批准后按既有幂等安装器做范围修复;Session Bridge 扩展在首次需要时以可点链接给出(无 setup wizard)
-- **记忆与触达** —— 动机画像 / 愿望池 / 同行人 / 旅行时间线,由租户作用域 SQLite 账本持久化;`GOTRY_LOCALE=en` 切英文求解输出
-- **按任务路由的回合预算** —— 确定性零 LLM 路由器分类 quick / sync / deep-planning;deep-planning 转后台落 `gotry_turn_handoff.v1` 工单(ETA 约 1 小时)而不是让会话流死掉
-- **M4 lifecycle 证据采集器** —— 显式 opt-in、隔离 `stateRoot`、consent + HMAC key 必需;导出只作为 #223 scorer 的 candidate/synthetic 输入
-- **近期切片与 fail-closed 加固** —— 有界地面接驳(#341)、航班/酒店锚点字段指纹(#363)、供应商 malformed 响应(#279/#352)、政策锚点全文指纹(#359)、booking planner 与重复调用修复(#282/#327)、安全派发诊断(#329)、IANA 时区合同(#343)、常住地软默认(#338)、子代理/jobs id 安全闸(#194)、账本 CLI 与只读修复计划(#254)、Node ≥22.15 构建兼容(#265)。每项均为确定性隔离证据——均不打开 M4/M5/M6 gate。完整轨迹见 [CHANGELOG.md](CHANGELOG.md)
-
-**已知限制**(诚实清单):
-
-- **M3 Exit 未关闭** —— 真实种子用户证据(50–200 人 cohort)尚未积累;自动化测试证明的是合同与公式,不是 business pass
-- **M4→M6 真实证据门仍开放** —— 真实 `observed_private` N≥5 repeat cohort 未落地;M5 等 #136 供应协议/内部授权,M6 等 #137 的 P6 批准与签约试点;本地或 fixture 证明永不打开这些 gate
-- **酒店会话适配** —— 携程酒店/美团登录态面等实测回填;机票已通
-- **#272 实时证据仍开放** —— 仅落地确定性离线摘要加固(#335)
-- **界面语言** —— 英文仅覆盖求解确定性输出层;dsh 宿主界面与对话面属宿主/校准件
-- **外部 benchmark 泛化** —— 迄今所有冻结外部运行均仅 diagnostic(无分数、无 uplift 声明);逐轮台账见 [`docs/evaluation/benchmark-environment-bridge.md`](docs/evaluation/benchmark-environment-bridge.md)
-- **预订** —— 今天没有任何可下单路径;M5 只经 WriteGate 与 booking-saga 状态机启封
+**已知限制**:M3 Exit 未关闭(真实 50–200 人 cohort 未积累)· M4→M6 证据门(#136/#137;fixture 证明永不开启)· 携程酒店/美团会话面待回填 · #272 实时证据未收口 · 英文仅覆盖求解输出层 · 外部运行均仅 diagnostic · 今天没有可下单路径(M5 只经 WriteGate 启封)。
 
 <details>
 <summary>更深的工程状态(账本合同 / 证据合同 / 里程碑口径)</summary>
@@ -251,61 +177,36 @@ timeline
   M6 : B2B 包裹——内核零改动的 sponsor 插件
 ```
 
-| # | 里程碑 | 范围 | 状态 |
-|---|---|---|---|
-| M0 | 确定性管道 | 引擎双实现 + 真实数据包 + 对账框架 | ✅ |
-| M1 | Agent 形态成立 | LLM 进环;对话即界面;gates 选择题 | ✅ |
-| M2 | 实时数据 | hotelbyte 桥 + 航班源;证据链换实时标签 | ✅ |
-| M3 | 最小可用产品 | 最小 Web 面 + 50–200 种子用户(洱海/普吉场景) | **← 当前 —— evidence 未收口** |
-| M4 | 记忆与「下一次出发」 | 六层记忆 C 端域;paired-cohort 价值证据 + 显式 lifecycle collector | founder 授权并行;真实 N≥5 cohort 未收口 |
-| M5 | 交易闭环 | WriteGate 上生产;预订 / 支付 / 退改;首选供应商目标 `hotelbyte-cli` | entry gate 启封:M4 Exit + 供应协议 |
-| M6 | B2B 包裹 | principal/sponsor 插件,内核零改动 | entry gate 启封:M5 Exit + P6 创始人评审 |
-
-唯一权威时间线(逐里程碑的进入/退出条件、交付物与 gate):[`docs/roadmap.md`](docs/roadmap.md)。
+唯一权威时间线(逐里程碑进入/退出条件与 gate):[`docs/roadmap.md`](docs/roadmap.md)。
 
 ## 跑测试
 
 ```bash
-./scripts/run-all-tests.sh                     # 全栈套件(纯 TS,无 Python 依赖)
-cd ts
-npx tsx scripts/evaluation-contract-tests.ts   # 评测 Phase 0 合同(离线)
-npx tsx scripts/evaluation-cadence-tests.ts    # 确定性节奏策略/planner
+./scripts/run-all-tests.sh    # 全栈套件(纯 TS)
 ```
 
-套件覆盖金标准引擎、对话重放、跨进程异步工单、插件 smoke、实时桥、事故观测与进程护栏、i18n、记忆域、M4 lifecycle collector、Z3 并发闸、事实闸、打包消费者回合截止 E2E 等;权威分节以 `scripts/run-all-tests.sh` 实际枚举为准。打包 Web 重试/取消证明(#289)在 `ts/` 下经 `GOTRY_SESSION_LIVE=0 npx --no-install tsx scripts/issue-289-web-retry-e2e.ts` 运行(需 Node 24 + 本机 Chrome;可审产物落 `.omx/artifacts/issue-289-web-retry-e2e/`)。真实会话 benchmark(`npx tsx scripts/sf-live-benchmark.ts --golden=static`)为 opt-in,需你的 Chrome 会话扩展在线,永不进 CI。PR 要求本地 final-SHA 证据;CI 是附加信号,不是替代。
+打包 Web 重试/取消证明(#289):`cd ts && GOTRY_SESSION_LIVE=0 npx --no-install tsx scripts/issue-289-web-retry-e2e.ts`。真实会话 benchmark 为 opt-in,永不进 CI。PR 要求本地 final-SHA 证据;CI 是附加信号。
 
 ## 参与开发
 
-从最新 `main` 切出 `feat/ · fix/ · docs/ · chore/` 分支,本地全栈绿后开 Pull Request——`main` 不直接推。CI 在 Node 22/24 跑 typecheck + 全部套件，在 Node 22/24/26 跑 focused dist 兼容闸；维护者核对被审 exact head 后选择仓库允许的合入方式,并记录 destination SHA。**测试红着不许合。** 完整指南:[CONTRIBUTING.md](CONTRIBUTING.md)。Bug/功能建议:用 issue 模板(先搜既有 issue)。
+从最新 `main` 切 `feat/ · fix/ · docs/ · chore/` 分支,typecheck + 全栈回归全绿后开 PR。**测试红着不许合。** 指南:[CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 给 AI Agent
 
-如果你是在本仓工作的 agent,[`AGENTS.md`](AGENTS.md) 是绑定契约,先读它。要点:
-
-- **入场先清扫异步工单**:`ts/gotry-state/async/*.json` 无同名 `.deliverable.md` → `cd ts && npx tsx scripts/async-collect.ts <id>`。
-- **分层纪律**:算术只在 `model.ts` / `unified.py` 的 evaluate 层;求解只在 `unified.ts` / `unified.py`;`engine.*` / `journey.*` 是 deprecated 兼容层,新代码不得调用。改任何一侧必须跑全栈回归。
-- **绝不写共享状态**:`ts/dsh-runtime/gotry-state/` 是创始人真实产品数据;验证写路径只用隔离 `stateRoot`。
-- **状态同步纪律**:任何改变系统形态/状态/债务的提交,必须在同一提交内同步 `architecture.md` §11 六状态面;只暂存具名文件——禁止 `git add -A`。
-
-程序层语境:[`docs/gotry-master-outline.md`](docs/gotry-master-outline.md)。技术权威面:[`docs/architecture.md`](docs/architecture.md)。
+[`AGENTS.md`](AGENTS.md) 是绑定契约:入场先清扫异步工单 · 算术只在 evaluate 层、求解只在 `unified.*` · 绝不写共享状态(`ts/dsh-runtime/gotry-state/`)· 同提交同步 `architecture.md` §11 六状态面 · 只暂存具名文件,禁止 `git add -A`。
 
 ## 文档
 
 | 文档 | 内容 |
 |---|---|
-| [`docs/README.md`](docs/README.md) | 文档规范与总索引(目录税则 · 命名 · 生命周期) |
-| [`docs/architecture.md`](docs/architecture.md) | 系统 / ADR / 演进 / 债务清单(中文,权威) |
-| [`docs/gotry-master-outline.md`](docs/gotry-master-outline.md) | 总纲:工作分解 · 复用矩阵 |
-| [`docs/gotry-product-design.md`](docs/gotry-product-design.md) | 产品设计:主循环 · 透明机制 · 全成本模型 |
+| [`docs/architecture.md`](docs/architecture.md) | 系统 / ADR / 演进 / 债务(权威) |
 | [`docs/roadmap.md`](docs/roadmap.md) | M0–M6 时间线与当前位置 |
 | [`docs/user-guide.md`](docs/user-guide.md) | 终端用户使用指南 |
-| [`docs/tools.md`](docs/tools.md) | 工具参考面:逐工具契约 · 通道路由 · onboarding · 运维脚本 |
+| [`docs/tools.md`](docs/tools.md) | 工具参考面:契约 · 路由 · onboarding |
 | [`docs/data-sources.md`](docs/data-sources.md) | 数据源与证据链政策 |
-| [`docs/ops/extension-privacy.md`](docs/ops/extension-privacy.md) | Session Bridge 扩展隐私 |
-| [`docs/research/kimi-postmortem.md`](docs/research/kimi-postmortem.md) | 一次真实 AI 旅行规划失败复盘(反面教材) |
-| [`docs/evaluation/persona-bench/`](docs/evaluation/persona-bench/) | Agent 产品人格横评——同一真实行程 prompt 的各家回答存档、评分卡与人格提炼 |
 | [`docs/release-notes.md`](docs/release-notes.md) | 逐版本发布决策(「为什么」) |
-| [`CHANGELOG.md`](CHANGELOG.md) | 机器衍生的变更日志(Keep a Changelog + Conventional Commits) |
+| [`CHANGELOG.md`](CHANGELOG.md) | 机器衍生变更日志 |
+| [`docs/README.md`](docs/README.md) | 文档规范与总索引 |
 
 ## License
 
@@ -325,7 +226,7 @@ npx tsx scripts/evaluation-cadence-tests.ts    # 确定性节奏策略/planner
 
 **Built with**: DeepSeek Harness 0.1.5-alpha.1 (root-pinned) · Cordis · Z3 (WASM) · loopx (pipx) · hotelbyte-cli · Agent-Reach v1.5.0 · OpenFlights · TypeScript
 
-**版本基线:`v0.0.1-rc.22`(npm `latest`)。** 当前 checkout 的权威验证闸以 `scripts/run-all-tests.sh` 实际枚举为准;发布流程见 `scripts/publish-npm.sh`。
+**版本基线:`v0.0.1-rc.22`(npm `latest`)。** 验证闸:`scripts/run-all-tests.sh`;发布流程:`scripts/publish-npm.sh`。
 
 ---
 


### PR DESCRIPTION
## 为什么

#369(二轮精简)已合,创始人继续反馈:**还是太长,遣词造句也要精简,至少再压 50%**;并指出开篇句 "working window and bookings" 权重与时序不对——GoTry 自己将具备用户确认的预订能力(M5 WriteGate),不该把"已订资源"放进第一句定位里。

## 改了什么(纯文档,2 文件)

- **再砍近半**:EN 31.3K→16.4K 字符(相对最初 56.7K 累计 −71%),ZH 27.6K→15.1K(累计 −57%);行数 EN 328→229、ZH 335→236。
- **全书短句化**:逐节重写为短句;词汇表、愿望池状态图、分层表、Roadmap 表格让位给 docs(Roadmap 只留 mermaid)。
- **开篇句去 bookings**:EN/ZH 首句只保留"问清你的工作窗口",已订资源降级为 mermaid 访谈图的一个输入节点,不再进定位句。
- **逐字保留**:badges、流程 mermaid、架构图 `<picture>` 块(EN 页用英文标注资产,ZH 页用中文标注资产)、演示视频内联 URL、demo transcript、benchmark 表、证据边界 blockquote、timeline mermaid、star-history。

## 验证

- `git diff origin/main HEAD --stat` = 仅 README.md + README.zh-CN.md(+86/−284),零代码面。
- `cd ts && npx tsc --noEmit` 在最终 SHA `09a7c8a` 绿。
- 全栈回归在同分支二轮提交 `ff2c2dd` 上跑过:除已知 pre-existing flake(suite 48 `benchmark-environment-bridge-e2e`,独立重跑通过)外全绿;三轮提交仅动 README,不影响运行时。
- GFM 渲染抽查:user-attachments 视频 URL 在渲染结果中保留、相对链接可解析、每文件 2 个 mermaid 块完好。
