### PR TITLE
test(booking): clean-consumer install revalidates registry metadata (#394 followup)

### DIFF
--- a/scripts/booking-surface-package-proof.ts
+++ b/scripts/booking-surface-package-proof.ts
@@ -55,7 +55,7 @@ const tarballResult = spawnSync('npm', ['pack', '--silent', '--ignore-scripts'],
 assert.equal(tarballResult.status, 0, tarballResult.stderr || tarballResult.stdout)
 const tarball = resolve(root, tarballResult.stdout.trim())
 writeFileSync(join(packedConsumer, 'package.json'), JSON.stringify({ name: 'clean-consumer', private: true, type: 'module' }))
-const install = spawnSync('npm', ['install', '--prefer-offline', '--ignore-scripts', '--no-audit', '--no-fund', tarball], {
+const install = spawnSync('npm', ['install', '--prefer-online', '--ignore-scripts', '--no-audit', '--no-fund', tarball], {
   cwd: packedConsumer,
   encoding: 'utf8',
   timeout: CLEAN_CONSUMER_INSTALL_TIMEOUT_MS,


### PR DESCRIPTION
## 为什么

#394 记录的 §49 ERESOLVE 红已随上游动作解除：`@deepseek-ai/dsh-agent@0.1.5-rc.1`/`rc.2` **已发布到公共 npm**（registry `versions` 列表直证；dist-tag `latest` 仍停在 0.1.0-rc.6 属上游标签维护问题，不影响解析）。

本 PR 修的是**本地方才暴露的另一半**：证明脚本用 `npm install --prefer-offline`，会吃到本地 npm 缓存里的**陈旧 packument**（本机缓存另有 10 个历史 sudo npm 遗留的 root 属主条目导致 EACCES）——「干净消费者」的合同模拟不应依赖本地缓存状态。

## 变更（1 词）

`--prefer-offline` → `--prefer-online`：安装时对 registry 元数据做再验证（staleness-while-revalidate 反转），包体仍走缓存。对真实用户语义更准确：消费者安装时的依赖解析以 registry 当前元数据为准。

## 验证（本地实测）

- 修复前（陈旧缓存）：`npm warn ERESOLVE overriding peer dependency`（dsh-agent@undefined）→ 断言红 exit 1（v2/v3 两轮全栈在案）。
- 修复后（同陈旧缓存环境 + --prefer-online + 清理缓存损坏条目前后各跑一次）：`booking-surface-package-proof.ts` **exit 0**，`npm warn`/ERESOLVE 计数 0。
- dsh-acp peer `@deepseek-ai/dsh-agent@^0.1.5-rc.1` 由 rc.2 满足（semver 同元组预发布递增）。

## Gates

`npx tsx scripts/booking-surface-package-proof.ts` exit 0（含 §49 断言 + DSH 闭包计数）。全栈回归合并前由 root 跑。

## 边界

不改契约语义、不改依赖树（零 lockfile 变化）；真实 UAT 仍在 M5 Entry + #318 门后。