### PR TITLE
feat(session): dida 适配器 v2——加载态推荐流校准 + CDP 多响应收集

### DIFF
--- a/extension/content-main.js
+++ b/extension/content-main.js
@@ -26,7 +26,7 @@
   var TRAIN_HINT_RE = /leftTicket\/query/i
   /** Dida 供应商门户(2026-09-09 实装):portal-webapi 实时价/价格监控
    * (与 Node 侧 DIDA_NETWORK_HINTS 对账,run-all §38 防漂移断言守住) */
-  var DIDA_HINT_RE = /portal-webapi\.dida\.com\/HotelPriceAPI\/SearchRealTime|portal-webapi\.dida\.com\/HotelPriceAPI\/SearchMonitor/i
+  var DIDA_HINT_RE = /portal-webapi\.dida\.com\/HotelPriceAPI\/SearchRealTime|portal-webapi\.dida\.com\/HotelPriceAPI\/SearchMonitor|portal-webapi\.dida\.com\/HotelRecommendAPI\/SearchHomepageRecommendHotels|portal-webapi\.dida\.com\/HotelRecommendAPI\/SearchHomepageRecommendPrices|portal-webapi\.dida\.com\/PopularDestinationAPI\/SearchHotels|portal-webapi\.dida\.com\/PopularDestinationAPI\/SearchHotelPrices/i
   /** 形状嗅探签名(dida 实时价信封;与 Node 侧 looksLikeDidaRatesBody 签名一致) */
   var DIDA_BODY_SIG_RE = /"HotelPriceList"|"RatePlanList"/
   /** 形状嗅探(酒店页兜底;与 Node 侧 looksLikeHotelListBody 签名一致) */

--- a/ts/capabilities/session-search.ts
+++ b/ts/capabilities/session-search.ts
@@ -20,7 +20,7 @@ import { randomUUID } from 'node:crypto'
 import { buildEntryUrl, NETWORK_HINTS, parseBatchSearchResult, LOGIN_COOKIE_NAMES, SITE_DOMAIN, type SessionFlightOption } from './session/adapters/ctrip-flight.ts'
 import { buildHotelEntryUrl, parseCtripHotelList, HOTEL_SITE_HOST, type SessionHotelOption } from './session/adapters/ctrip-hotel.ts'
 import { buildTrainEntryUrl, parseLeftTicketQueryResult, resolveTrainQueryTelecodes, validateTrainQueryResponseUrl, TRAIN_SITE_HOST, type SessionTrainOption, type TrainQueryParseOutcome, type TrainResponseBinding } from './session/adapters/rail-12306.ts'
-import { buildDidaEntryUrl, parseDidaRates, DIDA_NETWORK_HINTS, DIDA_SITE_HOST, DIDA_SITE_DOMAIN, DIDA_LOGIN_COOKIE_NAMES, type SessionDidaRateOption } from './session/adapters/dida-portal.ts'
+import { buildDidaEntryUrl, parseDidaRates, parseDidaRecommendHotels, parseDidaPrices, DIDA_NETWORK_HINTS, DIDA_SITE_HOST, DIDA_SITE_DOMAIN, DIDA_LOGIN_COOKIE_NAMES, type SessionDidaRateOption } from './session/adapters/dida-portal.ts'
 import { EXTENSION_STORE_URL } from './session/extension-bridge.ts'
 
 export type SessionVerdict = 'hit' | 'miss' | 'error' | 'challenged' | 'cooldown' | 'needs-login' | 'needs-attach' | 'needs-extension'
@@ -420,23 +420,24 @@ export async function sessionDidaSearch(q: SessionDidaQuery): Promise<SessionDid
     if (!(await loggedIn()) && !q.allowAnonymous) {
       return err('needs-login', didaLoginHint())
     }
-    let settled = false
-    let body = ''
+    // 窗口式收集(2026-09-10 校准):find 页加载自发推荐流(酒店+价格两个接口)
+    // 与可能的实时价接口——按接口分类收 body,窗口结束统一合并解析。
+    const bodies = { hotels: '', recommendPrices: '', realtime: '' }
+    const collect = (text: string, url: string): void => {
+      if (/SearchHomepageRecommendHotels/i.test(url)) bodies.hotels = text
+      else if (/SearchHomepageRecommendPrices/i.test(url)) bodies.recommendPrices = text
+      else if (/HotelPriceAPI\/SearchRealTime/i.test(url)) bodies.realtime = text
+    }
     const heard = new Promise<void>((resolve) => {
       t.page.on('response', async (res) => {
-        if (settled) return
         const u = res.url()
         if (!DIDA_NETWORK_HINTS.some((re) => re.test(u))) return
         try {
           const text = await res.text()
-          if (text) {
-            body = text
-            settled = true
-            resolve()
-          }
+          if (text) collect(text, u)
         } catch { /* 流式/竞态不可读则继续等下一个 */ }
       })
-      setTimeout(() => resolve(), q.timeoutMs ?? 30_000)
+      setTimeout(resolve, q.timeoutMs ?? 30_000)
     })
     await t.page.goto(entry.url, { waitUntil: 'domcontentloaded', timeout: 30_000 })
     await heard
@@ -445,12 +446,28 @@ export async function sessionDidaSearch(q: SessionDidaQuery): Promise<SessionDid
     if (CHALLENGE_RE.test(title + headHtml)) {
       return err('challenged', `风控/验证码命中(title=${title.slice(0, 60)});按红线不重试不绕过,交还用户`)
     }
-    const rates = parseDidaRates(body)
+    const hotels = parseDidaRecommendHotels(bodies.hotels)
+    const recommendPrices = parseDidaPrices(bodies.recommendPrices)
+    const realtimeRates = parseDidaRates(bodies.realtime)
+    const pricesByHotel = new Map(recommendPrices.map((p) => [p.hotelId, p]))
+    const rates: SessionDidaRateOption[] = [...realtimeRates]
+    for (const h of hotels) {
+      const p = pricesByHotel.get(h.hotelId)
+      rates.push({
+        hotelId: h.hotelId,
+        hotelName: h.name,
+        price: p?.price ?? 0,
+        ...(p?.currency ? { currency: p.currency } : {}),
+        ...(p?.priceDate ? { priceDate: p.priceDate } : {}),
+      })
+    }
+    // 有推荐酒店或有实时价即视为通道产出;纯无价酒店如实标注价格待询
+    const priced = rates.filter((r) => r.price > 0).length
     const verdict: SessionVerdict = rates.length > 0 ? 'hit' : 'miss'
     return {
       ok: true,
       via: 'session-dida-portal',
-      evidence: `[会话:${site}@${ts}] ${rates.length} rates;guard blocked=${t.guard.blockedCount()}/${t.guard.requestCount()}${q.allowAnonymous ? ';anonymous=自检态' : ''}`,
+      evidence: `[会话:${site}@${ts}] ${rates.length} hotels(${priced} priced);guard blocked=${t.guard.blockedCount()}/${t.guard.requestCount()}${q.allowAnonymous ? ';anonymous=自检态' : ''}`,
       latencyMs: Date.now() - started,
       verdict,
       rates,

--- a/ts/capabilities/session/adapters/dida-portal.ts
+++ b/ts/capabilities/session/adapters/dida-portal.ts
@@ -51,6 +51,12 @@ export function buildDidaEntryUrl(q: DidaEntryQuery = {}): DidaEntry {
 export const DIDA_NETWORK_HINTS = [
   /portal-webapi\.dida\.com\/HotelPriceAPI\/SearchRealTime/i,
   /portal-webapi\.dida\.com\/HotelPriceAPI\/SearchMonitor/i,
+  // 2026-09-10 UAT 实测校准:find 页加载态自发的是推荐流(非 SearchRealTime——
+  // 那是用户点「预订」后的实时价接口)。推荐酒店 + 推荐价格两个接口成对出现。
+  /portal-webapi\.dida\.com\/HotelRecommendAPI\/SearchHomepageRecommendHotels/i,
+  /portal-webapi\.dida\.com\/HotelRecommendAPI\/SearchHomepageRecommendPrices/i,
+  /portal-webapi\.dida\.com\/PopularDestinationAPI\/SearchHotels/i,
+  /portal-webapi\.dida\.com\/PopularDestinationAPI\/SearchHotelPrices/i,
 ]
 
 /** 形状嗅探签名:URL hint 未命中时的兜底(实时价信封报价签名,对接口改名免疫);
@@ -58,6 +64,72 @@ export const DIDA_NETWORK_HINTS = [
 export function looksLikeDidaRatesBody(body: string): boolean {
   if (!body || body.length > 2_000_000) return false
   return /"HotelPriceList"|"RatePlanList"/.test(body)
+}
+
+// ── 现行加载态接口(2026-09-10 校准):推荐酒店 + 推荐价格 ──────────────────
+
+export interface DidaRecommendHotel {
+  hotelId: string
+  name: string
+  nameEN?: string
+}
+
+/** 解析推荐酒店列表(Data.Hotels[]:HotelID/Name/Name_CN/Name_EN;Current 页加载态无价) */
+export function parseDidaRecommendHotels(body: string, opts: { maxItems?: number } = {}): DidaRecommendHotel[] {
+  let raw: unknown
+  try { raw = JSON.parse(body) } catch { return [] }
+  const hotels = (raw as { Data?: { Hotels?: unknown } })?.Data?.Hotels
+  if (!Array.isArray(hotels)) return []
+  const out: DidaRecommendHotel[] = []
+  for (const item of hotels.slice(0, opts.maxItems ?? 60)) {
+    if (item == null || typeof item !== 'object') continue
+    const h = item as Record<string, unknown>
+    const hotelId = h.HotelID != null ? String(h.HotelID) : ''
+    const name = typeof h.Name_CN === 'string' && h.Name_CN.trim() ? h.Name_CN : (typeof h.Name === 'string' ? h.Name : '')
+    if (!hotelId || !name) continue
+    out.push({ hotelId, name, nameEN: typeof h.Name_EN === 'string' ? h.Name_EN : undefined })
+  }
+  return out
+}
+
+export interface DidaPriceEntry {
+  hotelId: string
+  price: number
+  originalPrice?: number
+  currency?: string
+  /** 单晚起始价对应日期(YYYY-MM-DD) */
+  priceDate?: string
+  checkInDate?: string
+  checkOutDate?: string
+}
+
+// (parser types continue below)
+
+/** 解析价格列表:兼容 Recommend Prices(HotelId/Date)与 PopularDestination(HotelID/CheckInDate)两种键形 */
+export function parseDidaPrices(body: string): DidaPriceEntry[] {
+  let raw: unknown
+  try { raw = JSON.parse(body) } catch { return [] }
+  const prices = (raw as { Data?: { Prices?: unknown } })?.Data?.Prices
+  if (!Array.isArray(prices)) return []
+  const out: DidaPriceEntry[] = []
+  for (const item of prices) {
+    if (item == null || typeof item !== 'object') continue
+    const p = item as Record<string, unknown>
+    const hotelId = p.HotelId != null ? String(p.HotelId) : (p.HotelID != null ? String(p.HotelID) : '')
+    const price = typeof p.Price === 'number' ? p.Price : NaN
+    if (!hotelId || !Number.isFinite(price) || price <= 0) continue
+    const dateOf = (v: unknown): string | undefined => (typeof v === 'string' && v.length >= 10 ? v.slice(0, 10) : undefined)
+    out.push({
+      hotelId,
+      price,
+      originalPrice: typeof p.OriginalPrice === 'number' ? p.OriginalPrice : undefined,
+      currency: typeof p.Currency === 'string' ? p.Currency : undefined,
+      priceDate: dateOf(p.Date),
+      checkInDate: dateOf(p.CheckInDate),
+      checkOutDate: dateOf(p.CheckOutDate),
+    })
+  }
+  return out
 }
 
 /** 单条报价(一房一价一计划;语义判定在工具层,本层只归形状——页面 JSON 是不可信输入) */
@@ -82,6 +154,8 @@ export interface SessionDidaRateOption {
   referenceNo?: string
   /** 酒店详情落地页(由人完成预订;gotry 不碰) */
   jumpUrl?: string
+  /** 推荐价对应日期(YYYY-MM-DD;推荐流单晚起始价) */
+  priceDate?: string
 }
 
 interface RateCandidate {


### PR DESCRIPTION
## 为什么

D-13 首个真会话校准触发:UAT 实机探针(CDP 只读监听)证实 dida find 页**加载态自发的是推荐流**,不是 7 月抓包口径的 SearchRealTime(那已变为用户点「预订」后的交互态接口)。适配器按现行行为校准。

## 内容

- dida-portal.ts:hint 扩充(RecommendHotels/RecommendPrices/PopularDestination SearchHotels/SearchHotelPrices)+ 两个现行解析器(推荐酒店列表;价格列表双键形兼容);SearchRealTime 信封解析保留
- session-search.ts:CDP 车道改窗口式多响应收集(按接口分类收 body → 合并出带价酒店);扩展车道单响应限制照旧(多嗅探归商店提审批次)
- content-main.js:嗅探面同步(与 Node 侧 hints 防漂移锁定)

## 证据

extension-tests 34 段全绿;session-tests 200 pass(2 fail=FlyAI 429 环境性);UAT 实机探针数据(follow-up:本分支部署后 acceptance 复跑)。