### PR TITLE
fix(metrics-report): main() injected now so fixture stays in 7-day window

### DIFF
--- a/ts/scripts/build-metrics-report.ts
+++ b/ts/scripts/build-metrics-report.ts
@@ -342,9 +342,10 @@ export function parseArgs(argv: string[]): { stateRoot: string; out?: string; da
   return { stateRoot: isAbsolute(stateRoot) ? stateRoot : resolve(stateRoot), out, days }
 }
 
-export async function main(argv: string[]): Promise<void> {
+export async function main(argv: string[], injectedNow?: Date): Promise<void> {
   const { stateRoot, out, days } = parseArgs(argv)
-  const snapshot = await collectMetrics(stateRoot, { days })
+  const now = injectedNow ?? new Date()
+  const snapshot = await collectMetrics(stateRoot, { days, now })
   const markdown = renderMetricsReport(snapshot)
   if (out) {
     writeFileSync(out, markdown + '\n', 'utf-8')

--- a/ts/scripts/metrics-report-tests.ts
+++ b/ts/scripts/metrics-report-tests.ts
@@ -146,7 +146,7 @@ await withRoot(async (root, stateDir) => {
   writeFileSync(join(stateDir, 'doctor-report.md'), '# doctor\n', 'utf-8')
   const before = readdirSync(stateDir).sort()
   const outPath = join(root, 'report.md')
-  await main(['--state-root', root, '--out', outPath, '--days', '7'])
+  await main(['--state-root', root, '--out', outPath, '--days', '7'], NOW)
   const md = readFileSync(outPath, 'utf-8')
   assert.match(md, /hotel \| 2 \| hit:1 \/ error:1 \| 1\/2\(50%\)/)
   assert.match(md, /\| flyai \| down \| trial-exhausted \|/)


### PR DESCRIPTION
## Why

metrics-report-tests.ts locks `NOW = 2026-09-05T12:00:00Z` and writes fixture
incidents at `NOW-1d`. `main()` defaulted to `new Date()`, which is real
today (2026-09-12), pushing the fixture event out of the 7-day window and
dropping the incident row from the report — the `/plugin_error \| 1 /`
assertion in §6 then fails in CI any day other than 2026-09-04..05.

This was masked locally by date proximity but surfaces every other day.

## What

`main(argv, injectedNow?)` accepts an optional injected clock. Tests pass
`NOW` so fixture windows stay deterministic; the CLI keeps today's default.
No behavior change for production CLI users.

## Verification

- `npx tsx scripts/metrics-report-tests.ts` → 6/6 OK
- Backstop: same test now works on any host date.

Refs: §51 metrics panel (`scripts/run-all-tests.sh`), #138 first slice.