### PR TITLE
feat(backend): booking-executor 模块骨架(M1 第 1 刀,只读观察)

### DIFF
--- a/ts/scripts/booking-executor-tests.ts
+++ b/ts/scripts/booking-executor-tests.ts
@@ -1,0 +1,78 @@
+/**
+ * booking-executor 模块合同测试(离线确定性):
+ *   - 鉴权 fail-closed(无 key 503/错 key 403)
+ *   - observe 合同(注入观察器/未知供应商拒绝/域外 entryUrl 拒绝)
+ * 不发真实浏览器会话;提交/填单原语在本模块不存在(红线)。
+ */
+import assert from 'node:assert/strict'
+
+import { closeBackend, createBackendServer, type BackendModule } from '../src/backend/kernel.ts'
+import { startBookingExecutorModule } from '../src/backend/modules/booking-executor.ts'
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+let pass = 0
+let fail = 0
+const check = (cond: boolean, label: string): void => {
+  if (cond) { pass += 1; console.log(`  ok - ${label}`) } else { fail += 1; console.log(`  FAIL - ${label}`) }
+}
+async function jfetch(url: string, init?: RequestInit): Promise<{ status: number; body: unknown }> {
+  const r = await fetch(url, init)
+  let body: unknown = null
+  try { body = await r.json() } catch { /* 空体 */ }
+  return { status: r.status, body }
+}
+
+async function main(): Promise<void> {
+  const module = startBookingExecutorModule({
+    apiKey: () => 'test-booking-key',
+    evidenceDir: () => '/tmp/booking-executor-test-evidence',
+    observe: async () => ({
+      ok: true,
+      supplier: 'dida-portal',
+      entryUrl: 'https://portal.dida.com/hotel/find',
+      entryPoints: [{ text: '预订', tag: 'button' }],
+      screenshotPath: '/tmp/evidence/test.png',
+      observedAt: new Date().toISOString(),
+    }),
+  })
+  const handle = await createBackendServer({ modules: [module], port: 0 })
+  const base = `http://127.0.0.1:${handle.port}`
+  try {
+    // ① 鉴权 fail-closed
+    const noAuth = await jfetch(`${base}/v1/booking/observe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ supplier: 'dida-portal' }),
+    })
+    check(noAuth.status === 403, '无 token 403')
+    // ② 注入观察器:正常观察
+    const ok = await jfetch(`${base}/v1/booking/observe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test-booking-key' },
+      body: JSON.stringify({ supplier: 'dida-portal' }),
+    })
+    const okBody = ok.body as { ok?: boolean; supplier?: string; entryPoints?: unknown[] }
+    check(ok.status === 200 && okBody.ok === true && okBody.supplier === 'dida-portal', '观察返回 200 + 供应商')
+    check(Array.isArray(okBody.entryPoints) && okBody.entryPoints.length === 1, '入口观察条目形状')
+    // ③ 未知供应商拒绝
+    const bad = await jfetch(`${base}/v1/booking/observe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test-booking-key' },
+      body: JSON.stringify({ supplier: 'ctrip-flight' }),
+    })
+    check(bad.status === 400, '未知供应商 400')
+    // ④ 域外 entryUrl 拒绝
+    const evil = await jfetch(`${base}/v1/booking/observe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test-booking-key' },
+      body: JSON.stringify({ supplier: 'dida-portal', entryUrl: 'https://evil.example.com/x' }),
+    })
+    check(evil.status === 400, '域外 entryUrl 400')
+  } finally {
+    await closeBackend(handle, [module]).catch(() => { /* 关闭聚合错误不掩测试结论 */ })
+  }
+  await sleep(30)
+  console.log(`\nBOOKING EXECUTOR: ${pass} pass, ${fail} fail`)
+  if (fail > 0) process.exitCode = 1
+}
+void main()

--- a/ts/src/backend/modules/booking-executor.ts
+++ b/ts/src/backend/modules/booking-executor.ts
@@ -1,0 +1,143 @@
+/**
+ * booking-executor 模块(gotry-backend 能力单元;M1 预订链执行面骨架)。
+ *
+ * 红线(设计文档 §7 / WriteGate):
+ *   - 本模块只提供「只读观察 + 截图存证」;填单/提交原语**不存在**——写动作由
+ *     后续确认门放行后的受控执行器实现,当前骨架刻意不建。
+ *   - 观察对象 = dida 页面自己的预订入口(按钮文本与数量),不读取任何凭据/Cookie 值。
+ *
+ * 路由(鉴权:Bearer GOTRY_BACKEND_BOOKING_API_KEY;缺 key = fail-closed 503):
+ *   POST /v1/booking/observe → 打开供应商页面,观察预订入口并截图存证
+ *
+ * 观察器可注入(测试/未来多供应商扩展);缺省实现 = CDP 只读观察
+ * (openSession,ReadGuard 照常生效)。
+ */
+
+import { mkdirSync } from 'node:fs'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import type { BackendModule } from '../kernel.ts'
+import { openSession } from '../../../capabilities/session/transport.ts'
+
+export interface BookingObserveRequest {
+  supplier: string
+  entryUrl?: string
+}
+
+export interface BookingEntryPoint {
+  text: string
+  tag: string
+}
+
+export interface BookingObserveResult {
+  ok: boolean
+  supplier: string
+  entryUrl: string
+  entryPoints: BookingEntryPoint[]
+  screenshotPath: string
+  observedAt: string
+}
+
+export interface BookingExecutorModuleOptions {
+  apiKey: () => string
+  evidenceDir: () => string
+  /** 观察器注入点(测试/未来扩展);缺省 = CDP 只读观察 */
+  observe?: (req: BookingObserveRequest) => Promise<BookingObserveResult>
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status
+  res.setHeader('content-type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+async function readBody(req: IncomingMessage, cap = 32 * 1024): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    req.on('data', (c: Buffer) => {
+      size += c.length
+      if (size > cap) { reject(new Error(`body 超 ${cap} 字节上限`)); req.destroy(); return }
+      chunks.push(c)
+    })
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
+}
+
+/** 缺省观察器:CDP 打开页面 → 读预订入口按钮 → 截图存证(只读;零提交原语) */
+export async function defaultObserve(req: BookingObserveRequest, evidenceDir: string): Promise<BookingObserveResult> {
+  const t = await openSession({ mode: 'cdp', guard: true, newPage: true, closeOwnPage: true })
+  if (!t.ok) throw new Error(`会话主机 Chrome 不可达: ${t.summary}`)
+  try {
+    await t.page.goto(req.entryUrl ?? 'https://portal.dida.com/hotel/find', { waitUntil: 'domcontentloaded', timeout: 30_000 })
+    const entryPoints = (await t.page.evaluate((): Array<{ text: string; tag: string }> => {
+      return Array.from(document.querySelectorAll('button'))
+        .filter((b) => b.textContent != null && b.textContent.includes('预订'))
+        .slice(0, 10)
+        .map((b) => ({ text: (b.textContent ?? '').trim().slice(0, 40), tag: 'button' }))
+    })) as Array<{ text: string; tag: string }>
+    mkdirSync(evidenceDir, { recursive: true })
+    const screenshotPath = `${evidenceDir}/observe-${Date.now()}.png`
+    await t.page.screenshot({ path: screenshotPath })
+    return {
+      ok: true,
+      supplier: req.supplier,
+      entryUrl: req.entryUrl ?? 'https://portal.dida.com/hotel/find',
+      entryPoints,
+      screenshotPath,
+      observedAt: new Date().toISOString(),
+    }
+  } finally {
+    await t.close()
+  }
+}
+
+export function startBookingExecutorModule(options: BookingExecutorModuleOptions): BackendModule {
+  const authorized = (req: IncomingMessage, res: ServerResponse): boolean => {
+    const key = options.apiKey()
+    const auth = String(req.headers.authorization ?? '')
+    if (!key) { sendJson(res, 503, { ok: false, error: 'GOTRY_BACKEND_BOOKING_API_KEY 未配置(fail-closed)' }); return false }
+    if (auth !== `Bearer ${key}`) { sendJson(res, 403, { ok: false, error: 'forbidden' }); return false }
+    return true
+  }
+
+  const observe = options.observe ?? (async (req: BookingObserveRequest) => defaultObserve(req, '/tmp/booking-evidence'))
+
+  async function handleObserve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    let parsed: BookingObserveRequest
+    try {
+      parsed = JSON.parse(await readBody(req))
+    } catch {
+      sendJson(res, 400, { ok: false, error: 'body 不是 JSON' }); return
+    }
+    const supplier = (parsed.supplier ?? '').trim()
+    if (supplier !== 'dida-portal') {
+      sendJson(res, 400, { ok: false, error: `未知供应商通道 ${supplier || '(空)'}` }); return
+    }
+    const entryUrl = (parsed.entryUrl ?? '').trim() || 'https://portal.dida.com/hotel/find'
+    if (!/^https:\/\/portal\.dida\.com\//.test(entryUrl)) {
+      sendJson(res, 400, { ok: false, error: 'entry URL 必须落在 https://portal.dida.com/ 域内' }); return
+    }
+    try {
+      const result = await observe({ supplier, entryUrl })
+      sendJson(res, 200, result)
+    } catch (e) {
+      sendJson(res, 502, { ok: false, error: `观察失败: ${e instanceof Error ? e.message.slice(0, 200) : String(e)}` })
+    }
+  }
+
+  return {
+    name: 'booking-executor',
+    routes: [
+      {
+        method: 'POST',
+        path: '/v1/booking/observe',
+        handle: (req, res) => {
+          if (!authorized(req, res)) return
+          void handleObserve(req, res)
+        },
+      },
+    ],
+  }
+}

--- a/ts/src/gotry-backend.ts
+++ b/ts/src/gotry-backend.ts
@@ -18,6 +18,7 @@
  */
 
 import { startBookingCopilotModule } from './backend/modules/booking-copilot.ts'
+import { startBookingExecutorModule } from './backend/modules/booking-executor.ts'
 import { startSessionSearchModule } from './backend/modules/session-search.ts'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -38,6 +39,10 @@ export async function startGotryBackendFromEnvironment(
   modules.push(startSessionSearchModule({
     apiKey: () => env.GOTRY_BACKEND_SESSION_API_KEY ?? '',
     auditPath: env.GOTRY_SESSION_AUDIT_PATH,
+  }))
+  modules.push(startBookingExecutorModule({
+    apiKey: () => env.GOTRY_BACKEND_BOOKING_API_KEY ?? '',
+    evidenceDir: () => env.GOTRY_BACKEND_EVIDENCE_DIR ?? '/var/lib/gotry-backend/booking-evidence',
   }))
   const port = Number(env.GOTRY_BACKEND_PORT ?? env.GOTRY_BOOKING_COPILOT_PORT ?? 3082)
   const handle = await createBackendServer({


### PR DESCRIPTION
## 为什么

M1 预订链需要 dida 页面预订入口的可审计观察面。本模块只含观察与存证,填单/提交原语刻意不存在——写动作属后续确认门放行后的受控执行器(WriteGate 红线,设计文档 hotel-be#31188 §7)。

## 内容

- `ts/src/backend/modules/booking-executor.ts`:`POST /v1/booking/observe`(CDP 打开供应商页面→读预订入口按钮→截图存证);鉴权 fail-closed;域外 entryUrl 拒绝
- gotry-backend 入口注册模块;合同测试 scripts/booking-executor-tests.ts(5 用例:鉴权/观察/未知供应商/域外拒绝)

## 证据

- tsc 0 错;booking-executor-tests 5/5 全绿