### PR TITLE
test(extension): bridge-only fetch contract accepts joinTicket.bridgeUrl derived expressions (#380 followup)

### DIFF
--- a/ts/scripts/extension-tests.ts
+++ b/ts/scripts/extension-tests.ts
@@ -366,9 +366,11 @@ async function main(): Promise<void> {
     assert.ok(manifestAny.content_scripts.every((b) => b.matches.includes(`https://${DIDA_SITE_HOST}/*`)), 'manifest 两组 content_scripts 均应注入 portal.dida.com')
     assert.ok(stripRe(contentMainJs).includes('"HotelPriceList"|"RatePlanList"'), 'dida 形状签名两侧必须逐字一致')
   })
-  await check('物理只读形态:扩展全部 fetch 只指向桥(loopback / 远程桥 URL / bridgeBase() / joinTicket.bridgeUrl / 变量别名 url);不用 chrome.debugger;站点域一律 zero fetch', () => {
+  await check('物理只读形态:扩展全部 fetch 只指向桥(loopback / 远程桥 URL / bridgeBase() / joinTicket.bridgeUrl 含 .replace 派生 / 变量别名 url);不用 chrome.debugger;站点域一律 zero fetch', () => {
     for (const [name, src] of [['background', backgroundJs], ['content-main', contentMainJs], ['content-bridge', contentBridgeJs]] as const) {
-      const bridgeFetches = src.match(/fetch\(`?(?:http:\/\/127\.0\.0\.1|\$\{bridgeBase\(\)\}|\$\{remoteBridge\.baseUrl\}|\$\{joinTicket\.bridgeUrl[^)]*\})|\bfetch\(\s*url\b/g) ?? []
+      // joinTicket.bridgeUrl 分支用 [^}]* 而非 [^)]*:允许同一变量的 .replace(...) 等纯派生表达式(如去尾斜杠),
+      // 派生链一旦写出嵌套 `${}` 或新目标即不再命中——只放宽对同一变量的匹配,不放宽目标集合(fail-closed)。
+      const bridgeFetches = src.match(/fetch\(`?(?:http:\/\/127\.0\.0\.1|\$\{bridgeBase\(\)\}|\$\{remoteBridge\.baseUrl\}|\$\{joinTicket\.bridgeUrl[^}]*\})|\bfetch\(\s*url\b/g) ?? []
       const allFetches = src.match(/fetch\(/g) ?? []
       assert.equal(bridgeFetches.length, allFetches.length, `${name}: fetch 必须只指向桥——扩展零写行为的代码面证据`)
     }


### PR DESCRIPTION
## 为什么

main 自 #380（execute in admin browser extension）合入后在 `ts/scripts/extension-tests.ts` §38「物理只读形态」红灯：background.js 的 join ticket 健康探针改成 `${joinTicket.bridgeUrl.replace(/\/+$/, '')}/health`（去尾斜杠），白名单正则 `$\{joinTicket\.bridgeUrl[^)]*\}` 被表达式内的 `)` 卡住匹配不上 → `3 !== 4`。

**零写契约没有被破坏**：该 fetch 目标仍是桥（joinTicket.bridgeUrl）。红是合同正则没跟上 #380 的新代码形态。

## 变更（1 行正则 + 注释 + 标题补充）

- joinTicket 分支 `[^)]*` → `\[^}\]*`：允许同一变量的纯派生表达式（.replace 等）；派生链一旦写出嵌套插值或新目标即不再命中——**只放宽对同一变量的匹配，不放宽目标集合，fail-closed 方向**。
- check 标题同步标注「含 .replace 派生」。

## 红→绿

- 红：main c28d6be 与 a8544dc 两处独立复跑 `extension-tests.ts` → 同一断言 FAIL `3 !== 4`（exit 1）。
- 绿：本分支 1fe24c1 → `extension-tests.ts` exit 0（36 ok，含该断言）。

## Gates（Node 24，1fe24c1）

| Gate | exit |
|---|---|
| npx tsc --noEmit | 0 |
| npx tsx scripts/extension-tests.ts | 0 |

根侧全栈回归合并前由 root 跑（进行中，见 PR 评论补证据）。

## 边界

不改扩展代码、不改零写契约语义、不新增任何被允许的 fetch 目标。