### PR TITLE
test(hotelbyte): spawn timeout headroom for cold-start full-suite runs (#232 followup)

### DIFF
--- a/ts/scripts/hotelbyte-spawn-e2e-tests.ts
+++ b/ts/scripts/hotelbyte-spawn-e2e-tests.ts
@@ -27,7 +27,7 @@
  *
  * 红线(结构性保证):唯一被执行的可执行文件是 mkdtemp 下的本地 fixture 脚本;
  * 套件零 PATH 上的 hbcli 解析、零网络、零凭据;GOTRY_HBCLI_LIVE 不参与、置 1 也不改变本套件行为;
- * 所有 spawn 带有界超时(hang 场景 500ms 内 SIGKILL 收敛)。
+ * 所有 spawn 带有界超时(hang 场景 500ms 内 SIGKILL 收敛;常规场景 15s 只防真死锁,全栈冷态首跑亦稳定)。
  *
  * 运行: cd ts && npx tsx scripts/hotelbyte-spawn-e2e-tests.ts
  */
@@ -250,7 +250,7 @@ try {
 
   // book 复用参数:绑定 ref 与 rate-pkg 经真实 argv 进子进程(回传断言即 spawn 边界证明)
   const bookArgs = ['trade', 'book', '--json', '--rate-pkg-id', RATE_PKG, '--customer-reference-no', REF]
-  async function bookSpawn(mode: string, args: string[] = bookArgs, timeoutMs = 2000): Promise<SpawnOutcome> {
+  async function bookSpawn(mode: string, args: string[] = bookArgs, timeoutMs = 15_000): Promise<SpawnOutcome> {
     return runFake(fakeBin, args, { FAKE_BOOK_MODE: mode, FAKE_RATE_PKG_ID: RATE_PKG }, timeoutMs)
   }
   async function querySpawn(mode: string): Promise<SpawnOutcome> {
@@ -258,7 +258,7 @@ try {
       fakeBin,
       ['trade', 'query-orders', '--json', '--customer-reference-no', REF],
       { FAKE_QUERY_MODE: mode },
-      2000,
+      15_000,
     )
   }
 
@@ -267,7 +267,7 @@ try {
     fakeBin,
     ['search', 'check-avail', '--json', '--rate-pkg-id', RATE_PKG],
     { FAKE_RATE_PKG_ID: RATE_PKG },
-    2000,
+    15_000,
   )
   assert.equal(quoteOutcome.exitCode, 0, 'quote spawn exit0')
   assert.equal(quoteOutcome.timedOut, false, 'quote spawn 不超时')


### PR DESCRIPTION
## 为什么

PR #407 的 §66 套件在 **全栈冷态首跑**（rsync 依赖树后磁盘冷 + 并行负载）下场景 1 假红：quote spawn 的 2s 默认上限被 node 冷启动超越（status=null 即 SIGKILL）。暖态复跑 12/12 全绿——非契约缺陷，是测试负载敏感。

## 变更

常规场景默认 spawn 上限 2000ms → **15s**（bookSpawn/querySpawn/quote 三处 + 头注释口径）；**hang 场景的显式 500ms SIGKILL 设计点不动**（那是收敛语义本身）。契约语义零变化。

## 验证

- 暖态：12/12 OK exit 0（本分支）。
- 冷态敏感性：#407 全栈 v5 日志在案（quote status=null）——放宽后该窗口消除。
- Gates：focused exit 0；tsc --noEmit exit 0。全栈由 root 合并前跑。

## 边界

仅测试超时上限；契约/断言语义零变化；hang 收敛 500ms 语义保留。