### PR TITLE
test(metrics): relative fixture clock fixing calendar-aged 7-day window (#138 followup)

### DIFF
--- a/ts/scripts/metrics-report-tests.ts
+++ b/ts/scripts/metrics-report-tests.ts
@@ -10,8 +10,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { aggregateFacts, aggregateChannels, aggregateIncidents, aggregateLatency, collectMetrics, renderMetricsReport, main } from './build-metrics-report.ts'
 
-const NOW = new Date('2026-09-05T12:00:00Z')
+// fixture 时间戳必须相对真实时钟:聚合器(main)按真实 now 取 --days 窗口,
+// 硬编码绝对日期会随日历自然老化出窗(2026-09-11 起 iso(1) 跌出 7 天窗,§6 假红)。
 const DAY = 86_400_000
+const NOW = new Date(Date.now() - 1 * DAY)
 const iso = (daysAgo: number) => new Date(NOW.getTime() - daysAgo * DAY).toISOString()
 
 let checkCount = 0


### PR DESCRIPTION
## 为什么

main 自 2026-09-11 17:37 起在 run-all §51 假红：fixture `NOW` 硬编码 `2026-09-05T12:00:00Z`，`iso(1)` 落在 09-04T12:00Z；聚合器 `main()` 按真实时钟取 `--days 7` 窗口，09-11T17:37 后该行自然跌出 7 天窗 → 报告「事故面(空)」而断言要求 `plugin_error | 1`。这是测试时钟腐坏，不是聚合器缺陷。

## 变更（3 行）

fixture `NOW` 改为相对真实时钟（now-1d），`iso()` 语义不变。聚合器代码零改动。

## 红→绿

- 红：v2/v3 两次全栈日志 §51 `AssertionError: The input did not match /plugin_error \| 1 /`（报告「(空:窗口内无事故)」）。
- 绿：本分支 `metrics-report-tests.ts` → `METRICS REPORT TESTS OK(6 checks)` exit 0；`tsc --noEmit` exit 0。

## 边界

仅测试 fixture；无产品代码、无文档状态面变化。