### PR TITLE
fix: replace private npm tarball URLs in lockfiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,7 +264,7 @@
     },
     "node_modules/@agentclientprotocol/sdk": {
       "version": "1.4.0",
-      "resolved": "https://bnpm.byted.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
       "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -273,7 +273,7 @@
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.123.0",
-      "resolved": "https://bnpm.byted.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
       "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "license": "MIT",
       "dependencies": {
@@ -294,7 +294,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
-      "resolved": "https://bnpm.byted.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -309,7 +309,7 @@
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
-      "resolved": "https://bnpm.byted.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -323,7 +323,7 @@
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
-      "resolved": "https://bnpm.byted.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -332,7 +332,7 @@
     },
     "node_modules/@aws-crypto/util": {
       "version": "5.2.0",
-      "resolved": "https://bnpm.byted.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -343,7 +343,7 @@
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1048.0",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
       "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -368,7 +368,7 @@
     },
     "node_modules/@aws-sdk/core": {
       "version": "3.978.0",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/core/-/core-3.978.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
       "integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -387,7 +387,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.972.71",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
       "integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -403,7 +403,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.972.73",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
       "integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -421,7 +421,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
       "version": "4.12.1",
-      "resolved": "https://bnpm.byted.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
       "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -435,7 +435,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.973.16",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
       "integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -459,7 +459,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-login": {
       "version": "3.972.78",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
       "integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -476,7 +476,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.972.83",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
       "integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -498,7 +498,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.972.71",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
       "integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -514,7 +514,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.973.15",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
       "integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -532,7 +532,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
       "version": "3.1129.0",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
       "integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -549,7 +549,7 @@
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.972.77",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
       "integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -566,7 +566,7 @@
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
       "version": "3.972.34",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
       "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -581,7 +581,7 @@
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
       "version": "3.972.29",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
       "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -596,7 +596,7 @@
     },
     "node_modules/@aws-sdk/middleware-websocket": {
       "version": "3.972.53",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.53.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.53.tgz",
       "integrity": "sha512-bIrDaMENQmYRBHntOiOheqkiw5+fhKW4Lqb+mS1uqF0VwvdWI22fW2HFgWrng66CmYd+4k8ePlpj38sEfTuMLQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -614,7 +614,7 @@
     },
     "node_modules/@aws-sdk/nested-clients": {
       "version": "3.997.45",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
       "integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -633,7 +633,7 @@
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
       "version": "4.12.1",
-      "resolved": "https://bnpm.byted.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
       "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -647,7 +647,7 @@
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.996.46",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
       "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -662,7 +662,7 @@
     },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.1048.0",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
       "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -679,7 +679,7 @@
     },
     "node_modules/@aws-sdk/types": {
       "version": "3.974.5",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
       "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -692,7 +692,7 @@
     },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.10",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
       "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -704,7 +704,7 @@
     },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.972.40",
-      "resolved": "https://bnpm.byted.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
       "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -717,7 +717,7 @@
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.3.0",
-      "resolved": "https://bnpm.byted.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
       "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
@@ -726,7 +726,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://bnpm.byted.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
@@ -740,7 +740,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://bnpm.byted.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
@@ -749,7 +749,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://bnpm.byted.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
@@ -793,7 +793,7 @@
     },
     "node_modules/@deepseek-ai/cordis-plugin-hmr": {
       "version": "1.0.17",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.17.tgz",
       "integrity": "sha512-o1BooaJpwd+C80Tn5+B48MGqrfNZydlfRVQjmCrrULA4nCmlMqBKjDF2FmcZoNP+L2uX9m/6DdGKVtFpQRQVUQ==",
       "license": "MIT",
       "dependencies": {
@@ -842,7 +842,7 @@
     },
     "node_modules/@deepseek-ai/cordis-plugin-timer": {
       "version": "1.1.4",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.4.tgz",
       "integrity": "sha512-GhxOiU+TF2BbNBKlV2N24zvfv2Kh7RxkFW1hjML6s+DOb+y2zomzbeC5zHIIjsc/rpRwbKpDNucPGSwkH0ChXw==",
       "license": "MIT",
       "dependencies": {
@@ -860,7 +860,7 @@
     },
     "node_modules/@deepseek-ai/dsh": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh/-/dsh-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.5-rc.1.tgz",
       "integrity": "sha512-rmNmzQCg3oIc1z8xH7izRSOuy1TNzq+/NILyfM+7e8DKOyV+yBtg47WEsqR2SiIe1ATec3L/rUa1YhIcfQ2XEg==",
       "license": "MIT",
       "dependencies": {
@@ -943,7 +943,7 @@
     },
     "node_modules/@deepseek-ai/dsh-acp": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.5-rc.1.tgz",
       "integrity": "sha512-Ze5yCIcfz0VjBNrt3B7mfRI0WPYJd8ZckdaV3lRwO98PcVuO330y8DTuQXdBvgvFpmZCLselVW1mB9tT7240hA==",
       "license": "MIT",
       "dependencies": {
@@ -970,7 +970,7 @@
     },
     "node_modules/@deepseek-ai/dsh-acp-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-O6+Hl//+uog9ezp+aVI0oQyNAtZ4GHf6haGxgPe7U9Kp/KUKjVYC94Lb2x45SgEimJroSxBOcR1CIQop2Tsn1g==",
       "license": "MIT",
       "dependencies": {
@@ -984,7 +984,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.5-rc.1.tgz",
       "integrity": "sha512-obIPyTSjq1y0Yhasm3mLhK5BW6Ge0VQoRT8FBt0ooLsct2+pFAjgyd7GP3KzFaz7zaEhQJ/NNEmCaU0KOsYutg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1001,7 +1001,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.5-rc.1.tgz",
       "integrity": "sha512-yEUYhogUpiUfctefVHpNZ+9WvCKjm2wbVIj1iGnCRmHtvlrB2tmAJ7OkaOhUK3AxY0WovSjf+8Y8+sGLMx980A==",
       "license": "MIT",
       "dependencies": {
@@ -1016,7 +1016,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.5-rc.1.tgz",
       "integrity": "sha512-HpYUZSB0RB2gZnG2chR53Ama8grr95TIBoYlLyDFvHy61zl6HOtYEsm44LQp5gNlycAyoUPxoyXExo7hVn5glQ==",
       "license": "MIT",
       "dependencies": {
@@ -1036,7 +1036,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.5-rc.1.tgz",
       "integrity": "sha512-FcpsiXMHR7M3UwZtC6CYzhmU9xhvbFuuEQisfUqW7c+G6oVhrX9kg8ytI50jXZempcdmVHZLyNeUcuDmgGtx7Q==",
       "license": "MIT",
       "dependencies": {
@@ -1061,7 +1061,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.5-rc.1.tgz",
       "integrity": "sha512-kUBeWCF/7g7Z73kPJHleyqZt72aDOrLCeqbwrLks1svDy6ubMUvWi9jAYrYzvSYCJg+fD7x8/13tw49NriJyxA==",
       "license": "MIT",
       "dependencies": {
@@ -1088,7 +1088,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q4sjyFnws8PqrOmRtthT5ps2jToFRIxC+ogpEcoAik/ggFwfBEC8+IZ3KT2kxNzTvymCyDsxbJxFtirO6gE7SQ==",
       "license": "MIT",
       "dependencies": {
@@ -1101,7 +1101,7 @@
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.5-rc.1.tgz",
       "integrity": "sha512-+ecDwUWxv+E18+m0lhaC6/Z6EfmtqG2EhNxmycQi0u02t7CU0/ZiTZrUaWIB6365btlPy+GTBHE9C+SIlTomEA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1112,7 +1112,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.5-rc.1.tgz",
       "integrity": "sha512-q/R5sJt8Q6D37mAQBM7gIB6mTC88qJ1WY6gLjtcwOn0GgSRwY17ChgIZq/b6YUxAJ3ykgKTeKfvAj8pvyRX09w==",
       "license": "MIT",
       "dependencies": {
@@ -1128,7 +1128,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.5-rc.1.tgz",
       "integrity": "sha512-sFoGZ3jJbrKLxbxSoyUpxhbRhgrxtxutfOcTJWacCTTfJQWvyJiJtbt4aK/997Uqgv19CklIBVkDBfqMDZA4RA==",
       "license": "MIT",
       "dependencies": {
@@ -1143,7 +1143,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-session-controller": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.5-rc.1.tgz",
       "integrity": "sha512-BwOU/VMFpYQo7fAp0RyeBbSlIwNg9BNI3tDatRpYHBNKBcckiN0Lv2HO3Aoe7dLRh8yqqaOeiUVBY3Mkva1aZA==",
       "license": "MIT",
       "dependencies": {
@@ -1198,7 +1198,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-settings-controller": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.5-rc.1.tgz",
       "integrity": "sha512-MeeYkdfhiVy6oHOoyHKKsuahbSinPSaOY3nIiudbLIQYrGyF9+KGFPmP7LM+KF/G9mP/Q8Dh9nZq3BUIMBj3LQ==",
       "license": "MIT",
       "dependencies": {
@@ -1217,7 +1217,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-workspace-controller": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.5-rc.1.tgz",
       "integrity": "sha512-1mzTuL850EFqBPD+JwGzC9aNpZQ7LgxZCt3TP4YBVZcbys3D5Gopbb+wIJsqMHpfwIA2eqY9m3KAJjaJepF4Sg==",
       "license": "MIT",
       "dependencies": {
@@ -1237,7 +1237,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-workspace-files": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-workspace-files/-/dsh-api-workspace-files-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-files/-/dsh-api-workspace-files-0.1.5-rc.1.tgz",
       "integrity": "sha512-fDUHdBBMH50vHwViZoM3tdp3fgrzFB4x/NqwNRwnJfaVgg2t5exRok9gSoHmsKYaP5EkEqGXYozOCNUx9GWVYg==",
       "license": "MIT",
       "dependencies": {
@@ -1252,7 +1252,7 @@
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.5-rc.1.tgz",
       "integrity": "sha512-yWxb2SbcW/Vq2mt3Q6+PTbYdxSPK4KEWADTDdWDseiIn4F78szElS+zyclc1jmr9HlcZkTuLg9mwUZhgjixJjw==",
       "license": "MIT",
       "dependencies": {
@@ -1279,7 +1279,7 @@
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.5-rc.1.tgz",
       "integrity": "sha512-5fiPu6usjlzTd9IfOyINMHqMdxsmyTI3YY3s+BqAGk5qwqedrh83gPEer9a94L8lkhX+06AC0wdsSROI5bNZsQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1288,7 +1288,7 @@
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.5-rc.1.tgz",
       "integrity": "sha512-uTBtB/LDlYgPI6i9Ac9jaK/bV1wN8cDTZBUkec80Yg3qMzW6K74wvBv5lPmoiXQgp4q3eOmDNEmodSS2ZxxVdg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1298,7 +1298,7 @@
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-FVrfFKktYBKt9MzODf9oxdB0QOCcY2i/9cHOuxYDluS+SRP/zs3c7Rs/GsUk0Crg8Q2LQNf7CCYQ0Lr2ymGHEA==",
       "license": "MIT",
       "dependencies": {
@@ -1313,7 +1313,7 @@
     },
     "node_modules/@deepseek-ai/dsh-authorization": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.5-rc.1.tgz",
       "integrity": "sha512-VoG21RzrGx5AQYAgMtXYgd6ku1XNxPsQMLdnkQlfIUgzgjZx2Lju8CArfCqxCOEna2Ku4vAz+gm8PEp/Q4Paxg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1325,7 +1325,7 @@
     },
     "node_modules/@deepseek-ai/dsh-base": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.5-rc.1.tgz",
       "integrity": "sha512-cfFyTpUKNnMlS6NRIG8AnvjSsr3enAyl0a1CXnD+wQ1tzoqhGY5+OKsgkVdciKw0Co5WeTSSPItU5lmjBwo4hg==",
       "license": "MIT",
       "dependencies": {
@@ -1420,7 +1420,7 @@
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-1JxwFJI2cRt+/3yQ8DPxmO6jFqZSOBrLCFZ9ObumZ+AcIddsqEVyJBGoniHDmPRRqt8riEisksvkFskhSdnm2g==",
       "license": "MIT",
       "dependencies": {
@@ -1436,7 +1436,7 @@
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-mQ+/0Fo3LTIX+4k3m+P4y9e9IA6/BeNHrWW19U+Un4hBo5JtTwWhAaJN1nCdV6mG5tveXbIe2tpiv65GJdvt8w==",
       "license": "MIT",
       "peerDependencies": {
@@ -1449,7 +1449,7 @@
     },
     "node_modules/@deepseek-ai/dsh-brand": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.5-rc.1.tgz",
       "integrity": "sha512-nfEsuSNghhrcvjMnjlPU55Z60K/5FjCRY4ZJtnc0SHR0PgoMl7N9I9+y4t2kDMe3rnEKlH2UgIGIZ/msGOYvpg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1458,7 +1458,7 @@
     },
     "node_modules/@deepseek-ai/dsh-chunked-list": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-chunked-list/-/dsh-chunked-list-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-chunked-list/-/dsh-chunked-list-0.1.5-rc.1.tgz",
       "integrity": "sha512-3c/pYWSE++OWdilO8kG7mY9UyhHnwfV0qYQN+Bxwt2YdjqRQZ/6UkwvzNQIAoDqUEWJYwcQUQoLHTrgrrpIxNw==",
       "license": "MIT",
       "dependencies": {
@@ -1470,7 +1470,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.5-rc.1.tgz",
       "integrity": "sha512-mBHCF/WT5kAn4fHJDe0mL5TcVUEIRWGUAwPzr32xitQrIAM6jh5G+pPVJLDtTk+ZbHGkGusN0+nQh2gCJpGHjQ==",
       "license": "MIT",
       "dependencies": {
@@ -1484,7 +1484,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-file-upload": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-file-upload/-/dsh-client-file-upload-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-file-upload/-/dsh-client-file-upload-0.1.5-rc.1.tgz",
       "integrity": "sha512-qjH4KGnr97GiBU9Pwr2jIOuZUAeI2QJ1em/e/QHFehu74RGIkvajojVn0d/xGxPqs3JCt/dvVR4OfctqzmVulA==",
       "license": "MIT",
       "dependencies": {
@@ -1499,7 +1499,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-hmr": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.5-rc.1.tgz",
       "integrity": "sha512-RKymfSAI21aZ35elHZHMztwwuVTvqn4UY/eeAyDrfPfErPWPwIScKd935u+vAhM4HuBZnIL3E/Sl4MYvws4NZw==",
       "license": "MIT",
       "dependencies": {
@@ -1511,7 +1511,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-locale": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.5-rc.1.tgz",
       "integrity": "sha512-DNzkyudBnGEPPaqRTsBnrr8nast/ZOPSAO21pS1MldK277Wj7Po4bCURKg1cS9QT30Fs4NMeJdIvyV/xNWoMSw==",
       "license": "MIT",
       "dependencies": {
@@ -1523,7 +1523,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-modules": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.5-rc.1.tgz",
       "integrity": "sha512-PE+c+LDUBnk1IfVu4caIKMj2XwLx/tzu0p9gY1jGQa1cNxzKfPgftKHDwvqWMbJQowtLb+RiR2Tc+24nFylVyQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1532,7 +1532,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-resources": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-resources/-/dsh-client-resources-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-resources/-/dsh-client-resources-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q0g/4KWavf10yiYXWHjbrgHr5pejqySTAwXtouD6TrHvtgGAKtqWIa6s5t5y+YW3RqxabzAqmjCTqZrq+/RbWA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1541,7 +1541,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.5-rc.1.tgz",
       "integrity": "sha512-0W0ZrOewwgsUWgqd+Zz4hF6Vwn0xe/JNy6nf80BdjvV8RCms4o8hW1+c6dO0z6O42WLLlF4K7t1Hs/lkPN1YEA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1550,7 +1550,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-approval": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.5-rc.1.tgz",
       "integrity": "sha512-zba9ZtNmkfypU+wOkKGh5I3GmJMAH6rMj5FEsMs9/GG5x0Z8BlybHDELZIBVV4UoJfuZYvDFI/zemVMVRaGsVw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1559,7 +1559,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.5-rc.1.tgz",
       "integrity": "sha512-JmHfLBhXDfbo7+l1L92ACye3DSBtaF8bZ7EiQuTajwUHmtBtK/jKv9PKKXJnnHQNFwSrdcR2Sc2FxGW7WJHgQA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1568,7 +1568,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.5-rc.1.tgz",
       "integrity": "sha512-scbXvZiVH+Uag1R/twD3r/sqEhrU+EMKae78F2399JUjkAVZDdJLv4R6PlSJbIKy16OKt2cYgsRxEkUxs+1a7w==",
       "license": "MIT",
       "peerDependencies": {
@@ -1577,7 +1577,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-chat": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.5-rc.1.tgz",
       "integrity": "sha512-mi0KY13+w9uqXIrp8ZObHC0mGNOhSn2rx4sSobetYN+u4GW1xFvONBsPJYTCqvgnAWFEjAUtqHXmH/Tvmhe0wg==",
       "license": "MIT",
       "dependencies": {
@@ -1589,7 +1589,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-commands": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.5-rc.1.tgz",
       "integrity": "sha512-XU01bKi8Dlupq1E3l/dkUQueHRTm3hqbcTDbK/gbfVMUZXlUN9zNFxEvtXzQzBOrPMFs+gBH3nyza12ViuyOrg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1598,7 +1598,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.5-rc.1.tgz",
       "integrity": "sha512-/A+lvO6mc+uTJWJerFyhZeBV+Ez9Sid8+wx7NbIrrg/mdt191IdHqHI9v2sGiIQ/1d+nI3S0YjhOxMH4hGka5A==",
       "license": "MIT",
       "dependencies": {
@@ -1610,7 +1610,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.5-rc.1.tgz",
       "integrity": "sha512-+lhe7NilUE/Shy02UqBGFku+CCk97L/Jxbyv+LFVVQw+hbGUh2bSgCuNfRLfyQzaRwMxDATlqVM0T0cHkXU5RA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1619,7 +1619,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.5-rc.1.tgz",
       "integrity": "sha512-cT995A3OoY07GhpenbBRC/9z/WQFf5uFv5VMNZSnmrG/+X9huaOu7fZvWV1wiwWWgmhxVWxNFbyYyeq8VJerRA==",
       "license": "MIT",
       "dependencies": {
@@ -1631,7 +1631,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.5-rc.1.tgz",
       "integrity": "sha512-ssNVwTfj2kob4e/9zLISU4QVz7MOw7MWjP5+oqWCmpMVMd3wJBeRNqqOTx+ZaqijfMft8QNJIlyoJmgvYDdK+A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1640,7 +1640,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.5-rc.1.tgz",
       "integrity": "sha512-YK5uUJFZAnXmve0d/nrqF1V+duAxil8615Vx4TPc8b4BsXZ4uloCqHGAfQTkXVdIA3x9gLc9CRp2ZhUDLR7Wtw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1649,7 +1649,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-xM+bIv4gkQIMzOx2vtZRBT5P0rFoxEaOA0FhYuSmItmDUu/tECCbduarRyvBe5KKyjDL8ONCMY9hS8GwJHvjUA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1658,7 +1658,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.5-rc.1.tgz",
       "integrity": "sha512-y/Y6HPwZf146ZHJW5G1O4eD4vKWYVi+xFFY50tdsHRMSPpoiQnnlIAbG12OQknsKslc4SDdA7FHNLxzGankPRA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1667,7 +1667,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.5-rc.1.tgz",
       "integrity": "sha512-PVMSsYyexvebr45PCo2Va2VtfGIpUPkS3umH+WsI/pc1JoYw7REW5lqUy639N4tGDh3WTFhU9bczpAf1Aj8T1g==",
       "license": "MIT",
       "peerDependencies": {
@@ -1676,7 +1676,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-layout": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.5-rc.1.tgz",
       "integrity": "sha512-XbaJSLhZM5rSbcpAy9IyoYgC6nmEppUptzU3H50/cbFqoDCDvXrcflx04UlifRI5tb5ofZtNOvDqqCsJ6kwcIg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1685,7 +1685,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.5-rc.1.tgz",
       "integrity": "sha512-jOpjPC9O+/XqhBjI7Z6u5c7nj/vAV2S84jH592ruG4qZF/rr4EkMs+KZy3Bm7nRxOIpNaJM0D8sGFAgfoAgqvQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1694,7 +1694,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.5-rc.1.tgz",
       "integrity": "sha512-fl59qM9HcNplIXC+MqSgujsaUt3vZYOQpJWO1Y2vihkrg6fHjZoY2TOw42b53fr9NGH/dUImQ0iXll4X4F9Hpw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1703,7 +1703,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-open-in-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-open-in-app/-/dsh-client-ui-open-in-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-open-in-app/-/dsh-client-ui-open-in-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-wzsG3tR/FrkZ/mr+2jwbOVbRNKVLabTcz+XAnJqAeYCAymQmxCCNrAaOUUiaWwGfbrWbAOGp2XnANqs4MjDqug==",
       "license": "MIT",
       "peerDependencies": {
@@ -1712,7 +1712,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.5-rc.1.tgz",
       "integrity": "sha512-Dr0orTetf84oJ2+53HohNvxXmZ4vNMT5ZiLaMhJslWvE2DkqMMq5u7ceVTx3/+MBQvJBKX9V6Atas3Qw64bp8g==",
       "license": "MIT",
       "peerDependencies": {
@@ -1721,7 +1721,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-plan": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.5-rc.1.tgz",
       "integrity": "sha512-B/yYlTP/8QIF0cXCyFRatZ71wlDe+9HiUGCly3AhGgyuYO1xqXuJAhRtsLei0U4hzbar3SL2DF109pO1XlAB+Q==",
       "license": "MIT",
       "peerDependencies": {
@@ -1730,7 +1730,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-reference": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.5-rc.1.tgz",
       "integrity": "sha512-08Iu4RBC3lO6YtlZWihIL0kF9+oQA/J6qQJp5oN+qHuRbjJUcfQ41JLplTiEP3PUWwVeMEpsT69+zWdPsDTUPw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1739,7 +1739,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.5-rc.1.tgz",
       "integrity": "sha512-v3NlhGgcYDUtskwjylVuKJ+FMiuJgYdWg/bIjth+obj7cF2SBJR4A0/9XfCKQvh2xbF/puRLZ7DG3KRl8+BKBQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1748,7 +1748,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.5-rc.1.tgz",
       "integrity": "sha512-k5bhs50oxNNQDQW10aK2z1o07ZjejDwjFqMqYqn8nMaqpG3b/14v063Vfr0woimwpSuSTtO1oBPDZyPGLYguhg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1757,7 +1757,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-session": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.5-rc.1.tgz",
       "integrity": "sha512-qrAKy9soxmTmStjs6mnxHx992iTKzn1uBu1p5UL1wHPYJKus6cTHjBD8HlaYMYE4IzB9AFezUjDfOOjwgyxlUQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1766,7 +1766,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.5-rc.1.tgz",
       "integrity": "sha512-5O+HJrGuyJL0rNf7ulLI7CbdVozYfKDrAYKXoykAzZZ11EgSEaOrNfRobBhUKMsmXyfbKec7qce9rtG+HOgiuA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1775,7 +1775,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.5-rc.1.tgz",
       "integrity": "sha512-oGzUbFGr27KnteXU7/82K5sI/MRB9b+B1sFiQTpUEix318uNfE6q3/o0mhpBcbQoSmpP0D++Bgn12vlgklvsog==",
       "license": "MIT",
       "dependencies": {
@@ -1787,7 +1787,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.5-rc.1.tgz",
       "integrity": "sha512-qCzSHZLZoV5NLgzVGj+h/OAqEOUF9NaFxyD3bdZSpy1xL9ZTmBitpjdmllqiBiIbxRx4AxCiYfOQ38ZGMlyD4Q==",
       "license": "MIT",
       "peerDependencies": {
@@ -1796,7 +1796,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.5-rc.1.tgz",
       "integrity": "sha512-8dvV1zZBG0yx2/DPj3MWtFom8jaJONkCwu0n98peEvGtqzu1vJJZQEfMAD6kxSi/jq5Ws0pt60byPa5PAtW2vA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1805,7 +1805,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.5-rc.1.tgz",
       "integrity": "sha512-DEE4oGtDd0O0jCuo3Jrpt1FF5RIA49P6TfObJbhugOzdt2X1vdsoEqZZDAO4yuu6f2QedgM1mGP3IMCP9J57Qg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1814,7 +1814,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.5-rc.1.tgz",
       "integrity": "sha512-AG8NSL/dzQaq9NmnVpVQIXuNghR3Gr6QbAQvx7Qm49JG+JbJGBurWcYXLgH6OX+hxE2w3y0DezJ2LxLq6ZZs0A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1823,7 +1823,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar-documentpreview": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar-documentpreview/-/dsh-client-ui-sidebar-documentpreview-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-documentpreview/-/dsh-client-ui-sidebar-documentpreview-0.1.5-rc.1.tgz",
       "integrity": "sha512-EnxzXokzQDP/ZkhtQuzHqwFYzB6EZFESRzGhuUTREyZihdM7q4Z1zcRObOw8Btr7WSuiZH/il4RGwDN16XTvMg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1832,7 +1832,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar-files": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar-files/-/dsh-client-ui-sidebar-files-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-files/-/dsh-client-ui-sidebar-files-0.1.5-rc.1.tgz",
       "integrity": "sha512-QnR84tTkCpk59j403bIhGjdLFounfNrRcWQKRcFU01bGkaMdhIaU6AsEGv5pTw2DbCTP4blCeTGr806olIjzIQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1841,7 +1841,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar-right": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar-right/-/dsh-client-ui-sidebar-right-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-right/-/dsh-client-ui-sidebar-right-0.1.5-rc.1.tgz",
       "integrity": "sha512-JFKsoWRdfX4r++DL2CbuDAgZ6Di1L3siSjcl5z6ilieFfcsN9eUHyOcZN+2WKOQtmpw374ZwrN5Z/i+coO/mCA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1850,7 +1850,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.5-rc.1.tgz",
       "integrity": "sha512-Y6BeDPWD1/waLUiJgnI1T1uz3zzTUypvva7Tr9Sykf50JROIffRVwPCQnZQn61A5k+fbDCFMaaabHpzFdYPNAQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1859,7 +1859,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.5-rc.1.tgz",
       "integrity": "sha512-FViVXMZSnxod6FBAkXOGb+YEMRNPfi+Aauyh+my5EWbvSKEnXTKBYEtoiSN9Y2laS8ZonJgNI4p5Bthb7MVpYA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1868,7 +1868,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q4A4dgpF9WVKN/wo+3LlFHJOp7UMFdFzEITB5WhiwsKADYpU/n6sE8FkWIeFo0g1eqJY9bHAseqQYOAdZ227/g==",
       "license": "MIT",
       "dependencies": {
@@ -1880,7 +1880,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.5-rc.1.tgz",
       "integrity": "sha512-3TOV/T2r7sCxHXaXh+HHvRxh5oMv8ONg9yHTWVsCBKiMO2ZMWBmb4Eqns7+C0c6mNH9FXRR4vSzaUci+v57XDQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1889,7 +1889,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.5-rc.1.tgz",
       "integrity": "sha512-j5rZXHuu+0v8kBVC65s5dBKSh/qFzA0B577d0zL4D7f1iP1zQ3OGnRYKRlcsZ+WCA4b3nIAI3StJdnKx65+xNA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1898,7 +1898,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.5-rc.1.tgz",
       "integrity": "sha512-NpIjEdE97VKDG2vGye8GY6VLUbY0CzJCGIAir+UZ24WfHtlGxhoKheBvoeijjiEEKoQwM1o2xlDUBGxK8DlfjQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1907,7 +1907,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.5-rc.1.tgz",
       "integrity": "sha512-IqAfHrQMbnfrYFz6fuK6z9POtJUiWiIUnZ3WxTxSxbVqi386G0+HoEu22rzqglgeSMH9VdXpsoczXE5jphcw4A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1916,7 +1916,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.5-rc.1.tgz",
       "integrity": "sha512-ESKP4+0zJa5KB86HzKl573Zk3EUwyuzyXc0y1Bj/J7aWsFLj4LYkud7iVl0Pag5P2cM7LpB/0Pm/d45E9tec8w==",
       "license": "MIT",
       "peerDependencies": {
@@ -1925,7 +1925,7 @@
     },
     "node_modules/@deepseek-ai/dsh-cmdline": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.5-rc.1.tgz",
       "integrity": "sha512-hZFWY6blJCp8WFbyP9ETLMtBhp6jNcBSaxaFxtOO3MTVFgbUGE/2/zdTSu389j9B/eNXhEoiaIsk9BT0VtD4lg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1935,7 +1935,7 @@
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.5-rc.1.tgz",
       "integrity": "sha512-DfqzMEQW42lVQjjQ6FCEmtzAuYGle1grxqrRPqdXhkDYe4aTSLJLEcqn7/BYZSI64/G1XQYvdS+jkYxbymbv3A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1944,7 +1944,7 @@
     },
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.5-rc.1.tgz",
       "integrity": "sha512-UvrZCSLFD15bwrN2r+MMVxgWSLzwz0R2zm4FbA3yUHDtQXpNsGZeGq6uLVOTc5yKsrFGkxCA/0gIaBPo2dze3w==",
       "license": "MIT",
       "dependencies": {
@@ -1960,7 +1960,7 @@
     },
     "node_modules/@deepseek-ai/dsh-command-compact": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.5-rc.1.tgz",
       "integrity": "sha512-VzZ2dltTYijSL5lMWiOxrIcO0sd/kW/df2mQFJtlDygn9qP6KmXkJYjy78iF9lCnu2tkeUwL9ypd16ZdS4/MKA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1971,7 +1971,7 @@
     },
     "node_modules/@deepseek-ai/dsh-command-feedback": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.5-rc.1.tgz",
       "integrity": "sha512-LqDBHmjfI3oF5uwG2te5Xwa64zbV3aD0EsVa7/V7nMoWSuORlbdBa9YN0EBXpsxmjOwbik8BKaPZPIAdoLRNsQ==",
       "license": "MIT",
       "dependencies": {
@@ -1987,7 +1987,7 @@
     },
     "node_modules/@deepseek-ai/dsh-command-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-qmfPA2fOf53Vgda1btYhJ1ryQpcwiGxtYukyhQKwmwOt/wa1b+Xkcvq58qQOAOtm5fSbWWpKGRhbFxikxlHl3g==",
       "license": "MIT",
       "peerDependencies": {
@@ -1999,7 +1999,7 @@
     },
     "node_modules/@deepseek-ai/dsh-commands": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.5-rc.1.tgz",
       "integrity": "sha512-OMk0uVNbr2RdsItcIigp/2boGulqjei1uoQH3/DZYHB+aWWRXEYa6rk6vW3t82lnkd/6nvyQFV8eccQWZ2PQXQ==",
       "license": "MIT",
       "dependencies": {
@@ -2020,7 +2020,7 @@
     },
     "node_modules/@deepseek-ai/dsh-compaction": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.5-rc.1.tgz",
       "integrity": "sha512-DF1BcWNwA997vrR94yfxVxSvXCVejgv8/ytxNkxvliKK79wFr6DMPAdv9ludapE5PXVO62PLgjV4CE2lxW53fA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2034,7 +2034,7 @@
     },
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.5-rc.1.tgz",
       "integrity": "sha512-Zhl+GOZdNuPmInk6Oko1IkfDMpGSoE2VLFkhfhqjP7mxC3t/OxWmP1fXkvNKiHGHPXrGUx9NLRE1T0AK3zSAGg==",
       "license": "MIT",
       "dependencies": {
@@ -2059,7 +2059,7 @@
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.5-rc.1.tgz",
       "integrity": "sha512-s9TmPMUenf8fDQxm2C0nwKasLMqCYx+ZSn5gXN/GFnSTW2YrPPD/o7KnvlhhFGeuBoE2s+hUXgg5Ro4cbPmzlA==",
       "license": "MIT",
       "dependencies": {
@@ -2076,7 +2076,7 @@
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.5-rc.1.tgz",
       "integrity": "sha512-kd/5/0wWzTbhuigTfymPg8f659Q+HyymVapE+EdYImJDUgbKDPon9i4DmS1wiiwTYgjHPo8VR7QhZ231vJaw8A==",
       "license": "MIT",
       "peerDependencies": {
@@ -2085,7 +2085,7 @@
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.5-rc.1.tgz",
       "integrity": "sha512-f9wflxVAwH6YRQl/CJE8xC18iKAslokEGGRXtWst/ymiOlhTaQC4Iv7CAlrTF5c7er+OUeIODs22GTGHtglz1A==",
       "license": "MIT",
       "dependencies": {
@@ -2106,7 +2106,7 @@
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.5-rc.1.tgz",
       "integrity": "sha512-+pcIimUNe2OQWZVwJFTbKEMUQA/6JAx+EMPodzgJgZzDPwsnYE8OClS2aXY9PW8T6DdaKAX+MVWptTsoVVEmBA==",
       "license": "MIT",
       "dependencies": {
@@ -2119,7 +2119,7 @@
     },
     "node_modules/@deepseek-ai/dsh-credentials-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-S5C3+ItHsJ4WlSQEvY4qqHB/txxe7NnaQXEbsjVDZUwUci5Ia3TaEvH0yz6Oi6ovG2oPrYulzorg6G1ayjPRZg==",
       "license": "MIT",
       "dependencies": {
@@ -2137,7 +2137,7 @@
     },
     "node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.5-rc.1.tgz",
       "integrity": "sha512-xnWdajsbw8vLLoWWw/t3URyFZho5NhFCVfcKumLUU7/6g8RXpYSfdPE1ouMufg/++ESSYEAFtITRaPuZ80jiDg==",
       "license": "MIT",
       "peerDependencies": {
@@ -2146,7 +2146,7 @@
     },
     "node_modules/@deepseek-ai/dsh-deque": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.5-rc.1.tgz",
       "integrity": "sha512-lg+nPOuVz1OfqFnp7FmawYx76DjCrFXgLKG82m7xIHeTqJqUpQlQnTalL20VzTqZCGTsnsvQtrQLzLXTPykXTg==",
       "license": "MIT",
       "peerDependencies": {
@@ -2155,7 +2155,7 @@
     },
     "node_modules/@deepseek-ai/dsh-file-reference": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.5-rc.1.tgz",
       "integrity": "sha512-XjgSLZOiAK3khVpACpqk+/G5j9noPO14+tf5p70S7N5PFFNT2oav4ojB+OGo+gs1bNWrDlij6vR0ePxV2rzfSA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2165,7 +2165,7 @@
     },
     "node_modules/@deepseek-ai/dsh-file-reference-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-Ig/UBqBsCA675680DZ8xk5OELb8ERU4mJ8uTjIuTsUyQliNGcP49I23DywoiNIzLX/zzAigeYkZ77bZLFu7vLg==",
       "license": "MIT",
       "dependencies": {
@@ -2181,7 +2181,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.5-rc.1.tgz",
       "integrity": "sha512-F+loGiwsT09YpRONuFv0+bevEdfmbKBFjxxM8JkDOXpgwk1JXdGNSy7Kp4vXXVh3GcmYkd8VA7iB7NuVp51ytQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2194,7 +2194,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-Qyqs9l+ZENq4PL7EwBpisvXcqJvCxGTrD/zH0Zj+S0eZee1kXrQjkY0gjW6dxAosGlLL7hZu0kdaD7TPxtKVcA==",
       "license": "MIT",
       "dependencies": {
@@ -2208,7 +2208,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-TGu/2UrZS8KWr6x3sKLce7u0KoGrq5l+RK7ITd79n2WNzSCcAdzN5tsxUEo8JgfHij5S0QRgID0Q8DOx/6iQew==",
       "license": "MIT",
       "peerDependencies": {
@@ -2218,7 +2218,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-np+3EdQ86w609DwyaEUFGEHjSQ5i2NFypQxcM9sB+zX6DVSUR9sA2W/fmnStFJdsSzvgXYTCnJiBhlKnAXPf0g==",
       "license": "MIT",
       "peerDependencies": {
@@ -2231,7 +2231,7 @@
     },
     "node_modules/@deepseek-ai/dsh-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-RF+cHqV0O7xkoqkhIst6NhMAwqXXAjTf7Z+H7FLHtZBvFAawU8zC7n7/tmS4P7rZYV+XYFYCDdNoI0GwPReCYA==",
       "license": "MIT",
       "dependencies": {
@@ -2252,7 +2252,7 @@
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.5-rc.1.tgz",
       "integrity": "sha512-t564V58sl4N6V4CBbgOvJGlGFCUt6NtnDVZaebE8bDZOedRd7DtoXyxtuTZOBk4skF+416oQJdA24ybtefH2Ow==",
       "license": "MIT",
       "peerDependencies": {
@@ -2266,7 +2266,7 @@
     },
     "node_modules/@deepseek-ai/dsh-headless": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.5-rc.1.tgz",
       "integrity": "sha512-J1XWUYuPPxxzZC0cUgznJ7yuDG/lhuXXAwOsfkTq6BADb083GzXJL6ppKolDBOhbgLmmLj/7Zq+Ss7aswyEhBA==",
       "license": "MIT",
       "dependencies": {
@@ -2288,7 +2288,7 @@
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.5-rc.1.tgz",
       "integrity": "sha512-CxMi9qHY/zIkzo+UsA+/8UbTagRo6HL07iy32iTYV7gVmXTRt66ViNMDcwXHIlqiQ1A6y7cc0GYTVk88XcyL7A==",
       "license": "MIT",
       "peerDependencies": {
@@ -2297,7 +2297,7 @@
     },
     "node_modules/@deepseek-ai/dsh-hook-protocol": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.5-rc.1.tgz",
       "integrity": "sha512-rkroa/Fq+ErLAaFm5Z9Er01RFq1W0zbzmuDkmg4EeKUjTA3/SlQW0UldbeNIP/amxiqRJdDSYGwGKDXvRnYabQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2309,7 +2309,7 @@
     },
     "node_modules/@deepseek-ai/dsh-hooks-claude-code": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.5-rc.1.tgz",
       "integrity": "sha512-2WaWwkPSjRG3OVhO/nxfxc1qZQb2g7YPSOhqsmJsgnumtcdTuDCuQbS0VRQpkAJrBMbW20/hitpl1U2FgHLdmA==",
       "license": "MIT",
       "dependencies": {
@@ -2328,7 +2328,7 @@
     },
     "node_modules/@deepseek-ai/dsh-hooks-codex": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.5-rc.1.tgz",
       "integrity": "sha512-NfILKE0cluKGogalOCjVM/l5FMBtSH0mUWhGNVI9mPqQ7flVWbi205XOvznmbENyw9Jnak1W3X/AeT1E0PXC3Q==",
       "license": "MIT",
       "dependencies": {
@@ -2346,7 +2346,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.5-rc.1.tgz",
       "integrity": "sha512-zKbIv4vnWMLV0BVo7LrAjsphbgIB77Se0iOGV3bnF1d9RKHxnkLfyZ6Vt6Y/MKqtKR9UMi1q2z/qls153VOWBw==",
       "license": "MIT",
       "peerDependencies": {
@@ -2355,7 +2355,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.5-rc.1.tgz",
       "integrity": "sha512-GYkEPJo2+3DrZfsJY+nYHIeFYp8kQ0YfCo4Ul1NJ4ALwN/bg4IboLoesMtNsc5W/BaGNV0Y46ivCBjFx33ibeg==",
       "license": "MIT",
       "dependencies": {
@@ -2373,7 +2373,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.5-rc.1.tgz",
       "integrity": "sha512-dmB+OK+NFkVjtIguRwgdPMTE7j4/wSotBBM+hvTgAeLF0QR3J2elipiQAhwgQwTtWh5ktLblfzV+/R7yinaIhQ==",
       "license": "MIT",
       "dependencies": {
@@ -2386,7 +2386,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.5-rc.1.tgz",
       "integrity": "sha512-gbR/CkVRs9rVEMTPwCdhXCeJQtVe2/ph/R7CSZr6AWY9GUXDahbw2V1a2GU/FmySO6hfWD2MBx5+fCUuWs59WQ==",
       "license": "MIT",
       "dependencies": {
@@ -2400,7 +2400,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.5-rc.1.tgz",
       "integrity": "sha512-4ryTu2EPqM2w1h1Z7kLzYAm2paC4MjuwJmWwz6qwBsI5OeZNYt4Q8Ew1C8F8vsFR/jcwho4ZCkdhLcEunLF5fQ==",
       "license": "MIT",
       "dependencies": {
@@ -2414,7 +2414,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-open-in-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-open-in-app/-/dsh-host-open-in-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-open-in-app/-/dsh-host-open-in-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-gfyH+UfR3t8hPpHACN5csFz1r+13efNUC9dpa/HriY2LnnVvcN1Kj9CW7hOAe/NfawFF/adYxb4kqo0wgzWxYA==",
       "license": "MIT",
       "dependencies": {
@@ -2429,7 +2429,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.5-rc.1.tgz",
       "integrity": "sha512-xCOJ1nTW2s5etl18QhBBGpcOxiDfGxofe+4pd90/ZX+vW1vAhaHqyTYSRucOQVGyJb9zvdWCg7R3GcBYn6pUrQ==",
       "license": "MIT",
       "dependencies": {
@@ -2450,7 +2450,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-webserver": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.5-rc.1.tgz",
       "integrity": "sha512-5kOu9kb0AuRN60/zwPTRcki801ozgnWAFwS1QtQ4ZNgCYIbAiU8gwJHY1//qEpUOuHS+26k+Tqq5/WCJmLGE6Q==",
       "license": "MIT",
       "dependencies": {
@@ -2464,7 +2464,7 @@
     },
     "node_modules/@deepseek-ai/dsh-http-proxy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-http-proxy/-/dsh-http-proxy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-http-proxy/-/dsh-http-proxy-0.1.5-rc.1.tgz",
       "integrity": "sha512-uzqFRi5d6k5ZiV4Q7CxkPUKGZrURN7VBdKAS0LNuBCUApI//vA72blWC+vn2Lz0BKKb8GDrBTuD2ZwCdXIObYg==",
       "license": "MIT",
       "dependencies": {
@@ -2476,7 +2476,7 @@
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.5-rc.1.tgz",
       "integrity": "sha512-iXhJJ3r34NHFEWiuc5pxXlU19hPfNclvH9Ll0X7CzQ39Oh/4UlfO3DBlLpBU7T9fE/y7/UkuI1aRt+dNeiVQsQ==",
       "license": "MIT",
       "dependencies": {
@@ -2488,7 +2488,7 @@
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.5-rc.1.tgz",
       "integrity": "sha512-0AWlZLcIpwdtV9A9fVeJ7b9jpXX0494fPL594gE/Kp1q9jHYyerIulrMHZa17kpu9W59cb1AJNPQy2xN6VDX7g==",
       "license": "MIT",
       "peerDependencies": {
@@ -2501,7 +2501,7 @@
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-19sCxqUKduNO8E3YICSzOfajpBLPXbK/3p40GlxR6bGcOhxqhyH3TPdQS6UQjwNa5bUXHiW9GyB1xUWUUFGAJA==",
       "license": "MIT",
       "dependencies": {
@@ -2517,7 +2517,7 @@
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.5-rc.1.tgz",
       "integrity": "sha512-F2vKsFL491FYjlPLzM2/TtuCt88LrV5SAk+r4zNlt9gvbQ+ZEdeVD4uFRwFc8TpYfdM/yL3qioGEpTuU26TxTQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2526,7 +2526,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.5-rc.1.tgz",
       "integrity": "sha512-KPKJFTNLjURphuF4NlS8DRK94CUYL/dKB8Hzg/22jtxAFO2paX3ifL0vhdPq9xPbcyplaF7LYlf0+3+pXFTnTg==",
       "license": "MIT",
       "dependencies": {
@@ -2544,7 +2544,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-PwqB/Amrtc4nF+ndH6UNIOAH+X2QREwV3R3NaBxY/n0j+hfAl3BUmafj/9UvKlFwStYLLxsyS4um7Vy+XQXhNg==",
       "license": "MIT",
       "dependencies": {
@@ -2570,7 +2570,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.5-rc.1.tgz",
       "integrity": "sha512-5OiNHkkVFDucqXY1KT9QQB7EAulbKDDpqrrK7WTJbLzjVUs98ZetAOf1UOZ15JqA1hABX2+fCoXyitPK9yuuvA==",
       "license": "MIT",
       "dependencies": {
@@ -2593,7 +2593,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.5-rc.1.tgz",
       "integrity": "sha512-WcA5KOmv8aC5F8s60riyaVBSNKBpCrSByzpNbATpNKmU6MHKHSpmYOfOO8vUJQY+cdC3qCOcWwtOd56VpoMPGw==",
       "license": "MIT",
       "dependencies": {
@@ -2613,7 +2613,7 @@
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.5-rc.1.tgz",
       "integrity": "sha512-vaxO+lGLsj4B5okcJ3uwrAUoyq9EFqpt6m0rUY9jYlSQHc7RfMkKJ0wpegt8GXUw/WJ0a89dvqI8ojMzi6Jlig==",
       "license": "MIT",
       "dependencies": {
@@ -2633,7 +2633,7 @@
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.5-rc.1.tgz",
       "integrity": "sha512-PztvCosgvzuEOLIwtQ1gVrH7Mz/IUXY9Kj/x63hMpQcnJBmgu7Td5fZljtiAkKexVn2PRFFktyo7MRdN6b08VA==",
       "license": "MIT",
       "dependencies": {
@@ -2652,7 +2652,7 @@
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.5-rc.1.tgz",
       "integrity": "sha512-mQxUZ6eY2FGD3nD/IdoC0PgYpAyip/iOvlHpdoIhV9ehbAd0+YwXw8lzsgrO/bq/KGnff2+LjXSkJvyBcPAabA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2661,7 +2661,7 @@
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.5-rc.1.tgz",
       "integrity": "sha512-bXRq3nGtrsIGOlNNFHLp3gx+59Njl9jnbK30vqiga01y82QzBepfXROWSJGj0Cea0mjxb1tyv0KDRvsHbvTiow==",
       "license": "MIT",
       "peerDependencies": {
@@ -2670,7 +2670,7 @@
     },
     "node_modules/@deepseek-ai/dsh-package-manifest": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-package-manifest/-/dsh-package-manifest-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-package-manifest/-/dsh-package-manifest-0.1.5-rc.1.tgz",
       "integrity": "sha512-BWbXpw5AaCJXrGrbvo+CQYBkiS2ilX3hF3a+dQ4N1OqMALFSMNmUV03aT5yT8WUQEngR6ixvOUUgJvHUK0MiiQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2679,7 +2679,7 @@
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.5-rc.1.tgz",
       "integrity": "sha512-A0xrvtH0AgcH/QycrKHIGEeE98xS0ana8q4wmIYKs/AjuZICR0N/qT4qb1GnPRxcuz/7Z8rHjD/fhou/gFRTpw==",
       "license": "MIT",
       "dependencies": {
@@ -2701,7 +2701,7 @@
     },
     "node_modules/@deepseek-ai/dsh-persona": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.5-rc.1.tgz",
       "integrity": "sha512-IgZ5aCD7Y9bS82WStxTW3InVhajfy5e5mCAMTJMa3Zu2sSCBJ1N9lPKgAmMR8c9YGXl03t7YVuM07fjRYfvmMw==",
       "license": "MIT",
       "dependencies": {
@@ -2714,7 +2714,7 @@
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.5-rc.1.tgz",
       "integrity": "sha512-E1ajaP9NdbIGZK1i+q1QlhPkDSqIEm1Jsiilp3MGQOCM0nxN78IjfbQo8dpgRZMJ9y/N9zXYJtLpGjLksNkv0A==",
       "license": "MIT",
       "dependencies": {
@@ -2740,7 +2740,7 @@
     },
     "node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-6W0vYHshQBw9RLGayAMx+PwoIiCWPSZ3hOrgiuWoeecwFYdHgLvInP2Cht0tCGcidUDLojmooPJ8XxefZ4I8Dw==",
       "license": "MIT",
       "dependencies": {
@@ -2763,7 +2763,7 @@
     },
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-VjTb+R44iPZ2czxD2VN+5YzCpU3WsOtdaKiwNzfswmam73KcjMWuJP1XH6hHLFD3QOjhSr1AaaMYijHYWIEvKQ==",
       "license": "MIT",
       "dependencies": {
@@ -2779,7 +2779,7 @@
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-QRD6PfcQuaRwUTn9EMIx15l1erRqk0erUamcAB3sxPyZOMWIFP7w2cp44Va8RGGDEUb9ZB1vRUH6cF4FAKSZRw==",
       "license": "MIT",
       "peerDependencies": {
@@ -2792,7 +2792,7 @@
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.5-rc.1.tgz",
       "integrity": "sha512-dFdo4icZLP8MvDpGTWTt9/xjVwwoJuzp5jUeBUBxyiK0uSfcdAv+bWW3ghDWeyfRUhpkJIThLb1VmkpfBk9paw==",
       "license": "MIT",
       "dependencies": {
@@ -2806,7 +2806,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-xT+oTsSE7tRZVqqcj2qDZJARoK6A+Dmhf3CWPqlaFG/83Zh41kwcW2YWE4sA+vCt2pI2iqLYRw1SftSGawOtVQ==",
       "license": "MIT",
       "dependencies": {
@@ -2820,7 +2820,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-cO8edQeX6sdOzbYuCzyadc6o7QFM2upNuEqb32+VXXDl3qCaNb68NBZxaZaBCfC2/aofcvCL+b6rRE5bcauXRA==",
       "license": "MIT",
       "dependencies": {
@@ -2838,7 +2838,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-jLeny81NVsAiEWW8+MqmtkXJfu8CSFDPiuR8W4I/bZ7TNHrPTN7jPuk1/JlphkU4bq1N1a3iLvsDyHK+56ZLVA==",
       "license": "MIT",
       "dependencies": {
@@ -2857,7 +2857,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.5-rc.1.tgz",
       "integrity": "sha512-gziY3YdGfq4W03W+qeEKF0oH/3U6XNU0YoUnU4PeBIJFqg1NPamxoX7CdoFXuJgLkYN97IFf2ihQMLfzWvhwhQ==",
       "license": "MIT",
       "dependencies": {
@@ -2870,7 +2870,7 @@
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.5-rc.1.tgz",
       "integrity": "sha512-3Kp/2G1yw7aolCQNvZocpN1kSj2dRUHQ/HpYhEmMInBT1OZT4nm+x7UXnxLcskc7R+HIKbd7KpV8YNwkn1K/Eg==",
       "license": "MIT",
       "dependencies": {
@@ -2890,7 +2890,7 @@
     },
     "node_modules/@deepseek-ai/dsh-scope": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.5-rc.1.tgz",
       "integrity": "sha512-HU6AGzCCWSQUS9KoDBAPkyQqgUVp+iI9P5Zn0qzLJv3IOdt6cYvxgjt/rORryuQUR9AUj7CGFO3OYw833H7HWA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2900,7 +2900,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-0slsRRDEkq5fxDYF0P9tHtZtzjyvg/dB30w6AhvqEX13MRiNdirUQNSsS62yCuCgRzTx0YDg+oQJUwPAw07tOg==",
       "license": "MIT",
       "dependencies": {
@@ -2915,7 +2915,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-client": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.1.5-rc.1.tgz",
       "integrity": "sha512-PccdJ5DycaCBJKc3F2YaU7SL4tQNKEW6SkDRiDEM6IrzYl0lZu2RWUlwWlXfi+e5zV+vMYfIYJ1wTdlROewMBw==",
       "license": "MIT",
       "dependencies": {
@@ -2930,7 +2930,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.5-rc.1.tgz",
       "integrity": "sha512-pg80s3S6EBJOmQb+wT4M10+jgxJw/6ebf8Mr0+FChwCR2HTraKQRo40LmPqgVMCZTj753VZODu8SIQbpUwzhoQ==",
       "license": "MIT",
       "dependencies": {
@@ -2951,7 +2951,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-minimal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.5-rc.1.tgz",
       "integrity": "sha512-jWH+1cmiS7LMrpF3OAQqoTSWxC45sxvNHshOBikYqaoUf4sBpSUiTaxy52ZWCB1/tcxB/ZYr1fBDDvTGsg9JfQ==",
       "license": "MIT",
       "dependencies": {
@@ -2989,7 +2989,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-protocol": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.5-rc.1.tgz",
       "integrity": "sha512-xTleAtWust5wpcjv3HQnFLB0KJIBFthwWerriVtXUz4JUw2b08m7S0JNveKIVDstulNxBvHqgXThtpz7nI9Pow==",
       "license": "MIT",
       "peerDependencies": {
@@ -3001,7 +3001,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.5-rc.1.tgz",
       "integrity": "sha512-0YBBrzkCbVEJolS/OpD0DZMSozmYxUTZopiG76MXInjOFBW9J4ca1a8WUjJjqelP1nJTmWGKXp92HcvNEny0Dg==",
       "license": "MIT",
       "dependencies": {
@@ -3016,7 +3016,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-q0DXnkvEBmgEnyHYmKGOrkPUOnyEQV/LDMiP6Cnx8xEgdDztALa0koUuRr0Z+3+vlWUKsbXuKkkn3D2yXMW8tA==",
       "license": "MIT",
       "peerDependencies": {
@@ -3030,7 +3030,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format/-/dsh-session-format-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format/-/dsh-session-format-0.1.5-rc.1.tgz",
       "integrity": "sha512-i90c0z2F4k+46CBOuWW/0b2UPnHpDqhS0PictwxWrh7Em7OSwyCTN2dz9cwraCXubg4APTiBCLeOslxvTCKzmQ==",
       "license": "MIT",
       "dependencies": {
@@ -3042,7 +3042,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-catalog": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-catalog/-/dsh-session-format-catalog-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-catalog/-/dsh-session-format-catalog-0.1.5-rc.1.tgz",
       "integrity": "sha512-5MT9Z56QjpcgJ+b9UFfVR3Rd9ylaJtKAFFkXp6uFm4ATsK5hTdtrVHgj2rsvqlEVnNAO2gcrnvVd/9diFotv6A==",
       "license": "MIT",
       "dependencies": {
@@ -3058,7 +3058,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-v0-to-v1": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-v0-to-v1/-/dsh-session-format-v0-to-v1-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v0-to-v1/-/dsh-session-format-v0-to-v1-0.1.5-rc.1.tgz",
       "integrity": "sha512-zKayd3l7YETy0agKB5Mg0gdDKkeaHUOmDYblVhS346Wl5G3ZTuurvgwXMNglfwvy7O0uNfOS/SvnU0eWQ4sV1w==",
       "license": "MIT",
       "dependencies": {
@@ -3071,7 +3071,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-v1-to-v2": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-v1-to-v2/-/dsh-session-format-v1-to-v2-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v1-to-v2/-/dsh-session-format-v1-to-v2-0.1.5-rc.1.tgz",
       "integrity": "sha512-wwgTHoeItoITykmlhWFhN8BM87NP58p/OMBrm9UEDd6Z0Y5T+8/ijoVFhPbWIQFMyWdTLF/3JMsS+RxcKwRESg==",
       "license": "MIT",
       "dependencies": {
@@ -3086,7 +3086,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-v2-to-v3": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-v2-to-v3/-/dsh-session-format-v2-to-v3-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v2-to-v3/-/dsh-session-format-v2-to-v3-0.1.5-rc.1.tgz",
       "integrity": "sha512-BH41t2xsAxk2ibigx8WcZZknwxT19IrN1gOm//Qoj0K0qFJ4lWWgj6kJcNyIhdFvTbXOAoaF7KTYEM10Nmzs+w==",
       "license": "MIT",
       "dependencies": {
@@ -3100,7 +3100,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-log-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q2eNVnLsigVRenf+qQxLHWF38GWiRFGWkHAacwwXCZOQUYBNFXnrSGXAGF8gW1tUQAkCKPTsx6LohMW7GDgfAg==",
       "license": "MIT",
       "dependencies": {
@@ -3117,7 +3117,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.5-rc.1.tgz",
       "integrity": "sha512-/SGAggREmyYmVu4F3daNqXE1rFcaeuvOONUwh5dRXf+xMtY/5E1wtwI0K0aJ53+1r6+Azzd9X4xc5EqToV4YiA==",
       "license": "MIT",
       "dependencies": {
@@ -3134,7 +3134,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.5-rc.1.tgz",
       "integrity": "sha512-ZOFdFdsX5w4lWln1CO2ZzdnibEIOoPu58rlafw4xsLaPoR5mnceVnIuGIYr8qqaB7iv2f9ZLNaGtyHT/Wgpv0Q==",
       "license": "MIT",
       "dependencies": {
@@ -3149,7 +3149,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.5-rc.1.tgz",
       "integrity": "sha512-/OzAiGuAS6UoiJoQSkoPekFVGB7lNYQp5maN7ZckzQ8oYf1xS5pQPFKptIrgYwd6pZRb2lDlFZhZtBvL0KGHOg==",
       "license": "MIT",
       "dependencies": {
@@ -3169,7 +3169,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.5-rc.1.tgz",
       "integrity": "sha512-dwDS3ite9I1oOAPneA87ieHBd+szFNrTeMNF4XHRxexMbBWxNZUv62h714UMNlk2niGKsAKE56PzwlnWHmGwGg==",
       "license": "MIT",
       "dependencies": {
@@ -3182,7 +3182,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.5-rc.1.tgz",
       "integrity": "sha512-455PbLGmBNQcOFX1s/yYd3fkRCy13TbQMcVouyhTCzo9KrbiDPg2jPVTkTpQgoo8X9RaAm/hbST781rNqja87g==",
       "license": "MIT",
       "dependencies": {
@@ -3199,7 +3199,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.5-rc.1.tgz",
       "integrity": "sha512-4FdRNYdUb7uXV9NGSJJtyV+qT0ex3DlidXyWsOPj+8DXo90I24mveLvK72w8IuXDXS2hpO7tJVYoRk8LkxCtIg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3227,7 +3227,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.5-rc.1.tgz",
       "integrity": "sha512-WU9L78sMN0smbRndw59COnkG63/r1d3HfRXnGLMcGiJWTJNsMQLniZq1t6SvChtPPsGN4Djr0jGwSULRI20Sbg==",
       "license": "MIT",
       "dependencies": {
@@ -3247,7 +3247,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.5-rc.1.tgz",
       "integrity": "sha512-rbHLt6qm75wqxzUpp3jw9twcEsWVTAZnSa8uNcqtIAeHbPhlgDKqNxvxOeoQPPmlNFr5y//FCQ4S27B1cqxw4A==",
       "license": "MIT",
       "dependencies": {
@@ -3282,7 +3282,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.5-rc.1.tgz",
       "integrity": "sha512-xq0iu4FRCw6Jgy6VFVwK/ND3R8gNWZ754GXkRfF59OYnWJ9N07JqYw0iCKzg3nUcd3kMYrPCDTPZW1jMUtn1eA==",
       "license": "MIT",
       "dependencies": {
@@ -3297,7 +3297,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.5-rc.1.tgz",
       "integrity": "sha512-051BiuVwm55jvoXuobz1FSA9p1hmpvcJUiBylpvU5rS7u+Jd+iLTkti80954FfSs3bNoTCBRb/mEHmXjl+9YaQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -3308,7 +3308,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.5-rc.1.tgz",
       "integrity": "sha512-UQfr47iXoMkOQXZqn56p5Pd7rXghPzxpuZJwSydhlNHqIzvYC17tf8TvbNA4FCc63uXv5ISSdcli6smZLHbtfA==",
       "license": "MIT",
       "dependencies": {
@@ -3332,7 +3332,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.5-rc.1.tgz",
       "integrity": "sha512-Gz1qZ9rXiNzogz9StL4+oV3PilLvK6kCgtXSYJZeLIr7quliwDObCmP68+B4vncLPUeBpEaN5ozyE2ymFuzNPg==",
       "license": "MIT",
       "dependencies": {
@@ -3352,7 +3352,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.5-rc.1.tgz",
       "integrity": "sha512-bEF/hyR7eBvBG/EDnERFajo3+phtyGbhpHdm5DRcMzv0EC+JMPVn/vVeOXYzYRvJ95trTntsoVBczL51YdFlkg==",
       "license": "MIT",
       "dependencies": {
@@ -3368,7 +3368,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.5-rc.1.tgz",
       "integrity": "sha512-csGnyYOFr7ubBZQ38sKgfQYujdWNP9n0FJdfgAM1y62lYKMWtjzuPJfKQGar7VsW2E/fBGeyIuLmUP5sEJc/0w==",
       "license": "MIT",
       "dependencies": {
@@ -3385,7 +3385,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-turn-outline": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.5-rc.1.tgz",
       "integrity": "sha512-vH6KMszzMCQHJOpVkYOhBqwAN94zFP33ByUbAWag2BT6YDmEXh3pE1lKd7glyGfuPJE6W0cDUUuWLIr5cWLkyA==",
       "license": "MIT",
       "dependencies": {
@@ -3400,7 +3400,7 @@
     },
     "node_modules/@deepseek-ai/dsh-settings": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.5-rc.1.tgz",
       "integrity": "sha512-9t6JlHwnMu7qTHpMVVRLyzfi7yWKlDozmh7Xbjjd5mmzY+dSdKTPsoRGSdGgTLvBMQBi0X2O8Kj2moDp30XKGg==",
       "license": "MIT",
       "dependencies": {
@@ -3416,7 +3416,7 @@
     },
     "node_modules/@deepseek-ai/dsh-settings-file": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.5-rc.1.tgz",
       "integrity": "sha512-y/9cLMidbEq53N4IFYVUgnim9Zfk0UYVTAPkzegOlHCyLQY2mK86u+GU4fXw1mMoO7JH5JjS6SiBTA8ZX4h0DQ==",
       "license": "MIT",
       "dependencies": {
@@ -3434,7 +3434,7 @@
     },
     "node_modules/@deepseek-ai/dsh-shell": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.5-rc.1.tgz",
       "integrity": "sha512-8V7iGmfsXDFMyftwQXemh1QLqcUysvy+bYWXr620/1B/sMn3oU8dhXvT8i4uD6VkMy2rds3XScUQ3XBl7ByMLA==",
       "license": "MIT",
       "peerDependencies": {
@@ -3446,7 +3446,7 @@
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.5-rc.1.tgz",
       "integrity": "sha512-OO4AmGqqHUWRPK1PSroO/TJG3rNwoAgIMx56S3aiM7v4cUtNmUtMQ71lv9kOezcW+2VlHxfup5jhzpYIQAIiSw==",
       "license": "MIT",
       "dependencies": {
@@ -3461,7 +3461,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.5-rc.1.tgz",
       "integrity": "sha512-SmlIL6lak8nf+Ioiad0N/iImx/S8NO23ile95rsnfJLOPCxSTjNunyjtSkE6ioyAS8UQaIb4gkVo+LvLYKI0NA==",
       "license": "MIT",
       "dependencies": {
@@ -3476,7 +3476,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.5-rc.1.tgz",
       "integrity": "sha512-DAEEzizxOPH13HlHDzxT4WiNzCFtbMAfGxTWKpftG5ybfRlb/DBZZu7Bg6vgm/ZXiWcpvlCo7kg0hie0DBjKsg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3486,7 +3486,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.5-rc.1.tgz",
       "integrity": "sha512-E8l6NITQ47uVNzfhPz9OLUzxZX3Q0M8K6Vqol5Q8Xjl2IKE9VKMKDErFVkf+IWzZclhMimcbZmqAeUrjbTOmFA==",
       "license": "MIT",
       "dependencies": {
@@ -3503,7 +3503,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://bnpm.byted.org/chokidar/-/chokidar-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
@@ -3518,7 +3518,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/readdirp": {
       "version": "5.1.1",
-      "resolved": "https://bnpm.byted.org/readdirp/-/readdirp-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
       "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "license": "MIT",
       "engines": {
@@ -3531,7 +3531,7 @@
     },
     "node_modules/@deepseek-ai/dsh-spill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.5-rc.1.tgz",
       "integrity": "sha512-Dl4ukHqXazACAkxuctFSl3HyjOLLCS1y8Yr8XiD4OQVkoNdJZWjpFwxZemrlEwodQRy4arcbWA0xUOBpGSMkhA==",
       "license": "MIT",
       "peerDependencies": {
@@ -3543,7 +3543,7 @@
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-rsXRuJLhhfyulMqZjYNHT0cOEsKzkwvumfmXQRvkb6LwHi9dHAtu4l7yVVX8F+OpywPKPVJhP+VkU2E5DfKkTw==",
       "license": "MIT",
       "dependencies": {
@@ -3556,7 +3556,7 @@
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-ABtC3dSUs2GWEypkJERbqb6lNqIe3I9qlPd91uG9BrdK2AT5yxhcNHv7PpNWEjhpVZ6dyM4T6ReMcKkKxFKPYg==",
       "license": "MIT",
       "dependencies": {
@@ -3573,7 +3573,7 @@
     },
     "node_modules/@deepseek-ai/dsh-storage": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.5-rc.1.tgz",
       "integrity": "sha512-ng3Xjt6klE35kGH4yBzNfDL1XRVhlw1rC8YQ4aqv8yAMJqeIA1T2eyizyKBl6ewgpu4pzwyANWEHymWLbVQarw==",
       "license": "MIT",
       "peerDependencies": {
@@ -3582,7 +3582,7 @@
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.5-rc.1.tgz",
       "integrity": "sha512-pRubmMAyvllAgmKeS20asIwJHywXL79NyUVXC643pz70IJau8iRTTEbJ6sbN/w4DHsVo5ljm0/PZx4TJ72eAgg==",
       "license": "MIT",
       "dependencies": {
@@ -3597,7 +3597,7 @@
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.5-rc.1.tgz",
       "integrity": "sha512-yPPJmlJRVkgTgbNy5by/0jZFxlixJdIZFp3Dn6o6xF790eYnhGqNUH94v6zuBTnPDgJiCkiwnoo5KK5FEMBkNA==",
       "license": "MIT",
       "dependencies": {
@@ -3610,7 +3610,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.5-rc.1.tgz",
       "integrity": "sha512-3XQxzPkKtjhKcn2TgC1myS4qqT5s+Ya0pSLcp0dP36eS9qGLYkg/F7nM48H/xRsNKari+CIcTkVKn9xvuEz6rg==",
       "license": "MIT",
       "dependencies": {
@@ -3673,7 +3673,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.5-rc.1.tgz",
       "integrity": "sha512-yPuv9snuphUgimZyguvPZRsF7XJ2IKNYpv+JzW1jrxy7lP+DJhxAHdHidwdNYfDKyt+SivRKAo9vqtpRM0m55Q==",
       "license": "MIT",
       "dependencies": {
@@ -3689,7 +3689,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.5-rc.1.tgz",
       "integrity": "sha512-seEjs92TDU/0A3Sk31KPUWT872q7DR+mNCrl0T6Pss37Gv8uhSG9qdorRGJAhf1Y4ACIB+zV334kGfwBgs0xTg==",
       "license": "MIT",
       "dependencies": {
@@ -3707,7 +3707,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.5-rc.1.tgz",
       "integrity": "sha512-vUf+ZdB8stqJUQZlwsZBN3nUJemlnyPiiJC44dF1Lwimx08F8LcXA+tiJ0b78H5p1StXS6BmicFKjrkvc9ZeRQ==",
       "license": "MIT",
       "dependencies": {
@@ -3721,7 +3721,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.5-rc.1.tgz",
       "integrity": "sha512-kAUwSkEn2NqDiX9J8f1CltDhaxBQau8KD1yBQ2cWJ91KdQV6cwi6F7sA6xKD7Ak46Au/YAwwNX+d7cYaKyr0iQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -3731,7 +3731,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-TKcqaIf1fJzjraXhwmSAQAqkPMvIjS0Y7b9fC4n7+G8eQpb3gaF/eJXn6Tx4OgFSDV5R/NLUqHaU/ogxTjdWhQ==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -3748,7 +3748,7 @@
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.5-rc.1.tgz",
       "integrity": "sha512-RAdO9biQoga1vAVTQY9J7THexiOE1FOd1Nli021MQt+Zf73c83BSd2DwXb0WDilLaMeSxZPaIRRqoXpJlpmLIA==",
       "license": "MIT",
       "dependencies": {
@@ -3763,7 +3763,7 @@
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.5-rc.1.tgz",
       "integrity": "sha512-fXsCGJMpefn0uauU1+E+/BWX77Z/Rk+hOxpm5ftNb1YcA6+bttArTQn6KdgFEq3SDXcZwvhUkITffK5wq7nvvA==",
       "license": "MIT",
       "peerDependencies": {
@@ -3774,7 +3774,7 @@
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.5-rc.1.tgz",
       "integrity": "sha512-CeIg1/5jjvtOmtkCyV+V0Qr9piKxDI5UT7jvoL4KdDVZ3R5nTUujaoaFPNhW65cCDR7kd5bEL8SES7JvE8ERJA==",
       "license": "MIT",
       "dependencies": {
@@ -3795,7 +3795,7 @@
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.5-rc.1.tgz",
       "integrity": "sha512-ebhaIxwcUBWzA3TPu811uICzyu2hyWjkh3msppYcilBt6fidgc5l2jVIMZdnDsejpdjDzba/eqwFY5JuexKzxQ==",
       "license": "MIT",
       "dependencies": {
@@ -3814,7 +3814,7 @@
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.5-rc.1.tgz",
       "integrity": "sha512-BcV4y/uCIm82VlIwuGsbLjAZXOxRBmjwusi637MV25hJhhGuWaKoMqAa0D/Lcfqu8hU+g3vgGJdpQvhHnG8sgQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -3823,7 +3823,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.5-rc.1.tgz",
       "integrity": "sha512-b5k6jS8AuW0avt0nRX2IrP38wt8sPL+vhYIE7f2kbdMfH9qcNgBegRh2DtcBLhtaf2E6fxQDQsvA6smOJeVYEA==",
       "license": "MIT",
       "dependencies": {
@@ -3840,7 +3840,7 @@
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.5-rc.1.tgz",
       "integrity": "sha512-Tp4rUwug/u3mV21ri++dN5kCXUecyiVTCeLs8OE/61HiPIUejr5deR54pZEwV+MPPymVOXrmR0V1dBSV0T7Jlw==",
       "license": "MIT",
       "dependencies": {
@@ -3859,7 +3859,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.5-rc.1.tgz",
       "integrity": "sha512-O98eATje45lNWJjIwzEjMULeDT5NnZr1LV3GMNd4PZJih9jfflKpuHnVMvRmyrhk6KRdO4tmsPRSs+Bij7wVUg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3871,7 +3871,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.5-rc.1.tgz",
       "integrity": "sha512-BfZ4R40I7AJFcjHgMkzh3unrp5S7mZT+szUUz4tkbMrAkgHfOdkIHhQ/BTgxWBuFzD18OfAMJ/RnegrBCFVKWw==",
       "license": "MIT",
       "dependencies": {
@@ -3893,7 +3893,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.5-rc.1.tgz",
       "integrity": "sha512-o1mu982ix8Re+84oxs1ZwFObwsEuvLymQlPb/qEJcRm82/Ui3rI0SByPbBHxiHrFp4PLB4WsWCzdKNfIuF8XKQ==",
       "license": "MIT",
       "dependencies": {
@@ -3909,7 +3909,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-rx7nmu2fRWVXbprb950gXpoBxtTLCaJDSShXF73TURZtAjehr7PwMypwWdp4y0YBLfGpmFRjLy09/BK08RFnzw==",
       "license": "MIT",
       "peerDependencies": {
@@ -3921,7 +3921,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.5-rc.1.tgz",
       "integrity": "sha512-dGX+Q/7ggnoLRtofTUXmdTRgvpiWWl53ghpPZgj6lNAh91hjKSmAwxq8vV3fXARZif9OKDJVJ7k0YBaYswOLYg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3937,7 +3937,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.5-rc.1.tgz",
       "integrity": "sha512-BWLWJCJxCECFHmS8gHbnyNJlSTG+KVbVMz73Qduoo+ABeDvWj6cFVXTewAUA9jFEIS3xzJcNilsV1g5DGaEnPw==",
       "license": "MIT",
       "dependencies": {
@@ -3959,7 +3959,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.5-rc.1.tgz",
       "integrity": "sha512-002xxeL5UD2QmssUbiI1mfVsP5hpPAmSM+RNPzlJoQ6OF5RwYjmbMeBhQ4mMlp170cyTLeOa6N6WRx+LnhQQcA==",
       "license": "MIT",
       "dependencies": {
@@ -3980,7 +3980,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-5NCniCOoCeXYXMZNPCmGlrOYIGjnGddTJVOCXNqqAcwxtOxHAoEHTtphaohIa/4Vy7mmRIHgO1KUii443ky1Bw==",
       "license": "MIT",
       "dependencies": {
@@ -3999,7 +3999,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.5-rc.1.tgz",
       "integrity": "sha512-SIgxnjQHl6KE+kpt7VjYCI3aw5DCeztCKGxuJzpLdqJkSoVtewp1Ofz0/Pg1R4DIIaGR8unRyqpZH8qf8uIpzA==",
       "license": "MIT",
       "dependencies": {
@@ -4017,7 +4017,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-present": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-present/-/dsh-tool-present-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-present/-/dsh-tool-present-0.1.5-rc.1.tgz",
       "integrity": "sha512-sfYwTyynqM5ev2TnPXX1WKAwlhFa9msptC//qCxZTsCRCeWoaKwwPj+js0P1nGGV9gIy6QJoDh0uYOPMNlb/Jg==",
       "license": "MIT",
       "dependencies": {
@@ -4035,7 +4035,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.5-rc.1.tgz",
       "integrity": "sha512-UmWePfsJIUfFVj2UFyh8wacqxSXYrABGoBHXWjYFlfqpXt7rfJL31rOl8N1+uYypAVCxe4O2IquuJxfYAVhBLA==",
       "license": "MIT",
       "dependencies": {
@@ -4057,7 +4057,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.5-rc.1.tgz",
       "integrity": "sha512-oQdHTNNsEwdmKTUw7Ve8EkYCVs5hWb3yUxRQJt0E5qPfoTWPzmAUfYQxyZnJW4iKs9TARFKsnA0KjeOAaE4HQw==",
       "license": "MIT",
       "dependencies": {
@@ -4073,7 +4073,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.5-rc.1.tgz",
       "integrity": "sha512-WwLx1/AXydG76/OmLPJheCOlrGXerGyJ6DTbBu+i5/v1/KqHsmg2XbBSBQNaSS1oZcpslPA04+cCOKtL6Sl1rQ==",
       "license": "MIT",
       "dependencies": {
@@ -4091,7 +4091,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.5-rc.1.tgz",
       "integrity": "sha512-f/ulddbkhWXphLce3vlnie8bT9P0LuasehqG+qjsBEiZvGpCS23M3IJoh2j90sUgLhAgW5OSQ0qaut3cTgfAsg==",
       "license": "MIT",
       "dependencies": {
@@ -4107,7 +4107,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.5-rc.1.tgz",
       "integrity": "sha512-t0wme2aOdW7xhyxeH2T+fuR3CyA2lYVioqtrsMNnq9IqUGgoEqEl+pZMgOA9kx1NIxMRyn25vweJlgbm6NaxOw==",
       "license": "MIT",
       "dependencies": {
@@ -4123,7 +4123,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.5-rc.1.tgz",
       "integrity": "sha512-29xQqqjzmMP2A0qxlQpYdbH4Eg3G+FWGpCeRDW7oFq62K4jbOlv7iba8DbG35+Av+TpnXJvMM8j/6BkyLw+dkg==",
       "license": "MIT",
       "dependencies": {
@@ -4147,7 +4147,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.5-rc.1.tgz",
       "integrity": "sha512-vEztxH6ctHdDJFYQjxaOuecV9a9ia0R1eW4DPP5nuQdr1KeJeOl76d6h9KFPdk9gkqZjJwpkJzdH1rAYjkMDhw==",
       "license": "MIT",
       "dependencies": {
@@ -4164,7 +4164,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-todo": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.5-rc.1.tgz",
       "integrity": "sha512-JfVRK72J26j/ouEmzhvcHnVqfFa0jJAPGtrGS9QV1gyTXCVvjlZi1vf4Qihf08d9Kj4LLFybXaxGlh4KEnZkcg==",
       "license": "MIT",
       "dependencies": {
@@ -4182,7 +4182,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-web": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.5-rc.1.tgz",
       "integrity": "sha512-yWU58XcvtKdTT8Rn9f+dkN6IIFUbPd7iIuv9l4PmRMmC9MFT4eZjXABPo1yByVFsW1jjDJlm/XZVyNTnhGBBbw==",
       "license": "MIT",
       "dependencies": {
@@ -4201,7 +4201,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.5-rc.1.tgz",
       "integrity": "sha512-gO7kRxRMabznM4UCMrpG8/YHLP/L5K4ocTMb+EiL9OcwvTSWNORNM2Zz5DAPb/aidJDGY5khSV9G2JGabqA9eA==",
       "license": "MIT",
       "dependencies": {
@@ -4220,7 +4220,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tools": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.5-rc.1.tgz",
       "integrity": "sha512-I5AUxKTqUrC0nvRO4UcpU+f65P+nKs5BUrS2nqZehhFZ2rVxhUAJ7YdORcY6pVkBTB15nPr5gK0WPgwyfS217w==",
       "license": "MIT",
       "dependencies": {
@@ -4242,7 +4242,7 @@
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.5-rc.1.tgz",
       "integrity": "sha512-5kTyT/ZIg8+LUpffO70zTvxPtcpiQPUqGNZCWLG9WrQZzHmOytgIdlGwlFg5Wc6T4JkyA7lXsm5BOn1jI1eJdA==",
       "license": "MIT",
       "dependencies": {
@@ -4256,7 +4256,7 @@
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.5-rc.1.tgz",
       "integrity": "sha512-HBxnSnvjiYPlir6An+/W+66dTRQnwpbNUbtOH6e5LHuV4CcHL5yrimTbMI04olJM9w2U9FyfwDOzmW6uqWjAew==",
       "license": "MIT",
       "peerDependencies": {
@@ -4265,7 +4265,7 @@
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.5-rc.1.tgz",
       "integrity": "sha512-h+lmV9FnNxtlZmY3vH9B4Sj49jt/I7mCPhGG2ffrA+K4twlOjB9TB2Eq9PMoHzWOoHoGoi5QeXDt0mH9fuj1lQ==",
       "license": "MIT",
       "dependencies": {
@@ -4277,7 +4277,7 @@
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.5-rc.1.tgz",
       "integrity": "sha512-fSxEBvHQnozIh5HV31t2BNodYzyv7iE2srna7p5k0Y/3R9c6DdoZyQZ9momcN9gloraq8HK5+cvrYHzgc4LYPQ==",
       "license": "MIT",
       "dependencies": {
@@ -4296,7 +4296,7 @@
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.5-rc.1.tgz",
       "integrity": "sha512-IqbMrL7qortyJGJs/H+iBbxiSke8x1csKxGDJmMmycvKOHo6RIwG5008JkZlEpmm9SU9aaJF1UzDfaGHJl10Tw==",
       "license": "MIT",
       "peerDependencies": {
@@ -4308,7 +4308,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-crypto": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.5-rc.1.tgz",
       "integrity": "sha512-8ZosLrwbXdsWRlZ/0Yu85GMhKbFHqGD+ayiFzABXGb3sxfG6nbQQWKtv1sRr77wJ6wYvM2R9rPOg+EDWkGocqQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -4317,7 +4317,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-time": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.5-rc.1.tgz",
       "integrity": "sha512-HXfJqKymuFv052hHzpHNvrHAcgMbx1BG0o9PiEGkqel9k0fXRBmhWGqrROebZxe5gpIotlVhq7QAXd36p/dyzA==",
       "license": "MIT",
       "peerDependencies": {
@@ -4326,7 +4326,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-values": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.5-rc.1.tgz",
       "integrity": "sha512-iHH62b+Mc0ueLHn1OQGLOC6+WMqjyK2+wxCkaiQGoGHBAyRGQBnBWiFAOGxp2xIElCXsc1mU1nrkN8D6jppYQg==",
       "license": "MIT",
       "peerDependencies": {
@@ -4335,7 +4335,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-workspace-path": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.5-rc.1.tgz",
       "integrity": "sha512-yGU2meCr+8Ru+4WbMtKLlROxtuj9zGjJ6N6bJs20kRxIT0JNlZ6uwqnDQONgN8u44WdyKEaIwbv5IGjxIftLRw==",
       "license": "MIT",
       "peerDependencies": {
@@ -4344,7 +4344,7 @@
     },
     "node_modules/@deepseek-ai/dsh-web": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.5-rc.1.tgz",
       "integrity": "sha512-kf57xP4cIsKK3DNRQ7jJaLQCA7u30xLRerd98epHDThcCLP8Ab8z7p2C0Xh1J4GdorDnU+jxQ1lae9svwGNmZA==",
       "license": "MIT",
       "dependencies": {
@@ -4357,7 +4357,7 @@
     },
     "node_modules/@deepseek-ai/dsh-web-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-9V2GPqEs0A+LFJVVPt7FQK//U8oM9S0TDhl6MqO7zQftimfnH8ruQZkEZXg9zXXEWULCW0vY1DtsPjvMepA8Mw==",
       "license": "MIT",
       "dependencies": {
@@ -4451,7 +4451,7 @@
     },
     "node_modules/@deepseek-ai/dsh-web-fetch-http": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.5-rc.1.tgz",
       "integrity": "sha512-n3cdS8saCgRoTyoV/Jx1gnQV5/hZ0n1ejIMuFUieSMwWfS+8KQNHHB1M8DhCtZ+XpQx5tict0D07hwLdjmb15A==",
       "license": "MIT",
       "dependencies": {
@@ -4468,13 +4468,13 @@
     },
     "node_modules/@deepseek-ai/dsh-web-frontend": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.5-rc.1.tgz",
       "integrity": "sha512-N6WnubGkuOt62OSFVs3XFybh9/VnDy2yMqaAivr1pIp3YtLsMv9QEyYrgqUhsYsuqu1Tfr5GAVmmcNI5OA7i/Q==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-/eu47plhOZLQcm+PeTh3hxSyaXpSJ+oEfVfWwfZ/TxEwbMKZm/mL/FTNnWtzvAhVB8e6nt0ERGVuQATco0k5lg==",
       "license": "MIT",
       "dependencies": {
@@ -4492,7 +4492,7 @@
     },
     "node_modules/@deepseek-ai/dsh-webhook": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.5-rc.1.tgz",
       "integrity": "sha512-Zj5cxTYweaC5sLnSHc26TZWY0PPJ+yCPSnuP2vrpn18FErMC539XfHN5+ann0iqK2fN7NKnxCqJmHHSI+Q43lw==",
       "license": "MIT",
       "dependencies": {
@@ -4514,7 +4514,7 @@
     },
     "node_modules/@deepseek-ai/dsh-webhook-github": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.5-rc.1.tgz",
       "integrity": "sha512-sroVKHjfsHAHnioMEmkSb7CJyJgFr44yISWv+d19SC2opcuo/1gcMqpbLMsbpxK1bODm2D9JR7W73TYJvF8ymA==",
       "license": "MIT",
       "dependencies": {
@@ -4532,7 +4532,7 @@
     },
     "node_modules/@deepseek-ai/dsh-win32-process": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.5-rc.1.tgz",
       "integrity": "sha512-bGRRprQhbSLqG4LjCJjAUyeVLCJibriNyR123xW50MhzX7Dvw6j8xG2saJ0HvQt8ak98RJYXeURVgD8HpDsgbA==",
       "license": "MIT",
       "dependencies": {
@@ -4544,7 +4544,7 @@
     },
     "node_modules/@deepseek-ai/dsh-workflow": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.5-rc.1.tgz",
       "integrity": "sha512-cIVts/XHHrrte0YRGixezFlLv0pVEsCzpqLvco24MCCFJrlpcJFkW44YTUJffUAYfpVq6O7MV6S4Y5f07sdsZA==",
       "license": "MIT",
       "peerDependencies": {
@@ -4558,7 +4558,7 @@
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.5-rc.1.tgz",
       "integrity": "sha512-tXbav9wwZugtu1e09I4Y5gt8VyfmRlQPZkXYtOq+ltxwgZA0hJcaRV4UWpWCc0TSlSH155eAFS+yJnHQjBiuUQ==",
       "license": "MIT",
       "dependencies": {
@@ -4578,7 +4578,7 @@
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.5-rc.1.tgz",
       "integrity": "sha512-RR/PLSnpW9OrWJ0np1DlvIfi9nTA2a1rLqeOsko6tI2yW3p8F82ZkdE3wZ8DWMTBru12VMkY8SiDhXOxPyihfA==",
       "license": "MIT",
       "dependencies": {
@@ -4597,7 +4597,7 @@
     },
     "node_modules/@deepseek-ai/node-addon-system": {
       "version": "0.1.2",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/node-addon-system/-/node-addon-system-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system/-/node-addon-system-0.1.2.tgz",
       "integrity": "sha512-EFn8K+mXIXiw6s3rxX+cgp2hZTEAQdVIsURhrXnBxycSXvtQ1EQpsSVzoNKtKAQI0I0VqkEcVEjHzS/PeaGsvw==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -4612,7 +4612,7 @@
     },
     "node_modules/@deepseek-ai/node-addon-system-darwin-arm64": {
       "version": "0.1.2",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/node-addon-system-darwin-arm64/-/node-addon-system-darwin-arm64-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-darwin-arm64/-/node-addon-system-darwin-arm64-0.1.2.tgz",
       "integrity": "sha512-IR0cx8um19mLCZaJ+H5PLblKr6Eg3PWvVo8eTQBr/SwH2nh5tM9CD9/5fHweNS9Pjt15UdFlGqnvLSd/w+O6Rw==",
       "cpu": [
         "arm64"
@@ -4650,7 +4650,7 @@
     },
     "node_modules/@earendil-works/pi-ai": {
       "version": "0.85.1",
-      "resolved": "https://bnpm.byted.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
       "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "license": "MIT",
       "dependencies": {
@@ -4674,7 +4674,7 @@
     },
     "node_modules/@earendil-works/pi-telemetry": {
       "version": "0.85.1",
-      "resolved": "https://bnpm.byted.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
       "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "license": "MIT",
       "engines": {
@@ -4683,7 +4683,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
-      "resolved": "https://bnpm.byted.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
@@ -4693,7 +4693,7 @@
     },
     "node_modules/@google/genai": {
       "version": "1.52.0",
-      "resolved": "https://bnpm.byted.org/@google/genai/-/genai-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
       "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4717,7 +4717,7 @@
     },
     "node_modules/@hono/node-server": {
       "version": "2.1.1",
-      "resolved": "https://bnpm.byted.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
       "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
@@ -4729,7 +4729,7 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/@img/colour/-/colour-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "engines": {
@@ -4738,7 +4738,7 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
       "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
@@ -4760,7 +4760,7 @@
     },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
       "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
@@ -4782,7 +4782,7 @@
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
       "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
@@ -4801,7 +4801,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
       "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
@@ -4817,7 +4817,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
       "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
@@ -4833,7 +4833,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
       "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
@@ -4852,7 +4852,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
       "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
@@ -4871,7 +4871,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
       "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
@@ -4890,7 +4890,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
       "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
@@ -4909,7 +4909,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
       "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
@@ -4928,7 +4928,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
       "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
@@ -4947,7 +4947,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
       "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
@@ -4966,7 +4966,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
       "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
@@ -4985,7 +4985,7 @@
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
       "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
@@ -5010,7 +5010,7 @@
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
       "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
@@ -5035,7 +5035,7 @@
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
       "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
@@ -5060,7 +5060,7 @@
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
       "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
@@ -5085,7 +5085,7 @@
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
       "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
@@ -5110,7 +5110,7 @@
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
       "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
@@ -5135,7 +5135,7 @@
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
       "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
@@ -5160,7 +5160,7 @@
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
       "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
@@ -5185,7 +5185,7 @@
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
       "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
@@ -5201,7 +5201,7 @@
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
       "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
@@ -5220,7 +5220,7 @@
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
       "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
@@ -5239,7 +5239,7 @@
     },
     "node_modules/@img/sharp-win32-ia32": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
       "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
@@ -5258,7 +5258,7 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
       "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
@@ -5277,13 +5277,13 @@
     },
     "node_modules/@joplin/turndown-plugin-gfm": {
       "version": "1.0.68",
-      "resolved": "https://bnpm.byted.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.68.tgz",
+      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.68.tgz",
       "integrity": "sha512-m8DfAQNC/V7g0j5H6Jv60WhekBBjodD+zTPGrU+g2m+ux/z8ZX07KQIl6kaAmbKwfvsQhC04op52g63I78sVgg==",
       "license": "MIT"
     },
     "node_modules/@koromix/koffi-android-arm64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
       "integrity": "sha512-1pJQ4jnZlUJduK9u9DC5CGy3aOgDUPvIXpNb6syV3+Dh5Q/ugezAIGCqvY+w+1mgXsve0pd0NVvJRjdZNHQ6MA==",
       "cpu": [
         "arm64"
@@ -5299,7 +5299,7 @@
     },
     "node_modules/@koromix/koffi-android-x64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
       "integrity": "sha512-HH40xGh3gVQifjOBnhwT2tECC0lL1lYe+nxHvWNSzxDIyQNcVPXg38ta7vuONRFpD+uIrw7fqGYLzbZIagkVcg==",
       "cpu": [
         "x64"
@@ -5315,7 +5315,7 @@
     },
     "node_modules/@koromix/koffi-darwin-arm64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
       "integrity": "sha512-Vj4h+xcjc5+Cn0DhPHjgRX4omKAv96Kehtcd+1YgYuY2W7FvQn9vS+3SmzVwhC5Qmg9bIwUZObYQ8T/4hBqQqA==",
       "cpu": [
         "arm64"
@@ -5331,7 +5331,7 @@
     },
     "node_modules/@koromix/koffi-darwin-x64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
       "integrity": "sha512-gFCWxNBTZIvxo1p+PURWfsy2Ctj5FGnVVs1f03lTLhBvmxEto70pdIiFztdFLDFkAJ1pmtQmruRKapeK+E8YPA==",
       "cpu": [
         "x64"
@@ -5347,7 +5347,7 @@
     },
     "node_modules/@koromix/koffi-freebsd-arm64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
       "integrity": "sha512-qj+f1s2e6vULaUG1cdlTcCXmunCq2t+rjxku1+esaMIqVnHpOwj0QzPuInG0AFdXjwBNQhyVR/HpDj8daEwwsQ==",
       "cpu": [
         "arm64"
@@ -5363,7 +5363,7 @@
     },
     "node_modules/@koromix/koffi-freebsd-ia32": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
       "integrity": "sha512-6olHb1Qfgai0jjs6ddlDDD0ZfsCxy7SPi8rMRpuYQWH0qhgtyQu82hw5b1p7z+TJ0zZP3ZeQQ6l+U/MlM1ICHQ==",
       "cpu": [
         "ia32"
@@ -5379,7 +5379,7 @@
     },
     "node_modules/@koromix/koffi-freebsd-x64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
       "integrity": "sha512-Dikhw1ySYNVMkmeFvFVjnU5Wdk6mffNoOjJxm9bTG96vg7OlemylxqdEven47R1YJ3yzNVJn/MlQ207ORWfi2w==",
       "cpu": [
         "x64"
@@ -5395,7 +5395,7 @@
     },
     "node_modules/@koromix/koffi-linux-arm": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
       "integrity": "sha512-OfwUwZylidq95wQKp6ClInULrfB2giu7dqM6Rhe0zAe6lES5I2SXNw15T9+GnRHk3/9hKT2XZ37OZLaKSyWNLA==",
       "cpu": [
         "arm"
@@ -5411,7 +5411,7 @@
     },
     "node_modules/@koromix/koffi-linux-arm64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
       "integrity": "sha512-K+cGUL5iBcDqxmsocrjmlASqDf24gc7artbVW3PewG2c9AqwC63lezgwvB85Nx4lZAQjB6zIFHh9A7t1yGbwhw==",
       "cpu": [
         "arm64"
@@ -5427,7 +5427,7 @@
     },
     "node_modules/@koromix/koffi-linux-ia32": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
       "integrity": "sha512-rxj6UYjU1qd98gxNQOSCdLpc5cPRi5Giq9rNd3jnGuSNIyMkwa6Dxw4cUjmhIBCYESMJtmNt5NWnJp5u9wTfYQ==",
       "cpu": [
         "ia32"
@@ -5443,7 +5443,7 @@
     },
     "node_modules/@koromix/koffi-linux-loong64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
       "integrity": "sha512-aHhnHzkPRmT/IHDlGvESJ/Bs32m8N6UE6Ab6kMeJzgk74IN8af2m/81/wZJtybR1M2UxCV4NmlVNUYQQvSAO3Q==",
       "cpu": [
         "loong64"
@@ -5459,7 +5459,7 @@
     },
     "node_modules/@koromix/koffi-linux-riscv64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
       "integrity": "sha512-qtQBsjbm3LiirLJvajWmKkNb7ARk7fvJVXdftJ7NtAnF3Xw8EbDvrtvmvtNI1yLPlYcBmlzCCD71hwhWYk0SIA==",
       "cpu": [
         "riscv64"
@@ -5475,7 +5475,7 @@
     },
     "node_modules/@koromix/koffi-linux-x64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
       "integrity": "sha512-c7hw7Qs/r5gnFRTQLcbifBwRU7wiocj+2pVuDQ5Ahb3r36SZmupmgYbTWcLvTW+hul1jd7SKRV0d14ZJq/tvSw==",
       "cpu": [
         "x64"
@@ -5491,7 +5491,7 @@
     },
     "node_modules/@koromix/koffi-openbsd-ia32": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
       "integrity": "sha512-mmY8fY8LQ/CB52+h3yrMYmVyoxzW3x08S0yI6VNfHWdfU6yJtZkKCbhjmQCYMrWbYKC4gMvwZwCywIGPAkLyeA==",
       "cpu": [
         "ia32"
@@ -5507,7 +5507,7 @@
     },
     "node_modules/@koromix/koffi-openbsd-x64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
       "integrity": "sha512-k4ig6aAPbFSRATOIIOfdf/KtlOGH4SVls6L9fy0QnTxRJYvY2oSltTsQtBDANgEQldlq8Kl5WnpRa1VSibP4Lw==",
       "cpu": [
         "x64"
@@ -5523,7 +5523,7 @@
     },
     "node_modules/@koromix/koffi-win32-arm64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
       "integrity": "sha512-cTWBJGK//pDMeKQJE/79Aq9MiOAF4H8QyLZHSQ9IWm8czOfwjG4J1AhsQ9DjI9KFOykH77hhnpmQTGVMIubGig==",
       "cpu": [
         "arm64"
@@ -5539,7 +5539,7 @@
     },
     "node_modules/@koromix/koffi-win32-ia32": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
       "integrity": "sha512-Z50EM6TAZ7CFyMmyX6thv8eNpJchqe9eenhibSIy2Eq/FQYF76gU2VK/LEoaF46L8hfC7TpTp9b10MvReHEyFA==",
       "cpu": [
         "ia32"
@@ -5555,7 +5555,7 @@
     },
     "node_modules/@koromix/koffi-win32-x64": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
       "integrity": "sha512-ZmZNiBO6bkOSh3QNzgfvb1cMY0yMobn6ZQrSMqbAce21qyYL8niIbyipz9N/PIRDciGhsV0wUxnZsxIO+yWsHQ==",
       "cpu": [
         "x64"
@@ -5571,13 +5571,13 @@
     },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
-      "resolved": "https://bnpm.byted.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
-      "resolved": "https://bnpm.byted.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
       "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
@@ -5617,19 +5617,19 @@
     },
     "node_modules/@octokit/openapi-types": {
       "version": "29.0.1",
-      "resolved": "https://bnpm.byted.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
       "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
       "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
       "version": "12.1.0",
-      "resolved": "https://bnpm.byted.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
       "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
       "license": "MIT"
     },
     "node_modules/@octokit/request-error": {
       "version": "7.1.2",
-      "resolved": "https://bnpm.byted.org/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.2.tgz",
       "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
       "license": "MIT",
       "dependencies": {
@@ -5641,7 +5641,7 @@
     },
     "node_modules/@octokit/types": {
       "version": "18.0.0",
-      "resolved": "https://bnpm.byted.org/@octokit/types/-/types-18.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-18.0.0.tgz",
       "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
       "license": "MIT",
       "dependencies": {
@@ -5650,7 +5650,7 @@
     },
     "node_modules/@octokit/webhooks": {
       "version": "14.2.0",
-      "resolved": "https://bnpm.byted.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
       "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
       "license": "MIT",
       "dependencies": {
@@ -5664,7 +5664,7 @@
     },
     "node_modules/@octokit/webhooks-methods": {
       "version": "6.0.0",
-      "resolved": "https://bnpm.byted.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
       "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
       "license": "MIT",
       "engines": {
@@ -5673,7 +5673,7 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
@@ -5682,7 +5682,7 @@
     },
     "node_modules/@opentelemetry/api-logs": {
       "version": "0.220.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
       "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5694,7 +5694,7 @@
     },
     "node_modules/@opentelemetry/core": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
       "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5709,7 +5709,7 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
       "version": "0.220.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
       "integrity": "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5728,7 +5728,7 @@
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.220.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
       "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5744,7 +5744,7 @@
     },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.220.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
       "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5764,7 +5764,7 @@
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5780,7 +5780,7 @@
     },
     "node_modules/@opentelemetry/resources": {
       "version": "2.11.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
       "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5796,7 +5796,7 @@
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
       "version": "2.11.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
       "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5811,7 +5811,7 @@
     },
     "node_modules/@opentelemetry/sdk-logs": {
       "version": "0.220.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
       "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5829,7 +5829,7 @@
     },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5845,7 +5845,7 @@
     },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
       "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5861,7 +5861,7 @@
     },
     "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5877,7 +5877,7 @@
     },
     "node_modules/@opentelemetry/sdk-trace": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
       "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5894,7 +5894,7 @@
     },
     "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5910,7 +5910,7 @@
     },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.43.0",
-      "resolved": "https://bnpm.byted.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
       "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "license": "Apache-2.0",
       "engines": {
@@ -5919,31 +5919,31 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
-      "resolved": "https://bnpm.byted.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5952,25 +5952,25 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://bnpm.byted.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
@@ -6004,7 +6004,7 @@
     },
     "node_modules/@smithy/core": {
       "version": "3.33.3",
-      "resolved": "https://bnpm.byted.org/@smithy/core/-/core-3.33.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
       "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6017,7 +6017,7 @@
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.5.2",
-      "resolved": "https://bnpm.byted.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
       "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6031,7 +6031,7 @@
     },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.8.0",
-      "resolved": "https://bnpm.byted.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
       "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6045,7 +6045,7 @@
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://bnpm.byted.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6057,7 +6057,7 @@
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.7.3",
-      "resolved": "https://bnpm.byted.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
       "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6071,7 +6071,7 @@
     },
     "node_modules/@smithy/signature-v4": {
       "version": "5.7.3",
-      "resolved": "https://bnpm.byted.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
       "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6085,7 +6085,7 @@
     },
     "node_modules/@smithy/types": {
       "version": "4.18.0",
-      "resolved": "https://bnpm.byted.org/@smithy/types/-/types-4.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
       "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6097,7 +6097,7 @@
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://bnpm.byted.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6110,7 +6110,7 @@
     },
     "node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://bnpm.byted.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6123,7 +6123,7 @@
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
@@ -6135,7 +6135,7 @@
     },
     "node_modules/@types/node": {
       "version": "22.20.2",
-      "resolved": "https://bnpm.byted.org/@types/node/-/node-22.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
       "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
       "license": "MIT",
       "dependencies": {
@@ -6144,13 +6144,13 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
-      "resolved": "https://bnpm.byted.org/@types/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@vscode/ripgrep": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
       "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
       "license": "MIT",
       "optionalDependencies": {
@@ -6170,7 +6170,7 @@
     },
     "node_modules/@vscode/ripgrep-darwin-arm64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
       "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
       "cpu": [
         "arm64"
@@ -6183,7 +6183,7 @@
     },
     "node_modules/@vscode/ripgrep-darwin-x64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
       "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
       "cpu": [
         "x64"
@@ -6196,7 +6196,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-arm": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
       "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
       "cpu": [
         "arm"
@@ -6209,7 +6209,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-arm64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
       "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
       "cpu": [
         "arm64"
@@ -6222,7 +6222,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-ia32": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
       "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
       "cpu": [
         "ia32"
@@ -6235,7 +6235,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-ppc64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
       "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
       "cpu": [
         "ppc64"
@@ -6248,7 +6248,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-riscv64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
       "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
       "cpu": [
         "riscv64"
@@ -6261,7 +6261,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-s390x": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
       "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
       "cpu": [
         "s390x"
@@ -6274,7 +6274,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-x64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
       "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
       "cpu": [
         "x64"
@@ -6287,7 +6287,7 @@
     },
     "node_modules/@vscode/ripgrep-win32-arm64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
       "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
       "cpu": [
         "arm64"
@@ -6300,7 +6300,7 @@
     },
     "node_modules/@vscode/ripgrep-win32-ia32": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
       "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
       "cpu": [
         "ia32"
@@ -6313,7 +6313,7 @@
     },
     "node_modules/@vscode/ripgrep-win32-x64": {
       "version": "1.18.0",
-      "resolved": "https://bnpm.byted.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
       "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
       "cpu": [
         "x64"
@@ -6326,7 +6326,7 @@
     },
     "node_modules/@xterm/headless": {
       "version": "6.0.0",
-      "resolved": "https://bnpm.byted.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
       "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
       "license": "MIT",
       "workspaces": [
@@ -6335,7 +6335,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/accepts/-/accepts-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
@@ -6348,7 +6348,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://bnpm.byted.org/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
@@ -6373,7 +6373,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://bnpm.byted.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
@@ -6429,7 +6429,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://bnpm.byted.org/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
@@ -6462,7 +6462,7 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
-      "resolved": "https://bnpm.byted.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
       "engines": {
@@ -6471,7 +6471,7 @@
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://bnpm.byted.org/body-parser/-/body-parser-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
@@ -6495,7 +6495,7 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://bnpm.byted.org/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -6508,7 +6508,7 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -6525,25 +6525,25 @@
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/bowser": {
       "version": "2.14.1",
-      "resolved": "https://bnpm.byted.org/bowser/-/bowser-2.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://bnpm.byted.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
       "dependencies": {
@@ -6558,7 +6558,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://bnpm.byted.org/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
@@ -6567,7 +6567,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://bnpm.byted.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -6580,7 +6580,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://bnpm.byted.org/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
@@ -6596,7 +6596,7 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://bnpm.byted.org/chokidar/-/chokidar-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
       "dependencies": {
@@ -6667,7 +6667,7 @@
     },
     "node_modules/commander": {
       "version": "15.0.0",
-      "resolved": "https://bnpm.byted.org/commander/-/commander-15.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
@@ -6676,7 +6676,7 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "resolved": "https://bnpm.byted.org/compressible/-/compressible-2.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "license": "MIT",
       "dependencies": {
@@ -6688,7 +6688,7 @@
     },
     "node_modules/compression": {
       "version": "1.8.1",
-      "resolved": "https://bnpm.byted.org/compression/-/compression-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
       "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
@@ -6706,7 +6706,7 @@
     },
     "node_modules/compression/node_modules/negotiator": {
       "version": "0.6.4",
-      "resolved": "https://bnpm.byted.org/negotiator/-/negotiator-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "license": "MIT",
       "engines": {
@@ -6715,7 +6715,7 @@
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
@@ -6728,7 +6728,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://bnpm.byted.org/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
@@ -6737,7 +6737,7 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://bnpm.byted.org/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
@@ -6746,7 +6746,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://bnpm.byted.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
@@ -6755,7 +6755,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
-      "resolved": "https://bnpm.byted.org/cors/-/cors-2.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
@@ -6772,7 +6772,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://bnpm.byted.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -6786,7 +6786,7 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://bnpm.byted.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
       "engines": {
@@ -6795,7 +6795,7 @@
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
@@ -6804,7 +6804,7 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.1",
-      "resolved": "https://bnpm.byted.org/default-browser/-/default-browser-5.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
       "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "license": "MIT",
       "dependencies": {
@@ -6820,7 +6820,7 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://bnpm.byted.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
       "engines": {
@@ -6832,7 +6832,7 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://bnpm.byted.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
       "engines": {
@@ -6844,7 +6844,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
@@ -6853,7 +6853,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://bnpm.byted.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
@@ -6868,7 +6868,7 @@
     },
     "node_modules/diff": {
       "version": "9.0.0",
-      "resolved": "https://bnpm.byted.org/diff/-/diff-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
       "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -6891,7 +6891,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -6905,7 +6905,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://bnpm.byted.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6914,7 +6914,7 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
@@ -6926,7 +6926,7 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
@@ -6935,7 +6935,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -6944,7 +6944,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://bnpm.byted.org/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -6953,7 +6953,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
@@ -6974,13 +6974,13 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://bnpm.byted.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://bnpm.byted.org/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
@@ -6989,7 +6989,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://bnpm.byted.org/eventsource/-/eventsource-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
       "dependencies": {
@@ -7001,7 +7001,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.1.1",
-      "resolved": "https://bnpm.byted.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
       "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
@@ -7010,7 +7010,7 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://bnpm.byted.org/express/-/express-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
@@ -7053,7 +7053,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.7.0",
-      "resolved": "https://bnpm.byted.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
       "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
@@ -7072,7 +7072,7 @@
     },
     "node_modules/express-rate-limit/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -7089,13 +7089,13 @@
     },
     "node_modules/express-rate-limit/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -7112,13 +7112,13 @@
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://bnpm.byted.org/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
@@ -7130,7 +7130,7 @@
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
-      "resolved": "https://bnpm.byted.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
@@ -7152,7 +7152,7 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://bnpm.byted.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
@@ -7175,13 +7175,13 @@
     },
     "node_modules/fflate": {
       "version": "0.8.3",
-      "resolved": "https://bnpm.byted.org/fflate/-/fflate-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://bnpm.byted.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
@@ -7202,7 +7202,7 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -7219,13 +7219,13 @@
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://bnpm.byted.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
       "dependencies": {
@@ -7237,7 +7237,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://bnpm.byted.org/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
@@ -7246,7 +7246,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/fresh/-/fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
@@ -7255,7 +7255,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -7264,7 +7264,7 @@
     },
     "node_modules/gaxios": {
       "version": "7.3.1",
-      "resolved": "https://bnpm.byted.org/gaxios/-/gaxios-7.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
       "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7278,7 +7278,7 @@
     },
     "node_modules/gcp-metadata": {
       "version": "8.1.2",
-      "resolved": "https://bnpm.byted.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7313,7 +7313,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://bnpm.byted.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -7337,7 +7337,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -7350,7 +7350,7 @@
     },
     "node_modules/google-auth-library": {
       "version": "10.9.1",
-      "resolved": "https://bnpm.byted.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
       "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7367,7 +7367,7 @@
     },
     "node_modules/google-logging-utils": {
       "version": "1.1.3",
-      "resolved": "https://bnpm.byted.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
@@ -7376,7 +7376,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://bnpm.byted.org/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -7388,7 +7388,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -7400,7 +7400,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://bnpm.byted.org/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -7412,7 +7412,7 @@
     },
     "node_modules/hono": {
       "version": "4.13.7",
-      "resolved": "https://bnpm.byted.org/hono/-/hono-4.13.7.tgz",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
       "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
@@ -7421,7 +7421,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://bnpm.byted.org/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
@@ -7441,7 +7441,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://bnpm.byted.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
       "dependencies": {
@@ -7454,7 +7454,7 @@
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -7471,13 +7471,13 @@
     },
     "node_modules/http-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://bnpm.byted.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
@@ -7490,7 +7490,7 @@
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -7507,7 +7507,7 @@
     },
     "node_modules/https-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
@@ -7519,7 +7519,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://bnpm.byted.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
@@ -7535,13 +7535,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://bnpm.byted.org/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.7.0",
-      "resolved": "https://bnpm.byted.org/ip-address/-/ip-address-10.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
       "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
@@ -7550,7 +7550,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "2.5.0",
-      "resolved": "https://bnpm.byted.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
       "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
       "license": "MIT",
       "engines": {
@@ -7559,7 +7559,7 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://bnpm.byted.org/is-docker/-/is-docker-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
       "bin": {
@@ -7574,7 +7574,7 @@
     },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
       "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
       "license": "MIT",
       "engines": {
@@ -7586,7 +7586,7 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
       "dependencies": {
@@ -7604,13 +7604,13 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://bnpm.byted.org/is-promise/-/is-promise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://bnpm.byted.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
@@ -7625,13 +7625,13 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.12",
-      "resolved": "https://bnpm.byted.org/jose/-/jose-6.2.12.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
       "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
       "license": "MIT",
       "funding": {
@@ -7640,7 +7640,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://bnpm.byted.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
@@ -7668,7 +7668,7 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
       "dependencies": {
@@ -7677,7 +7677,7 @@
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
-      "resolved": "https://bnpm.byted.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
       "dependencies": {
@@ -7696,13 +7696,13 @@
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://bnpm.byted.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
-      "resolved": "https://bnpm.byted.org/jwa/-/jwa-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
@@ -7713,7 +7713,7 @@
     },
     "node_modules/jws": {
       "version": "4.0.1",
-      "resolved": "https://bnpm.byted.org/jws/-/jws-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
@@ -7723,7 +7723,7 @@
     },
     "node_modules/koffi": {
       "version": "3.2.1",
-      "resolved": "https://bnpm.byted.org/koffi/-/koffi-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz",
       "integrity": "sha512-0qE3lZ8jllRqPN4Ob6Ajl7c2bJSJDhQWuKLGP5hIEpHLllJWv1ydHFMhHmHc5p/W9GticKVDbYzZd7TBoQ4CZg==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -7753,13 +7753,13 @@
     },
     "node_modules/long": {
       "version": "5.3.2",
-      "resolved": "https://bnpm.byted.org/long/-/long-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -7768,7 +7768,7 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/media-typer/-/media-typer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
@@ -7781,7 +7781,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
@@ -7793,7 +7793,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://bnpm.byted.org/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
@@ -7802,7 +7802,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://bnpm.byted.org/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
@@ -7833,13 +7833,13 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/negotiator/-/negotiator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
       "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
       "license": "MIT",
       "dependencies": {
@@ -7855,7 +7855,7 @@
     },
     "node_modules/negotiator/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://bnpm.byted.org/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -8046,7 +8046,7 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
       "funding": [
@@ -8066,7 +8066,7 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://bnpm.byted.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
@@ -8084,7 +8084,7 @@
     },
     "node_modules/node-pty": {
       "version": "1.2.0-beta.15",
-      "resolved": "https://bnpm.byted.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
       "integrity": "sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -8094,13 +8094,13 @@
     },
     "node_modules/node-pty/node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://bnpm.byted.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://bnpm.byted.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
@@ -8109,7 +8109,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://bnpm.byted.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
@@ -8121,7 +8121,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://bnpm.byted.org/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
@@ -8133,7 +8133,7 @@
     },
     "node_modules/on-headers": {
       "version": "1.1.0",
-      "resolved": "https://bnpm.byted.org/on-headers/-/on-headers-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
       "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
@@ -8142,7 +8142,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://bnpm.byted.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -8151,7 +8151,7 @@
     },
     "node_modules/open": {
       "version": "11.0.2",
-      "resolved": "https://bnpm.byted.org/open/-/open-11.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
       "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
       "license": "MIT",
       "dependencies": {
@@ -8171,7 +8171,7 @@
     },
     "node_modules/openai": {
       "version": "6.40.0",
-      "resolved": "https://bnpm.byted.org/openai/-/openai-6.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
       "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -8189,7 +8189,7 @@
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
-      "resolved": "https://bnpm.byted.org/p-retry/-/p-retry-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
       "dependencies": {
@@ -8202,7 +8202,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://bnpm.byted.org/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
@@ -8211,13 +8211,13 @@
     },
     "node_modules/partial-json": {
       "version": "0.1.7",
-      "resolved": "https://bnpm.byted.org/partial-json/-/partial-json-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://bnpm.byted.org/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -8226,7 +8226,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://bnpm.byted.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
@@ -8236,13 +8236,13 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.7",
-      "resolved": "https://bnpm.byted.org/picomatch/-/picomatch-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
@@ -8254,7 +8254,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://bnpm.byted.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
       "engines": {
@@ -8263,7 +8263,7 @@
     },
     "node_modules/powershell-utils": {
       "version": "0.2.1",
-      "resolved": "https://bnpm.byted.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
       "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
       "license": "MIT",
       "engines": {
@@ -8275,7 +8275,7 @@
     },
     "node_modules/protobufjs": {
       "version": "7.6.6",
-      "resolved": "https://bnpm.byted.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
       "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -8298,7 +8298,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://bnpm.byted.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
@@ -8311,7 +8311,7 @@
     },
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://bnpm.byted.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
@@ -8337,7 +8337,7 @@
     },
     "node_modules/qs": {
       "version": "6.16.0",
-      "resolved": "https://bnpm.byted.org/qs/-/qs-6.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
       "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8353,7 +8353,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
-      "resolved": "https://bnpm.byted.org/range-parser/-/range-parser-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
@@ -8366,7 +8366,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://bnpm.byted.org/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
@@ -8381,7 +8381,7 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://bnpm.byted.org/readdirp/-/readdirp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
       "engines": {
@@ -8403,7 +8403,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
-      "resolved": "https://bnpm.byted.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
       "license": "MIT",
       "engines": {
@@ -8412,7 +8412,7 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
-      "resolved": "https://bnpm.byted.org/retry/-/retry-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
       "engines": {
@@ -8421,7 +8421,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://bnpm.byted.org/router/-/router-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
@@ -8437,7 +8437,7 @@
     },
     "node_modules/router/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -8454,13 +8454,13 @@
     },
     "node_modules/router/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://bnpm.byted.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
       "engines": {
@@ -8472,7 +8472,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://bnpm.byted.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
@@ -8492,7 +8492,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://bnpm.byted.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
@@ -8507,7 +8507,7 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://bnpm.byted.org/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
@@ -8519,7 +8519,7 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://bnpm.byted.org/send/-/send-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
@@ -8545,7 +8545,7 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -8562,13 +8562,13 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://bnpm.byted.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://bnpm.byted.org/serve-static/-/serve-static-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
@@ -8587,13 +8587,13 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://bnpm.byted.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.35.4",
-      "resolved": "https://bnpm.byted.org/sharp/-/sharp-0.35.4.tgz",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
       "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8642,7 +8642,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -8654,7 +8654,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://bnpm.byted.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -8663,7 +8663,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
@@ -8682,7 +8682,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
@@ -8698,7 +8698,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
@@ -8716,7 +8716,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://bnpm.byted.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
@@ -8735,7 +8735,7 @@
     },
     "node_modules/standardwebhooks": {
       "version": "1.1.1",
-      "resolved": "https://bnpm.byted.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
       "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
       "license": "MIT",
       "dependencies": {
@@ -8745,7 +8745,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://bnpm.byted.org/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
@@ -8785,7 +8785,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://bnpm.byted.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
@@ -8794,7 +8794,7 @@
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
-      "resolved": "https://bnpm.byted.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
@@ -8842,7 +8842,7 @@
     },
     "node_modules/turndown": {
       "version": "7.2.4",
-      "resolved": "https://bnpm.byted.org/turndown/-/turndown-7.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
       "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
       "license": "MIT",
       "dependencies": {
@@ -8855,7 +8855,7 @@
     },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://bnpm.byted.org/type-is/-/type-is-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
@@ -8873,7 +8873,7 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://bnpm.byted.org/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -8886,7 +8886,7 @@
     },
     "node_modules/typebox": {
       "version": "1.3.7",
-      "resolved": "https://bnpm.byted.org/typebox/-/typebox-1.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
       "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
@@ -8921,13 +8921,13 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://bnpm.byted.org/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
@@ -8936,7 +8936,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://bnpm.byted.org/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
@@ -8945,7 +8945,7 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://bnpm.byted.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
       "engines": {
@@ -8960,7 +8960,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://bnpm.byted.org/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -9009,7 +9009,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://bnpm.byted.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
@@ -9036,7 +9036,7 @@
     },
     "node_modules/wsl-utils": {
       "version": "1.0.0",
-      "resolved": "https://bnpm.byted.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
       "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
       "license": "MIT",
       "dependencies": {
@@ -9052,7 +9052,7 @@
     },
     "node_modules/wsl-utils/node_modules/powershell-utils": {
       "version": "0.1.0",
-      "resolved": "https://bnpm.byted.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "license": "MIT",
       "engines": {
@@ -9085,7 +9085,7 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://bnpm.byted.org/yaml/-/yaml-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
@@ -9147,7 +9147,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
-      "resolved": "https://bnpm.byted.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -625,7 +625,7 @@
     },
     "node_modules/@deepseek-ai/dsh": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh/-/dsh-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.5-rc.1.tgz",
       "integrity": "sha512-rmNmzQCg3oIc1z8xH7izRSOuy1TNzq+/NILyfM+7e8DKOyV+yBtg47WEsqR2SiIe1ATec3L/rUa1YhIcfQ2XEg==",
       "license": "MIT",
       "dependencies": {
@@ -708,7 +708,7 @@
     },
     "node_modules/@deepseek-ai/dsh-acp": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.5-rc.1.tgz",
       "integrity": "sha512-Ze5yCIcfz0VjBNrt3B7mfRI0WPYJd8ZckdaV3lRwO98PcVuO330y8DTuQXdBvgvFpmZCLselVW1mB9tT7240hA==",
       "license": "MIT",
       "dependencies": {
@@ -735,7 +735,7 @@
     },
     "node_modules/@deepseek-ai/dsh-acp-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-O6+Hl//+uog9ezp+aVI0oQyNAtZ4GHf6haGxgPe7U9Kp/KUKjVYC94Lb2x45SgEimJroSxBOcR1CIQop2Tsn1g==",
       "license": "MIT",
       "dependencies": {
@@ -749,7 +749,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.5-rc.1.tgz",
       "integrity": "sha512-obIPyTSjq1y0Yhasm3mLhK5BW6Ge0VQoRT8FBt0ooLsct2+pFAjgyd7GP3KzFaz7zaEhQJ/NNEmCaU0KOsYutg==",
       "license": "MIT",
       "peerDependencies": {
@@ -766,7 +766,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.5-rc.1.tgz",
       "integrity": "sha512-yEUYhogUpiUfctefVHpNZ+9WvCKjm2wbVIj1iGnCRmHtvlrB2tmAJ7OkaOhUK3AxY0WovSjf+8Y8+sGLMx980A==",
       "license": "MIT",
       "dependencies": {
@@ -781,7 +781,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.5-rc.1.tgz",
       "integrity": "sha512-HpYUZSB0RB2gZnG2chR53Ama8grr95TIBoYlLyDFvHy61zl6HOtYEsm44LQp5gNlycAyoUPxoyXExo7hVn5glQ==",
       "license": "MIT",
       "dependencies": {
@@ -801,7 +801,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.5-rc.1.tgz",
       "integrity": "sha512-FcpsiXMHR7M3UwZtC6CYzhmU9xhvbFuuEQisfUqW7c+G6oVhrX9kg8ytI50jXZempcdmVHZLyNeUcuDmgGtx7Q==",
       "license": "MIT",
       "dependencies": {
@@ -826,7 +826,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.5-rc.1.tgz",
       "integrity": "sha512-kUBeWCF/7g7Z73kPJHleyqZt72aDOrLCeqbwrLks1svDy6ubMUvWi9jAYrYzvSYCJg+fD7x8/13tw49NriJyxA==",
       "license": "MIT",
       "dependencies": {
@@ -853,7 +853,7 @@
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q4sjyFnws8PqrOmRtthT5ps2jToFRIxC+ogpEcoAik/ggFwfBEC8+IZ3KT2kxNzTvymCyDsxbJxFtirO6gE7SQ==",
       "license": "MIT",
       "dependencies": {
@@ -866,7 +866,7 @@
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.5-rc.1.tgz",
       "integrity": "sha512-+ecDwUWxv+E18+m0lhaC6/Z6EfmtqG2EhNxmycQi0u02t7CU0/ZiTZrUaWIB6365btlPy+GTBHE9C+SIlTomEA==",
       "license": "MIT",
       "peer": true,
@@ -878,7 +878,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.5-rc.1.tgz",
       "integrity": "sha512-q/R5sJt8Q6D37mAQBM7gIB6mTC88qJ1WY6gLjtcwOn0GgSRwY17ChgIZq/b6YUxAJ3ykgKTeKfvAj8pvyRX09w==",
       "license": "MIT",
       "dependencies": {
@@ -894,7 +894,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.5-rc.1.tgz",
       "integrity": "sha512-sFoGZ3jJbrKLxbxSoyUpxhbRhgrxtxutfOcTJWacCTTfJQWvyJiJtbt4aK/997Uqgv19CklIBVkDBfqMDZA4RA==",
       "license": "MIT",
       "dependencies": {
@@ -909,7 +909,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-session-controller": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.5-rc.1.tgz",
       "integrity": "sha512-BwOU/VMFpYQo7fAp0RyeBbSlIwNg9BNI3tDatRpYHBNKBcckiN0Lv2HO3Aoe7dLRh8yqqaOeiUVBY3Mkva1aZA==",
       "license": "MIT",
       "dependencies": {
@@ -964,7 +964,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-settings-controller": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.5-rc.1.tgz",
       "integrity": "sha512-MeeYkdfhiVy6oHOoyHKKsuahbSinPSaOY3nIiudbLIQYrGyF9+KGFPmP7LM+KF/G9mP/Q8Dh9nZq3BUIMBj3LQ==",
       "license": "MIT",
       "dependencies": {
@@ -983,7 +983,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-workspace-controller": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.5-rc.1.tgz",
       "integrity": "sha512-1mzTuL850EFqBPD+JwGzC9aNpZQ7LgxZCt3TP4YBVZcbys3D5Gopbb+wIJsqMHpfwIA2eqY9m3KAJjaJepF4Sg==",
       "license": "MIT",
       "dependencies": {
@@ -1003,7 +1003,7 @@
     },
     "node_modules/@deepseek-ai/dsh-api-workspace-files": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-api-workspace-files/-/dsh-api-workspace-files-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-files/-/dsh-api-workspace-files-0.1.5-rc.1.tgz",
       "integrity": "sha512-fDUHdBBMH50vHwViZoM3tdp3fgrzFB4x/NqwNRwnJfaVgg2t5exRok9gSoHmsKYaP5EkEqGXYozOCNUx9GWVYg==",
       "license": "MIT",
       "dependencies": {
@@ -1018,7 +1018,7 @@
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.5-rc.1.tgz",
       "integrity": "sha512-yWxb2SbcW/Vq2mt3Q6+PTbYdxSPK4KEWADTDdWDseiIn4F78szElS+zyclc1jmr9HlcZkTuLg9mwUZhgjixJjw==",
       "license": "MIT",
       "dependencies": {
@@ -1045,7 +1045,7 @@
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.5-rc.1.tgz",
       "integrity": "sha512-5fiPu6usjlzTd9IfOyINMHqMdxsmyTI3YY3s+BqAGk5qwqedrh83gPEer9a94L8lkhX+06AC0wdsSROI5bNZsQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1054,7 +1054,7 @@
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.5-rc.1.tgz",
       "integrity": "sha512-uTBtB/LDlYgPI6i9Ac9jaK/bV1wN8cDTZBUkec80Yg3qMzW6K74wvBv5lPmoiXQgp4q3eOmDNEmodSS2ZxxVdg==",
       "license": "MIT",
       "peer": true,
@@ -1065,7 +1065,7 @@
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-FVrfFKktYBKt9MzODf9oxdB0QOCcY2i/9cHOuxYDluS+SRP/zs3c7Rs/GsUk0Crg8Q2LQNf7CCYQ0Lr2ymGHEA==",
       "license": "MIT",
       "dependencies": {
@@ -1080,7 +1080,7 @@
     },
     "node_modules/@deepseek-ai/dsh-authorization": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.5-rc.1.tgz",
       "integrity": "sha512-VoG21RzrGx5AQYAgMtXYgd6ku1XNxPsQMLdnkQlfIUgzgjZx2Lju8CArfCqxCOEna2Ku4vAz+gm8PEp/Q4Paxg==",
       "license": "MIT",
       "peer": true,
@@ -1093,7 +1093,7 @@
     },
     "node_modules/@deepseek-ai/dsh-base": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.5-rc.1.tgz",
       "integrity": "sha512-cfFyTpUKNnMlS6NRIG8AnvjSsr3enAyl0a1CXnD+wQ1tzoqhGY5+OKsgkVdciKw0Co5WeTSSPItU5lmjBwo4hg==",
       "license": "MIT",
       "dependencies": {
@@ -1188,7 +1188,7 @@
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-1JxwFJI2cRt+/3yQ8DPxmO6jFqZSOBrLCFZ9ObumZ+AcIddsqEVyJBGoniHDmPRRqt8riEisksvkFskhSdnm2g==",
       "license": "MIT",
       "peer": true,
@@ -1205,7 +1205,7 @@
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-mQ+/0Fo3LTIX+4k3m+P4y9e9IA6/BeNHrWW19U+Un4hBo5JtTwWhAaJN1nCdV6mG5tveXbIe2tpiv65GJdvt8w==",
       "license": "MIT",
       "peerDependencies": {
@@ -1218,7 +1218,7 @@
     },
     "node_modules/@deepseek-ai/dsh-brand": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.5-rc.1.tgz",
       "integrity": "sha512-nfEsuSNghhrcvjMnjlPU55Z60K/5FjCRY4ZJtnc0SHR0PgoMl7N9I9+y4t2kDMe3rnEKlH2UgIGIZ/msGOYvpg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1227,7 +1227,7 @@
     },
     "node_modules/@deepseek-ai/dsh-chunked-list": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-chunked-list/-/dsh-chunked-list-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-chunked-list/-/dsh-chunked-list-0.1.5-rc.1.tgz",
       "integrity": "sha512-3c/pYWSE++OWdilO8kG7mY9UyhHnwfV0qYQN+Bxwt2YdjqRQZ/6UkwvzNQIAoDqUEWJYwcQUQoLHTrgrrpIxNw==",
       "license": "MIT",
       "dependencies": {
@@ -1239,7 +1239,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.5-rc.1.tgz",
       "integrity": "sha512-mBHCF/WT5kAn4fHJDe0mL5TcVUEIRWGUAwPzr32xitQrIAM6jh5G+pPVJLDtTk+ZbHGkGusN0+nQh2gCJpGHjQ==",
       "license": "MIT",
       "dependencies": {
@@ -1253,7 +1253,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-file-upload": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-file-upload/-/dsh-client-file-upload-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-file-upload/-/dsh-client-file-upload-0.1.5-rc.1.tgz",
       "integrity": "sha512-qjH4KGnr97GiBU9Pwr2jIOuZUAeI2QJ1em/e/QHFehu74RGIkvajojVn0d/xGxPqs3JCt/dvVR4OfctqzmVulA==",
       "license": "MIT",
       "dependencies": {
@@ -1268,7 +1268,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-hmr": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.5-rc.1.tgz",
       "integrity": "sha512-RKymfSAI21aZ35elHZHMztwwuVTvqn4UY/eeAyDrfPfErPWPwIScKd935u+vAhM4HuBZnIL3E/Sl4MYvws4NZw==",
       "license": "MIT",
       "dependencies": {
@@ -1280,7 +1280,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-locale": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.5-rc.1.tgz",
       "integrity": "sha512-DNzkyudBnGEPPaqRTsBnrr8nast/ZOPSAO21pS1MldK277Wj7Po4bCURKg1cS9QT30Fs4NMeJdIvyV/xNWoMSw==",
       "license": "MIT",
       "dependencies": {
@@ -1292,7 +1292,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-modules": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.5-rc.1.tgz",
       "integrity": "sha512-PE+c+LDUBnk1IfVu4caIKMj2XwLx/tzu0p9gY1jGQa1cNxzKfPgftKHDwvqWMbJQowtLb+RiR2Tc+24nFylVyQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1301,7 +1301,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-resources": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-resources/-/dsh-client-resources-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-resources/-/dsh-client-resources-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q0g/4KWavf10yiYXWHjbrgHr5pejqySTAwXtouD6TrHvtgGAKtqWIa6s5t5y+YW3RqxabzAqmjCTqZrq+/RbWA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1310,7 +1310,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.5-rc.1.tgz",
       "integrity": "sha512-0W0ZrOewwgsUWgqd+Zz4hF6Vwn0xe/JNy6nf80BdjvV8RCms4o8hW1+c6dO0z6O42WLLlF4K7t1Hs/lkPN1YEA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1319,7 +1319,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-approval": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.5-rc.1.tgz",
       "integrity": "sha512-zba9ZtNmkfypU+wOkKGh5I3GmJMAH6rMj5FEsMs9/GG5x0Z8BlybHDELZIBVV4UoJfuZYvDFI/zemVMVRaGsVw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1328,7 +1328,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.5-rc.1.tgz",
       "integrity": "sha512-JmHfLBhXDfbo7+l1L92ACye3DSBtaF8bZ7EiQuTajwUHmtBtK/jKv9PKKXJnnHQNFwSrdcR2Sc2FxGW7WJHgQA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1337,7 +1337,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.5-rc.1.tgz",
       "integrity": "sha512-scbXvZiVH+Uag1R/twD3r/sqEhrU+EMKae78F2399JUjkAVZDdJLv4R6PlSJbIKy16OKt2cYgsRxEkUxs+1a7w==",
       "license": "MIT",
       "peerDependencies": {
@@ -1346,7 +1346,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-chat": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.5-rc.1.tgz",
       "integrity": "sha512-mi0KY13+w9uqXIrp8ZObHC0mGNOhSn2rx4sSobetYN+u4GW1xFvONBsPJYTCqvgnAWFEjAUtqHXmH/Tvmhe0wg==",
       "license": "MIT",
       "dependencies": {
@@ -1358,7 +1358,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-commands": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.5-rc.1.tgz",
       "integrity": "sha512-XU01bKi8Dlupq1E3l/dkUQueHRTm3hqbcTDbK/gbfVMUZXlUN9zNFxEvtXzQzBOrPMFs+gBH3nyza12ViuyOrg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1367,7 +1367,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.5-rc.1.tgz",
       "integrity": "sha512-/A+lvO6mc+uTJWJerFyhZeBV+Ez9Sid8+wx7NbIrrg/mdt191IdHqHI9v2sGiIQ/1d+nI3S0YjhOxMH4hGka5A==",
       "license": "MIT",
       "dependencies": {
@@ -1379,7 +1379,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.5-rc.1.tgz",
       "integrity": "sha512-+lhe7NilUE/Shy02UqBGFku+CCk97L/Jxbyv+LFVVQw+hbGUh2bSgCuNfRLfyQzaRwMxDATlqVM0T0cHkXU5RA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1388,7 +1388,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.5-rc.1.tgz",
       "integrity": "sha512-cT995A3OoY07GhpenbBRC/9z/WQFf5uFv5VMNZSnmrG/+X9huaOu7fZvWV1wiwWWgmhxVWxNFbyYyeq8VJerRA==",
       "license": "MIT",
       "dependencies": {
@@ -1400,7 +1400,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.5-rc.1.tgz",
       "integrity": "sha512-ssNVwTfj2kob4e/9zLISU4QVz7MOw7MWjP5+oqWCmpMVMd3wJBeRNqqOTx+ZaqijfMft8QNJIlyoJmgvYDdK+A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1409,7 +1409,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.5-rc.1.tgz",
       "integrity": "sha512-YK5uUJFZAnXmve0d/nrqF1V+duAxil8615Vx4TPc8b4BsXZ4uloCqHGAfQTkXVdIA3x9gLc9CRp2ZhUDLR7Wtw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1418,7 +1418,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-xM+bIv4gkQIMzOx2vtZRBT5P0rFoxEaOA0FhYuSmItmDUu/tECCbduarRyvBe5KKyjDL8ONCMY9hS8GwJHvjUA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1427,7 +1427,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.5-rc.1.tgz",
       "integrity": "sha512-y/Y6HPwZf146ZHJW5G1O4eD4vKWYVi+xFFY50tdsHRMSPpoiQnnlIAbG12OQknsKslc4SDdA7FHNLxzGankPRA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1436,7 +1436,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.5-rc.1.tgz",
       "integrity": "sha512-PVMSsYyexvebr45PCo2Va2VtfGIpUPkS3umH+WsI/pc1JoYw7REW5lqUy639N4tGDh3WTFhU9bczpAf1Aj8T1g==",
       "license": "MIT",
       "peerDependencies": {
@@ -1445,7 +1445,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-layout": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.5-rc.1.tgz",
       "integrity": "sha512-XbaJSLhZM5rSbcpAy9IyoYgC6nmEppUptzU3H50/cbFqoDCDvXrcflx04UlifRI5tb5ofZtNOvDqqCsJ6kwcIg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1454,7 +1454,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.5-rc.1.tgz",
       "integrity": "sha512-jOpjPC9O+/XqhBjI7Z6u5c7nj/vAV2S84jH592ruG4qZF/rr4EkMs+KZy3Bm7nRxOIpNaJM0D8sGFAgfoAgqvQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1463,7 +1463,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.5-rc.1.tgz",
       "integrity": "sha512-fl59qM9HcNplIXC+MqSgujsaUt3vZYOQpJWO1Y2vihkrg6fHjZoY2TOw42b53fr9NGH/dUImQ0iXll4X4F9Hpw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1472,7 +1472,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-open-in-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-open-in-app/-/dsh-client-ui-open-in-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-open-in-app/-/dsh-client-ui-open-in-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-wzsG3tR/FrkZ/mr+2jwbOVbRNKVLabTcz+XAnJqAeYCAymQmxCCNrAaOUUiaWwGfbrWbAOGp2XnANqs4MjDqug==",
       "license": "MIT",
       "peerDependencies": {
@@ -1481,7 +1481,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.5-rc.1.tgz",
       "integrity": "sha512-Dr0orTetf84oJ2+53HohNvxXmZ4vNMT5ZiLaMhJslWvE2DkqMMq5u7ceVTx3/+MBQvJBKX9V6Atas3Qw64bp8g==",
       "license": "MIT",
       "peerDependencies": {
@@ -1490,7 +1490,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-plan": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.5-rc.1.tgz",
       "integrity": "sha512-B/yYlTP/8QIF0cXCyFRatZ71wlDe+9HiUGCly3AhGgyuYO1xqXuJAhRtsLei0U4hzbar3SL2DF109pO1XlAB+Q==",
       "license": "MIT",
       "peerDependencies": {
@@ -1499,7 +1499,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-reference": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.5-rc.1.tgz",
       "integrity": "sha512-08Iu4RBC3lO6YtlZWihIL0kF9+oQA/J6qQJp5oN+qHuRbjJUcfQ41JLplTiEP3PUWwVeMEpsT69+zWdPsDTUPw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1508,7 +1508,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.5-rc.1.tgz",
       "integrity": "sha512-v3NlhGgcYDUtskwjylVuKJ+FMiuJgYdWg/bIjth+obj7cF2SBJR4A0/9XfCKQvh2xbF/puRLZ7DG3KRl8+BKBQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1517,7 +1517,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.5-rc.1.tgz",
       "integrity": "sha512-k5bhs50oxNNQDQW10aK2z1o07ZjejDwjFqMqYqn8nMaqpG3b/14v063Vfr0woimwpSuSTtO1oBPDZyPGLYguhg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1526,7 +1526,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-session": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.5-rc.1.tgz",
       "integrity": "sha512-qrAKy9soxmTmStjs6mnxHx992iTKzn1uBu1p5UL1wHPYJKus6cTHjBD8HlaYMYE4IzB9AFezUjDfOOjwgyxlUQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1535,7 +1535,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.5-rc.1.tgz",
       "integrity": "sha512-5O+HJrGuyJL0rNf7ulLI7CbdVozYfKDrAYKXoykAzZZ11EgSEaOrNfRobBhUKMsmXyfbKec7qce9rtG+HOgiuA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1544,7 +1544,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.5-rc.1.tgz",
       "integrity": "sha512-oGzUbFGr27KnteXU7/82K5sI/MRB9b+B1sFiQTpUEix318uNfE6q3/o0mhpBcbQoSmpP0D++Bgn12vlgklvsog==",
       "license": "MIT",
       "dependencies": {
@@ -1556,7 +1556,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.5-rc.1.tgz",
       "integrity": "sha512-qCzSHZLZoV5NLgzVGj+h/OAqEOUF9NaFxyD3bdZSpy1xL9ZTmBitpjdmllqiBiIbxRx4AxCiYfOQ38ZGMlyD4Q==",
       "license": "MIT",
       "peerDependencies": {
@@ -1565,7 +1565,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.5-rc.1.tgz",
       "integrity": "sha512-8dvV1zZBG0yx2/DPj3MWtFom8jaJONkCwu0n98peEvGtqzu1vJJZQEfMAD6kxSi/jq5Ws0pt60byPa5PAtW2vA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1574,7 +1574,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.5-rc.1.tgz",
       "integrity": "sha512-DEE4oGtDd0O0jCuo3Jrpt1FF5RIA49P6TfObJbhugOzdt2X1vdsoEqZZDAO4yuu6f2QedgM1mGP3IMCP9J57Qg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1583,7 +1583,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.5-rc.1.tgz",
       "integrity": "sha512-AG8NSL/dzQaq9NmnVpVQIXuNghR3Gr6QbAQvx7Qm49JG+JbJGBurWcYXLgH6OX+hxE2w3y0DezJ2LxLq6ZZs0A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1592,7 +1592,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar-documentpreview": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar-documentpreview/-/dsh-client-ui-sidebar-documentpreview-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-documentpreview/-/dsh-client-ui-sidebar-documentpreview-0.1.5-rc.1.tgz",
       "integrity": "sha512-EnxzXokzQDP/ZkhtQuzHqwFYzB6EZFESRzGhuUTREyZihdM7q4Z1zcRObOw8Btr7WSuiZH/il4RGwDN16XTvMg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1601,7 +1601,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar-files": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar-files/-/dsh-client-ui-sidebar-files-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-files/-/dsh-client-ui-sidebar-files-0.1.5-rc.1.tgz",
       "integrity": "sha512-QnR84tTkCpk59j403bIhGjdLFounfNrRcWQKRcFU01bGkaMdhIaU6AsEGv5pTw2DbCTP4blCeTGr806olIjzIQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1610,7 +1610,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar-right": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-sidebar-right/-/dsh-client-ui-sidebar-right-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-right/-/dsh-client-ui-sidebar-right-0.1.5-rc.1.tgz",
       "integrity": "sha512-JFKsoWRdfX4r++DL2CbuDAgZ6Di1L3siSjcl5z6ilieFfcsN9eUHyOcZN+2WKOQtmpw374ZwrN5Z/i+coO/mCA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1619,7 +1619,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.5-rc.1.tgz",
       "integrity": "sha512-Y6BeDPWD1/waLUiJgnI1T1uz3zzTUypvva7Tr9Sykf50JROIffRVwPCQnZQn61A5k+fbDCFMaaabHpzFdYPNAQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1628,7 +1628,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.5-rc.1.tgz",
       "integrity": "sha512-FViVXMZSnxod6FBAkXOGb+YEMRNPfi+Aauyh+my5EWbvSKEnXTKBYEtoiSN9Y2laS8ZonJgNI4p5Bthb7MVpYA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1637,7 +1637,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q4A4dgpF9WVKN/wo+3LlFHJOp7UMFdFzEITB5WhiwsKADYpU/n6sE8FkWIeFo0g1eqJY9bHAseqQYOAdZ227/g==",
       "license": "MIT",
       "dependencies": {
@@ -1649,7 +1649,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.5-rc.1.tgz",
       "integrity": "sha512-3TOV/T2r7sCxHXaXh+HHvRxh5oMv8ONg9yHTWVsCBKiMO2ZMWBmb4Eqns7+C0c6mNH9FXRR4vSzaUci+v57XDQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1658,7 +1658,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.5-rc.1.tgz",
       "integrity": "sha512-j5rZXHuu+0v8kBVC65s5dBKSh/qFzA0B577d0zL4D7f1iP1zQ3OGnRYKRlcsZ+WCA4b3nIAI3StJdnKx65+xNA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1667,7 +1667,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.5-rc.1.tgz",
       "integrity": "sha512-NpIjEdE97VKDG2vGye8GY6VLUbY0CzJCGIAir+UZ24WfHtlGxhoKheBvoeijjiEEKoQwM1o2xlDUBGxK8DlfjQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1676,7 +1676,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.5-rc.1.tgz",
       "integrity": "sha512-IqAfHrQMbnfrYFz6fuK6z9POtJUiWiIUnZ3WxTxSxbVqi386G0+HoEu22rzqglgeSMH9VdXpsoczXE5jphcw4A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1685,7 +1685,7 @@
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.5-rc.1.tgz",
       "integrity": "sha512-ESKP4+0zJa5KB86HzKl573Zk3EUwyuzyXc0y1Bj/J7aWsFLj4LYkud7iVl0Pag5P2cM7LpB/0Pm/d45E9tec8w==",
       "license": "MIT",
       "peerDependencies": {
@@ -1694,7 +1694,7 @@
     },
     "node_modules/@deepseek-ai/dsh-cmdline": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.5-rc.1.tgz",
       "integrity": "sha512-hZFWY6blJCp8WFbyP9ETLMtBhp6jNcBSaxaFxtOO3MTVFgbUGE/2/zdTSu389j9B/eNXhEoiaIsk9BT0VtD4lg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1704,7 +1704,7 @@
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.5-rc.1.tgz",
       "integrity": "sha512-DfqzMEQW42lVQjjQ6FCEmtzAuYGle1grxqrRPqdXhkDYe4aTSLJLEcqn7/BYZSI64/G1XQYvdS+jkYxbymbv3A==",
       "license": "MIT",
       "peer": true,
@@ -1714,7 +1714,7 @@
     },
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.5-rc.1.tgz",
       "integrity": "sha512-UvrZCSLFD15bwrN2r+MMVxgWSLzwz0R2zm4FbA3yUHDtQXpNsGZeGq6uLVOTc5yKsrFGkxCA/0gIaBPo2dze3w==",
       "license": "MIT",
       "dependencies": {
@@ -1730,7 +1730,7 @@
     },
     "node_modules/@deepseek-ai/dsh-command-compact": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.5-rc.1.tgz",
       "integrity": "sha512-VzZ2dltTYijSL5lMWiOxrIcO0sd/kW/df2mQFJtlDygn9qP6KmXkJYjy78iF9lCnu2tkeUwL9ypd16ZdS4/MKA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1741,7 +1741,7 @@
     },
     "node_modules/@deepseek-ai/dsh-command-feedback": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.5-rc.1.tgz",
       "integrity": "sha512-LqDBHmjfI3oF5uwG2te5Xwa64zbV3aD0EsVa7/V7nMoWSuORlbdBa9YN0EBXpsxmjOwbik8BKaPZPIAdoLRNsQ==",
       "license": "MIT",
       "dependencies": {
@@ -1757,7 +1757,7 @@
     },
     "node_modules/@deepseek-ai/dsh-command-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-qmfPA2fOf53Vgda1btYhJ1ryQpcwiGxtYukyhQKwmwOt/wa1b+Xkcvq58qQOAOtm5fSbWWpKGRhbFxikxlHl3g==",
       "license": "MIT",
       "peerDependencies": {
@@ -1769,7 +1769,7 @@
     },
     "node_modules/@deepseek-ai/dsh-commands": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.5-rc.1.tgz",
       "integrity": "sha512-OMk0uVNbr2RdsItcIigp/2boGulqjei1uoQH3/DZYHB+aWWRXEYa6rk6vW3t82lnkd/6nvyQFV8eccQWZ2PQXQ==",
       "license": "MIT",
       "dependencies": {
@@ -1790,7 +1790,7 @@
     },
     "node_modules/@deepseek-ai/dsh-compaction": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.5-rc.1.tgz",
       "integrity": "sha512-DF1BcWNwA997vrR94yfxVxSvXCVejgv8/ytxNkxvliKK79wFr6DMPAdv9ludapE5PXVO62PLgjV4CE2lxW53fA==",
       "license": "MIT",
       "peer": true,
@@ -1805,7 +1805,7 @@
     },
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.5-rc.1.tgz",
       "integrity": "sha512-Zhl+GOZdNuPmInk6Oko1IkfDMpGSoE2VLFkhfhqjP7mxC3t/OxWmP1fXkvNKiHGHPXrGUx9NLRE1T0AK3zSAGg==",
       "license": "MIT",
       "dependencies": {
@@ -1830,7 +1830,7 @@
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.5-rc.1.tgz",
       "integrity": "sha512-s9TmPMUenf8fDQxm2C0nwKasLMqCYx+ZSn5gXN/GFnSTW2YrPPD/o7KnvlhhFGeuBoE2s+hUXgg5Ro4cbPmzlA==",
       "license": "MIT",
       "dependencies": {
@@ -1847,7 +1847,7 @@
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.5-rc.1.tgz",
       "integrity": "sha512-kd/5/0wWzTbhuigTfymPg8f659Q+HyymVapE+EdYImJDUgbKDPon9i4DmS1wiiwTYgjHPo8VR7QhZ231vJaw8A==",
       "license": "MIT",
       "peerDependencies": {
@@ -1856,7 +1856,7 @@
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.5-rc.1.tgz",
       "integrity": "sha512-f9wflxVAwH6YRQl/CJE8xC18iKAslokEGGRXtWst/ymiOlhTaQC4Iv7CAlrTF5c7er+OUeIODs22GTGHtglz1A==",
       "license": "MIT",
       "dependencies": {
@@ -1877,7 +1877,7 @@
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.5-rc.1.tgz",
       "integrity": "sha512-+pcIimUNe2OQWZVwJFTbKEMUQA/6JAx+EMPodzgJgZzDPwsnYE8OClS2aXY9PW8T6DdaKAX+MVWptTsoVVEmBA==",
       "license": "MIT",
       "dependencies": {
@@ -1890,7 +1890,7 @@
     },
     "node_modules/@deepseek-ai/dsh-credentials-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-S5C3+ItHsJ4WlSQEvY4qqHB/txxe7NnaQXEbsjVDZUwUci5Ia3TaEvH0yz6Oi6ovG2oPrYulzorg6G1ayjPRZg==",
       "license": "MIT",
       "dependencies": {
@@ -1908,7 +1908,7 @@
     },
     "node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.5-rc.1.tgz",
       "integrity": "sha512-xnWdajsbw8vLLoWWw/t3URyFZho5NhFCVfcKumLUU7/6g8RXpYSfdPE1ouMufg/++ESSYEAFtITRaPuZ80jiDg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1917,7 +1917,7 @@
     },
     "node_modules/@deepseek-ai/dsh-deque": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.5-rc.1.tgz",
       "integrity": "sha512-lg+nPOuVz1OfqFnp7FmawYx76DjCrFXgLKG82m7xIHeTqJqUpQlQnTalL20VzTqZCGTsnsvQtrQLzLXTPykXTg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1926,7 +1926,7 @@
     },
     "node_modules/@deepseek-ai/dsh-file-reference": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.5-rc.1.tgz",
       "integrity": "sha512-XjgSLZOiAK3khVpACpqk+/G5j9noPO14+tf5p70S7N5PFFNT2oav4ojB+OGo+gs1bNWrDlij6vR0ePxV2rzfSA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1936,7 +1936,7 @@
     },
     "node_modules/@deepseek-ai/dsh-file-reference-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-Ig/UBqBsCA675680DZ8xk5OELb8ERU4mJ8uTjIuTsUyQliNGcP49I23DywoiNIzLX/zzAigeYkZ77bZLFu7vLg==",
       "license": "MIT",
       "dependencies": {
@@ -1952,7 +1952,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.5-rc.1.tgz",
       "integrity": "sha512-F+loGiwsT09YpRONuFv0+bevEdfmbKBFjxxM8JkDOXpgwk1JXdGNSy7Kp4vXXVh3GcmYkd8VA7iB7NuVp51ytQ==",
       "license": "MIT",
       "peer": true,
@@ -1966,7 +1966,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-Qyqs9l+ZENq4PL7EwBpisvXcqJvCxGTrD/zH0Zj+S0eZee1kXrQjkY0gjW6dxAosGlLL7hZu0kdaD7TPxtKVcA==",
       "license": "MIT",
       "dependencies": {
@@ -1980,7 +1980,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-TGu/2UrZS8KWr6x3sKLce7u0KoGrq5l+RK7ITd79n2WNzSCcAdzN5tsxUEo8JgfHij5S0QRgID0Q8DOx/6iQew==",
       "license": "MIT",
       "peerDependencies": {
@@ -1990,7 +1990,7 @@
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-np+3EdQ86w609DwyaEUFGEHjSQ5i2NFypQxcM9sB+zX6DVSUR9sA2W/fmnStFJdsSzvgXYTCnJiBhlKnAXPf0g==",
       "license": "MIT",
       "peerDependencies": {
@@ -2003,7 +2003,7 @@
     },
     "node_modules/@deepseek-ai/dsh-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-RF+cHqV0O7xkoqkhIst6NhMAwqXXAjTf7Z+H7FLHtZBvFAawU8zC7n7/tmS4P7rZYV+XYFYCDdNoI0GwPReCYA==",
       "license": "MIT",
       "dependencies": {
@@ -2024,7 +2024,7 @@
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.5-rc.1.tgz",
       "integrity": "sha512-t564V58sl4N6V4CBbgOvJGlGFCUt6NtnDVZaebE8bDZOedRd7DtoXyxtuTZOBk4skF+416oQJdA24ybtefH2Ow==",
       "license": "MIT",
       "peerDependencies": {
@@ -2038,7 +2038,7 @@
     },
     "node_modules/@deepseek-ai/dsh-headless": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.5-rc.1.tgz",
       "integrity": "sha512-J1XWUYuPPxxzZC0cUgznJ7yuDG/lhuXXAwOsfkTq6BADb083GzXJL6ppKolDBOhbgLmmLj/7Zq+Ss7aswyEhBA==",
       "license": "MIT",
       "dependencies": {
@@ -2060,7 +2060,7 @@
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.5-rc.1.tgz",
       "integrity": "sha512-CxMi9qHY/zIkzo+UsA+/8UbTagRo6HL07iy32iTYV7gVmXTRt66ViNMDcwXHIlqiQ1A6y7cc0GYTVk88XcyL7A==",
       "license": "MIT",
       "peerDependencies": {
@@ -2069,7 +2069,7 @@
     },
     "node_modules/@deepseek-ai/dsh-hook-protocol": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.5-rc.1.tgz",
       "integrity": "sha512-rkroa/Fq+ErLAaFm5Z9Er01RFq1W0zbzmuDkmg4EeKUjTA3/SlQW0UldbeNIP/amxiqRJdDSYGwGKDXvRnYabQ==",
       "license": "MIT",
       "peer": true,
@@ -2082,7 +2082,7 @@
     },
     "node_modules/@deepseek-ai/dsh-hooks-claude-code": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.5-rc.1.tgz",
       "integrity": "sha512-2WaWwkPSjRG3OVhO/nxfxc1qZQb2g7YPSOhqsmJsgnumtcdTuDCuQbS0VRQpkAJrBMbW20/hitpl1U2FgHLdmA==",
       "license": "MIT",
       "dependencies": {
@@ -2101,7 +2101,7 @@
     },
     "node_modules/@deepseek-ai/dsh-hooks-codex": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.5-rc.1.tgz",
       "integrity": "sha512-NfILKE0cluKGogalOCjVM/l5FMBtSH0mUWhGNVI9mPqQ7flVWbi205XOvznmbENyw9Jnak1W3X/AeT1E0PXC3Q==",
       "license": "MIT",
       "dependencies": {
@@ -2119,7 +2119,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.5-rc.1.tgz",
       "integrity": "sha512-zKbIv4vnWMLV0BVo7LrAjsphbgIB77Se0iOGV3bnF1d9RKHxnkLfyZ6Vt6Y/MKqtKR9UMi1q2z/qls153VOWBw==",
       "license": "MIT",
       "peerDependencies": {
@@ -2128,7 +2128,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.5-rc.1.tgz",
       "integrity": "sha512-GYkEPJo2+3DrZfsJY+nYHIeFYp8kQ0YfCo4Ul1NJ4ALwN/bg4IboLoesMtNsc5W/BaGNV0Y46ivCBjFx33ibeg==",
       "license": "MIT",
       "dependencies": {
@@ -2146,7 +2146,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.5-rc.1.tgz",
       "integrity": "sha512-dmB+OK+NFkVjtIguRwgdPMTE7j4/wSotBBM+hvTgAeLF0QR3J2elipiQAhwgQwTtWh5ktLblfzV+/R7yinaIhQ==",
       "license": "MIT",
       "dependencies": {
@@ -2159,7 +2159,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.5-rc.1.tgz",
       "integrity": "sha512-gbR/CkVRs9rVEMTPwCdhXCeJQtVe2/ph/R7CSZr6AWY9GUXDahbw2V1a2GU/FmySO6hfWD2MBx5+fCUuWs59WQ==",
       "license": "MIT",
       "dependencies": {
@@ -2173,7 +2173,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.5-rc.1.tgz",
       "integrity": "sha512-4ryTu2EPqM2w1h1Z7kLzYAm2paC4MjuwJmWwz6qwBsI5OeZNYt4Q8Ew1C8F8vsFR/jcwho4ZCkdhLcEunLF5fQ==",
       "license": "MIT",
       "dependencies": {
@@ -2187,7 +2187,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-open-in-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-open-in-app/-/dsh-host-open-in-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-open-in-app/-/dsh-host-open-in-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-gfyH+UfR3t8hPpHACN5csFz1r+13efNUC9dpa/HriY2LnnVvcN1Kj9CW7hOAe/NfawFF/adYxb4kqo0wgzWxYA==",
       "license": "MIT",
       "dependencies": {
@@ -2202,7 +2202,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.5-rc.1.tgz",
       "integrity": "sha512-xCOJ1nTW2s5etl18QhBBGpcOxiDfGxofe+4pd90/ZX+vW1vAhaHqyTYSRucOQVGyJb9zvdWCg7R3GcBYn6pUrQ==",
       "license": "MIT",
       "dependencies": {
@@ -2223,7 +2223,7 @@
     },
     "node_modules/@deepseek-ai/dsh-host-webserver": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.5-rc.1.tgz",
       "integrity": "sha512-5kOu9kb0AuRN60/zwPTRcki801ozgnWAFwS1QtQ4ZNgCYIbAiU8gwJHY1//qEpUOuHS+26k+Tqq5/WCJmLGE6Q==",
       "license": "MIT",
       "dependencies": {
@@ -2237,7 +2237,7 @@
     },
     "node_modules/@deepseek-ai/dsh-http-proxy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-http-proxy/-/dsh-http-proxy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-http-proxy/-/dsh-http-proxy-0.1.5-rc.1.tgz",
       "integrity": "sha512-uzqFRi5d6k5ZiV4Q7CxkPUKGZrURN7VBdKAS0LNuBCUApI//vA72blWC+vn2Lz0BKKb8GDrBTuD2ZwCdXIObYg==",
       "license": "MIT",
       "dependencies": {
@@ -2249,7 +2249,7 @@
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.5-rc.1.tgz",
       "integrity": "sha512-iXhJJ3r34NHFEWiuc5pxXlU19hPfNclvH9Ll0X7CzQ39Oh/4UlfO3DBlLpBU7T9fE/y7/UkuI1aRt+dNeiVQsQ==",
       "license": "MIT",
       "dependencies": {
@@ -2261,7 +2261,7 @@
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.5-rc.1.tgz",
       "integrity": "sha512-0AWlZLcIpwdtV9A9fVeJ7b9jpXX0494fPL594gE/Kp1q9jHYyerIulrMHZa17kpu9W59cb1AJNPQy2xN6VDX7g==",
       "license": "MIT",
       "peer": true,
@@ -2275,7 +2275,7 @@
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-19sCxqUKduNO8E3YICSzOfajpBLPXbK/3p40GlxR6bGcOhxqhyH3TPdQS6UQjwNa5bUXHiW9GyB1xUWUUFGAJA==",
       "license": "MIT",
       "dependencies": {
@@ -2291,7 +2291,7 @@
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.5-rc.1.tgz",
       "integrity": "sha512-F2vKsFL491FYjlPLzM2/TtuCt88LrV5SAk+r4zNlt9gvbQ+ZEdeVD4uFRwFc8TpYfdM/yL3qioGEpTuU26TxTQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2300,7 +2300,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.5-rc.1.tgz",
       "integrity": "sha512-KPKJFTNLjURphuF4NlS8DRK94CUYL/dKB8Hzg/22jtxAFO2paX3ifL0vhdPq9xPbcyplaF7LYlf0+3+pXFTnTg==",
       "license": "MIT",
       "dependencies": {
@@ -2318,7 +2318,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-PwqB/Amrtc4nF+ndH6UNIOAH+X2QREwV3R3NaBxY/n0j+hfAl3BUmafj/9UvKlFwStYLLxsyS4um7Vy+XQXhNg==",
       "license": "MIT",
       "dependencies": {
@@ -2344,7 +2344,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.5-rc.1.tgz",
       "integrity": "sha512-5OiNHkkVFDucqXY1KT9QQB7EAulbKDDpqrrK7WTJbLzjVUs98ZetAOf1UOZ15JqA1hABX2+fCoXyitPK9yuuvA==",
       "license": "MIT",
       "dependencies": {
@@ -2367,7 +2367,7 @@
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.5-rc.1.tgz",
       "integrity": "sha512-WcA5KOmv8aC5F8s60riyaVBSNKBpCrSByzpNbATpNKmU6MHKHSpmYOfOO8vUJQY+cdC3qCOcWwtOd56VpoMPGw==",
       "license": "MIT",
       "dependencies": {
@@ -2387,7 +2387,7 @@
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.5-rc.1.tgz",
       "integrity": "sha512-vaxO+lGLsj4B5okcJ3uwrAUoyq9EFqpt6m0rUY9jYlSQHc7RfMkKJ0wpegt8GXUw/WJ0a89dvqI8ojMzi6Jlig==",
       "license": "MIT",
       "dependencies": {
@@ -2407,7 +2407,7 @@
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.5-rc.1.tgz",
       "integrity": "sha512-PztvCosgvzuEOLIwtQ1gVrH7Mz/IUXY9Kj/x63hMpQcnJBmgu7Td5fZljtiAkKexVn2PRFFktyo7MRdN6b08VA==",
       "license": "MIT",
       "dependencies": {
@@ -2426,7 +2426,7 @@
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.5-rc.1.tgz",
       "integrity": "sha512-mQxUZ6eY2FGD3nD/IdoC0PgYpAyip/iOvlHpdoIhV9ehbAd0+YwXw8lzsgrO/bq/KGnff2+LjXSkJvyBcPAabA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2435,7 +2435,7 @@
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.5-rc.1.tgz",
       "integrity": "sha512-bXRq3nGtrsIGOlNNFHLp3gx+59Njl9jnbK30vqiga01y82QzBepfXROWSJGj0Cea0mjxb1tyv0KDRvsHbvTiow==",
       "license": "MIT",
       "peer": true,
@@ -2445,7 +2445,7 @@
     },
     "node_modules/@deepseek-ai/dsh-package-manifest": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-package-manifest/-/dsh-package-manifest-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-package-manifest/-/dsh-package-manifest-0.1.5-rc.1.tgz",
       "integrity": "sha512-BWbXpw5AaCJXrGrbvo+CQYBkiS2ilX3hF3a+dQ4N1OqMALFSMNmUV03aT5yT8WUQEngR6ixvOUUgJvHUK0MiiQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2454,7 +2454,7 @@
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.5-rc.1.tgz",
       "integrity": "sha512-A0xrvtH0AgcH/QycrKHIGEeE98xS0ana8q4wmIYKs/AjuZICR0N/qT4qb1GnPRxcuz/7Z8rHjD/fhou/gFRTpw==",
       "license": "MIT",
       "dependencies": {
@@ -2476,7 +2476,7 @@
     },
     "node_modules/@deepseek-ai/dsh-persona": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.5-rc.1.tgz",
       "integrity": "sha512-IgZ5aCD7Y9bS82WStxTW3InVhajfy5e5mCAMTJMa3Zu2sSCBJ1N9lPKgAmMR8c9YGXl03t7YVuM07fjRYfvmMw==",
       "license": "MIT",
       "dependencies": {
@@ -2489,7 +2489,7 @@
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.5-rc.1.tgz",
       "integrity": "sha512-E1ajaP9NdbIGZK1i+q1QlhPkDSqIEm1Jsiilp3MGQOCM0nxN78IjfbQo8dpgRZMJ9y/N9zXYJtLpGjLksNkv0A==",
       "license": "MIT",
       "dependencies": {
@@ -2515,7 +2515,7 @@
     },
     "node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-6W0vYHshQBw9RLGayAMx+PwoIiCWPSZ3hOrgiuWoeecwFYdHgLvInP2Cht0tCGcidUDLojmooPJ8XxefZ4I8Dw==",
       "license": "MIT",
       "dependencies": {
@@ -2538,7 +2538,7 @@
     },
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-VjTb+R44iPZ2czxD2VN+5YzCpU3WsOtdaKiwNzfswmam73KcjMWuJP1XH6hHLFD3QOjhSr1AaaMYijHYWIEvKQ==",
       "license": "MIT",
       "dependencies": {
@@ -2554,7 +2554,7 @@
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-QRD6PfcQuaRwUTn9EMIx15l1erRqk0erUamcAB3sxPyZOMWIFP7w2cp44Va8RGGDEUb9ZB1vRUH6cF4FAKSZRw==",
       "license": "MIT",
       "peerDependencies": {
@@ -2567,7 +2567,7 @@
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.5-rc.1.tgz",
       "integrity": "sha512-dFdo4icZLP8MvDpGTWTt9/xjVwwoJuzp5jUeBUBxyiK0uSfcdAv+bWW3ghDWeyfRUhpkJIThLb1VmkpfBk9paw==",
       "license": "MIT",
       "dependencies": {
@@ -2581,7 +2581,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.5-rc.1.tgz",
       "integrity": "sha512-xT+oTsSE7tRZVqqcj2qDZJARoK6A+Dmhf3CWPqlaFG/83Zh41kwcW2YWE4sA+vCt2pI2iqLYRw1SftSGawOtVQ==",
       "license": "MIT",
       "peer": true,
@@ -2596,7 +2596,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-cO8edQeX6sdOzbYuCzyadc6o7QFM2upNuEqb32+VXXDl3qCaNb68NBZxaZaBCfC2/aofcvCL+b6rRE5bcauXRA==",
       "license": "MIT",
       "dependencies": {
@@ -2614,7 +2614,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-jLeny81NVsAiEWW8+MqmtkXJfu8CSFDPiuR8W4I/bZ7TNHrPTN7jPuk1/JlphkU4bq1N1a3iLvsDyHK+56ZLVA==",
       "license": "MIT",
       "dependencies": {
@@ -2633,7 +2633,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.5-rc.1.tgz",
       "integrity": "sha512-gziY3YdGfq4W03W+qeEKF0oH/3U6XNU0YoUnU4PeBIJFqg1NPamxoX7CdoFXuJgLkYN97IFf2ihQMLfzWvhwhQ==",
       "license": "MIT",
       "dependencies": {
@@ -2646,7 +2646,7 @@
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.5-rc.1.tgz",
       "integrity": "sha512-3Kp/2G1yw7aolCQNvZocpN1kSj2dRUHQ/HpYhEmMInBT1OZT4nm+x7UXnxLcskc7R+HIKbd7KpV8YNwkn1K/Eg==",
       "license": "MIT",
       "dependencies": {
@@ -2666,7 +2666,7 @@
     },
     "node_modules/@deepseek-ai/dsh-scope": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.5-rc.1.tgz",
       "integrity": "sha512-HU6AGzCCWSQUS9KoDBAPkyQqgUVp+iI9P5Zn0qzLJv3IOdt6cYvxgjt/rORryuQUR9AUj7CGFO3OYw833H7HWA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2676,7 +2676,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-0slsRRDEkq5fxDYF0P9tHtZtzjyvg/dB30w6AhvqEX13MRiNdirUQNSsS62yCuCgRzTx0YDg+oQJUwPAw07tOg==",
       "license": "MIT",
       "dependencies": {
@@ -2691,7 +2691,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-client": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-client/-/dsh-sdk-client-0.1.5-rc.1.tgz",
       "integrity": "sha512-PccdJ5DycaCBJKc3F2YaU7SL4tQNKEW6SkDRiDEM6IrzYl0lZu2RWUlwWlXfi+e5zV+vMYfIYJ1wTdlROewMBw==",
       "license": "MIT",
       "dependencies": {
@@ -2706,7 +2706,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.5-rc.1.tgz",
       "integrity": "sha512-pg80s3S6EBJOmQb+wT4M10+jgxJw/6ebf8Mr0+FChwCR2HTraKQRo40LmPqgVMCZTj753VZODu8SIQbpUwzhoQ==",
       "license": "MIT",
       "dependencies": {
@@ -2727,7 +2727,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-minimal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.5-rc.1.tgz",
       "integrity": "sha512-jWH+1cmiS7LMrpF3OAQqoTSWxC45sxvNHshOBikYqaoUf4sBpSUiTaxy52ZWCB1/tcxB/ZYr1fBDDvTGsg9JfQ==",
       "license": "MIT",
       "dependencies": {
@@ -2765,7 +2765,7 @@
     },
     "node_modules/@deepseek-ai/dsh-sdk-protocol": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.5-rc.1.tgz",
       "integrity": "sha512-xTleAtWust5wpcjv3HQnFLB0KJIBFthwWerriVtXUz4JUw2b08m7S0JNveKIVDstulNxBvHqgXThtpz7nI9Pow==",
       "license": "MIT",
       "peer": true,
@@ -2778,7 +2778,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.5-rc.1.tgz",
       "integrity": "sha512-0YBBrzkCbVEJolS/OpD0DZMSozmYxUTZopiG76MXInjOFBW9J4ca1a8WUjJjqelP1nJTmWGKXp92HcvNEny0Dg==",
       "license": "MIT",
       "dependencies": {
@@ -2793,7 +2793,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-q0DXnkvEBmgEnyHYmKGOrkPUOnyEQV/LDMiP6Cnx8xEgdDztALa0koUuRr0Z+3+vlWUKsbXuKkkn3D2yXMW8tA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2807,7 +2807,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format/-/dsh-session-format-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format/-/dsh-session-format-0.1.5-rc.1.tgz",
       "integrity": "sha512-i90c0z2F4k+46CBOuWW/0b2UPnHpDqhS0PictwxWrh7Em7OSwyCTN2dz9cwraCXubg4APTiBCLeOslxvTCKzmQ==",
       "license": "MIT",
       "dependencies": {
@@ -2819,7 +2819,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-catalog": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-catalog/-/dsh-session-format-catalog-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-catalog/-/dsh-session-format-catalog-0.1.5-rc.1.tgz",
       "integrity": "sha512-5MT9Z56QjpcgJ+b9UFfVR3Rd9ylaJtKAFFkXp6uFm4ATsK5hTdtrVHgj2rsvqlEVnNAO2gcrnvVd/9diFotv6A==",
       "license": "MIT",
       "dependencies": {
@@ -2835,7 +2835,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-v0-to-v1": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-v0-to-v1/-/dsh-session-format-v0-to-v1-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v0-to-v1/-/dsh-session-format-v0-to-v1-0.1.5-rc.1.tgz",
       "integrity": "sha512-zKayd3l7YETy0agKB5Mg0gdDKkeaHUOmDYblVhS346Wl5G3ZTuurvgwXMNglfwvy7O0uNfOS/SvnU0eWQ4sV1w==",
       "license": "MIT",
       "dependencies": {
@@ -2848,7 +2848,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-v1-to-v2": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-v1-to-v2/-/dsh-session-format-v1-to-v2-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v1-to-v2/-/dsh-session-format-v1-to-v2-0.1.5-rc.1.tgz",
       "integrity": "sha512-wwgTHoeItoITykmlhWFhN8BM87NP58p/OMBrm9UEDd6Z0Y5T+8/ijoVFhPbWIQFMyWdTLF/3JMsS+RxcKwRESg==",
       "license": "MIT",
       "dependencies": {
@@ -2863,7 +2863,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-format-v2-to-v3": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-format-v2-to-v3/-/dsh-session-format-v2-to-v3-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v2-to-v3/-/dsh-session-format-v2-to-v3-0.1.5-rc.1.tgz",
       "integrity": "sha512-BH41t2xsAxk2ibigx8WcZZknwxT19IrN1gOm//Qoj0K0qFJ4lWWgj6kJcNyIhdFvTbXOAoaF7KTYEM10Nmzs+w==",
       "license": "MIT",
       "dependencies": {
@@ -2877,7 +2877,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-log-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-Q2eNVnLsigVRenf+qQxLHWF38GWiRFGWkHAacwwXCZOQUYBNFXnrSGXAGF8gW1tUQAkCKPTsx6LohMW7GDgfAg==",
       "license": "MIT",
       "dependencies": {
@@ -2894,7 +2894,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.5-rc.1.tgz",
       "integrity": "sha512-/SGAggREmyYmVu4F3daNqXE1rFcaeuvOONUwh5dRXf+xMtY/5E1wtwI0K0aJ53+1r6+Azzd9X4xc5EqToV4YiA==",
       "license": "MIT",
       "dependencies": {
@@ -2911,7 +2911,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.5-rc.1.tgz",
       "integrity": "sha512-ZOFdFdsX5w4lWln1CO2ZzdnibEIOoPu58rlafw4xsLaPoR5mnceVnIuGIYr8qqaB7iv2f9ZLNaGtyHT/Wgpv0Q==",
       "license": "MIT",
       "peer": true,
@@ -2927,7 +2927,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.5-rc.1.tgz",
       "integrity": "sha512-/OzAiGuAS6UoiJoQSkoPekFVGB7lNYQp5maN7ZckzQ8oYf1xS5pQPFKptIrgYwd6pZRb2lDlFZhZtBvL0KGHOg==",
       "license": "MIT",
       "dependencies": {
@@ -2947,7 +2947,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.5-rc.1.tgz",
       "integrity": "sha512-dwDS3ite9I1oOAPneA87ieHBd+szFNrTeMNF4XHRxexMbBWxNZUv62h714UMNlk2niGKsAKE56PzwlnWHmGwGg==",
       "license": "MIT",
       "dependencies": {
@@ -2960,7 +2960,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.5-rc.1.tgz",
       "integrity": "sha512-455PbLGmBNQcOFX1s/yYd3fkRCy13TbQMcVouyhTCzo9KrbiDPg2jPVTkTpQgoo8X9RaAm/hbST781rNqja87g==",
       "license": "MIT",
       "dependencies": {
@@ -2977,7 +2977,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.5-rc.1.tgz",
       "integrity": "sha512-4FdRNYdUb7uXV9NGSJJtyV+qT0ex3DlidXyWsOPj+8DXo90I24mveLvK72w8IuXDXS2hpO7tJVYoRk8LkxCtIg==",
       "license": "MIT",
       "peer": true,
@@ -3006,7 +3006,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.5-rc.1.tgz",
       "integrity": "sha512-WU9L78sMN0smbRndw59COnkG63/r1d3HfRXnGLMcGiJWTJNsMQLniZq1t6SvChtPPsGN4Djr0jGwSULRI20Sbg==",
       "license": "MIT",
       "dependencies": {
@@ -3026,7 +3026,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.5-rc.1.tgz",
       "integrity": "sha512-rbHLt6qm75wqxzUpp3jw9twcEsWVTAZnSa8uNcqtIAeHbPhlgDKqNxvxOeoQPPmlNFr5y//FCQ4S27B1cqxw4A==",
       "license": "MIT",
       "dependencies": {
@@ -3061,7 +3061,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.5-rc.1.tgz",
       "integrity": "sha512-xq0iu4FRCw6Jgy6VFVwK/ND3R8gNWZ754GXkRfF59OYnWJ9N07JqYw0iCKzg3nUcd3kMYrPCDTPZW1jMUtn1eA==",
       "license": "MIT",
       "dependencies": {
@@ -3076,7 +3076,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.5-rc.1.tgz",
       "integrity": "sha512-051BiuVwm55jvoXuobz1FSA9p1hmpvcJUiBylpvU5rS7u+Jd+iLTkti80954FfSs3bNoTCBRb/mEHmXjl+9YaQ==",
       "license": "MIT",
       "peer": true,
@@ -3088,7 +3088,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.5-rc.1.tgz",
       "integrity": "sha512-UQfr47iXoMkOQXZqn56p5Pd7rXghPzxpuZJwSydhlNHqIzvYC17tf8TvbNA4FCc63uXv5ISSdcli6smZLHbtfA==",
       "license": "MIT",
       "dependencies": {
@@ -3112,7 +3112,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.5-rc.1.tgz",
       "integrity": "sha512-Gz1qZ9rXiNzogz9StL4+oV3PilLvK6kCgtXSYJZeLIr7quliwDObCmP68+B4vncLPUeBpEaN5ozyE2ymFuzNPg==",
       "license": "MIT",
       "dependencies": {
@@ -3132,7 +3132,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.5-rc.1.tgz",
       "integrity": "sha512-bEF/hyR7eBvBG/EDnERFajo3+phtyGbhpHdm5DRcMzv0EC+JMPVn/vVeOXYzYRvJ95trTntsoVBczL51YdFlkg==",
       "license": "MIT",
       "dependencies": {
@@ -3148,7 +3148,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.5-rc.1.tgz",
       "integrity": "sha512-csGnyYOFr7ubBZQ38sKgfQYujdWNP9n0FJdfgAM1y62lYKMWtjzuPJfKQGar7VsW2E/fBGeyIuLmUP5sEJc/0w==",
       "license": "MIT",
       "peer": true,
@@ -3166,7 +3166,7 @@
     },
     "node_modules/@deepseek-ai/dsh-session-turn-outline": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.5-rc.1.tgz",
       "integrity": "sha512-vH6KMszzMCQHJOpVkYOhBqwAN94zFP33ByUbAWag2BT6YDmEXh3pE1lKd7glyGfuPJE6W0cDUUuWLIr5cWLkyA==",
       "license": "MIT",
       "dependencies": {
@@ -3181,7 +3181,7 @@
     },
     "node_modules/@deepseek-ai/dsh-settings": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.5-rc.1.tgz",
       "integrity": "sha512-9t6JlHwnMu7qTHpMVVRLyzfi7yWKlDozmh7Xbjjd5mmzY+dSdKTPsoRGSdGgTLvBMQBi0X2O8Kj2moDp30XKGg==",
       "license": "MIT",
       "peer": true,
@@ -3198,7 +3198,7 @@
     },
     "node_modules/@deepseek-ai/dsh-settings-file": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.5-rc.1.tgz",
       "integrity": "sha512-y/9cLMidbEq53N4IFYVUgnim9Zfk0UYVTAPkzegOlHCyLQY2mK86u+GU4fXw1mMoO7JH5JjS6SiBTA8ZX4h0DQ==",
       "license": "MIT",
       "dependencies": {
@@ -3216,7 +3216,7 @@
     },
     "node_modules/@deepseek-ai/dsh-shell": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.5-rc.1.tgz",
       "integrity": "sha512-8V7iGmfsXDFMyftwQXemh1QLqcUysvy+bYWXr620/1B/sMn3oU8dhXvT8i4uD6VkMy2rds3XScUQ3XBl7ByMLA==",
       "license": "MIT",
       "peer": true,
@@ -3229,7 +3229,7 @@
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.5-rc.1.tgz",
       "integrity": "sha512-OO4AmGqqHUWRPK1PSroO/TJG3rNwoAgIMx56S3aiM7v4cUtNmUtMQ71lv9kOezcW+2VlHxfup5jhzpYIQAIiSw==",
       "license": "MIT",
       "dependencies": {
@@ -3244,7 +3244,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.5-rc.1.tgz",
       "integrity": "sha512-SmlIL6lak8nf+Ioiad0N/iImx/S8NO23ile95rsnfJLOPCxSTjNunyjtSkE6ioyAS8UQaIb4gkVo+LvLYKI0NA==",
       "license": "MIT",
       "dependencies": {
@@ -3259,7 +3259,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.5-rc.1.tgz",
       "integrity": "sha512-DAEEzizxOPH13HlHDzxT4WiNzCFtbMAfGxTWKpftG5ybfRlb/DBZZu7Bg6vgm/ZXiWcpvlCo7kg0hie0DBjKsg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3269,7 +3269,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.5-rc.1.tgz",
       "integrity": "sha512-E8l6NITQ47uVNzfhPz9OLUzxZX3Q0M8K6Vqol5Q8Xjl2IKE9VKMKDErFVkf+IWzZclhMimcbZmqAeUrjbTOmFA==",
       "license": "MIT",
       "dependencies": {
@@ -3314,7 +3314,7 @@
     },
     "node_modules/@deepseek-ai/dsh-spill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.5-rc.1.tgz",
       "integrity": "sha512-Dl4ukHqXazACAkxuctFSl3HyjOLLCS1y8Yr8XiD4OQVkoNdJZWjpFwxZemrlEwodQRy4arcbWA0xUOBpGSMkhA==",
       "license": "MIT",
       "peer": true,
@@ -3327,7 +3327,7 @@
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-rsXRuJLhhfyulMqZjYNHT0cOEsKzkwvumfmXQRvkb6LwHi9dHAtu4l7yVVX8F+OpywPKPVJhP+VkU2E5DfKkTw==",
       "license": "MIT",
       "dependencies": {
@@ -3340,7 +3340,7 @@
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-ABtC3dSUs2GWEypkJERbqb6lNqIe3I9qlPd91uG9BrdK2AT5yxhcNHv7PpNWEjhpVZ6dyM4T6ReMcKkKxFKPYg==",
       "license": "MIT",
       "dependencies": {
@@ -3357,7 +3357,7 @@
     },
     "node_modules/@deepseek-ai/dsh-storage": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.5-rc.1.tgz",
       "integrity": "sha512-ng3Xjt6klE35kGH4yBzNfDL1XRVhlw1rC8YQ4aqv8yAMJqeIA1T2eyizyKBl6ewgpu4pzwyANWEHymWLbVQarw==",
       "license": "MIT",
       "peerDependencies": {
@@ -3366,7 +3366,7 @@
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.5-rc.1.tgz",
       "integrity": "sha512-pRubmMAyvllAgmKeS20asIwJHywXL79NyUVXC643pz70IJau8iRTTEbJ6sbN/w4DHsVo5ljm0/PZx4TJ72eAgg==",
       "license": "MIT",
       "dependencies": {
@@ -3381,7 +3381,7 @@
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.5-rc.1.tgz",
       "integrity": "sha512-yPPJmlJRVkgTgbNy5by/0jZFxlixJdIZFp3Dn6o6xF790eYnhGqNUH94v6zuBTnPDgJiCkiwnoo5KK5FEMBkNA==",
       "license": "MIT",
       "dependencies": {
@@ -3394,7 +3394,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.5-rc.1.tgz",
       "integrity": "sha512-3XQxzPkKtjhKcn2TgC1myS4qqT5s+Ya0pSLcp0dP36eS9qGLYkg/F7nM48H/xRsNKari+CIcTkVKn9xvuEz6rg==",
       "license": "MIT",
       "dependencies": {
@@ -3457,7 +3457,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.5-rc.1.tgz",
       "integrity": "sha512-yPuv9snuphUgimZyguvPZRsF7XJ2IKNYpv+JzW1jrxy7lP+DJhxAHdHidwdNYfDKyt+SivRKAo9vqtpRM0m55Q==",
       "license": "MIT",
       "dependencies": {
@@ -3473,7 +3473,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.5-rc.1.tgz",
       "integrity": "sha512-seEjs92TDU/0A3Sk31KPUWT872q7DR+mNCrl0T6Pss37Gv8uhSG9qdorRGJAhf1Y4ACIB+zV334kGfwBgs0xTg==",
       "license": "MIT",
       "peer": true,
@@ -3492,7 +3492,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.5-rc.1.tgz",
       "integrity": "sha512-vUf+ZdB8stqJUQZlwsZBN3nUJemlnyPiiJC44dF1Lwimx08F8LcXA+tiJ0b78H5p1StXS6BmicFKjrkvc9ZeRQ==",
       "license": "MIT",
       "dependencies": {
@@ -3506,7 +3506,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.5-rc.1.tgz",
       "integrity": "sha512-kAUwSkEn2NqDiX9J8f1CltDhaxBQau8KD1yBQ2cWJ91KdQV6cwi6F7sA6xKD7Ak46Au/YAwwNX+d7cYaKyr0iQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -3516,7 +3516,7 @@
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.5-rc.1.tgz",
       "integrity": "sha512-TKcqaIf1fJzjraXhwmSAQAqkPMvIjS0Y7b9fC4n7+G8eQpb3gaF/eJXn6Tx4OgFSDV5R/NLUqHaU/ogxTjdWhQ==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -3533,7 +3533,7 @@
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.5-rc.1.tgz",
       "integrity": "sha512-RAdO9biQoga1vAVTQY9J7THexiOE1FOd1Nli021MQt+Zf73c83BSd2DwXb0WDilLaMeSxZPaIRRqoXpJlpmLIA==",
       "license": "MIT",
       "dependencies": {
@@ -3548,7 +3548,7 @@
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.5-rc.1.tgz",
       "integrity": "sha512-fXsCGJMpefn0uauU1+E+/BWX77Z/Rk+hOxpm5ftNb1YcA6+bttArTQn6KdgFEq3SDXcZwvhUkITffK5wq7nvvA==",
       "license": "MIT",
       "peerDependencies": {
@@ -3559,7 +3559,7 @@
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.5-rc.1.tgz",
       "integrity": "sha512-CeIg1/5jjvtOmtkCyV+V0Qr9piKxDI5UT7jvoL4KdDVZ3R5nTUujaoaFPNhW65cCDR7kd5bEL8SES7JvE8ERJA==",
       "license": "MIT",
       "dependencies": {
@@ -3580,7 +3580,7 @@
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.5-rc.1.tgz",
       "integrity": "sha512-ebhaIxwcUBWzA3TPu811uICzyu2hyWjkh3msppYcilBt6fidgc5l2jVIMZdnDsejpdjDzba/eqwFY5JuexKzxQ==",
       "license": "MIT",
       "dependencies": {
@@ -3599,7 +3599,7 @@
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.5-rc.1.tgz",
       "integrity": "sha512-BcV4y/uCIm82VlIwuGsbLjAZXOxRBmjwusi637MV25hJhhGuWaKoMqAa0D/Lcfqu8hU+g3vgGJdpQvhHnG8sgQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -3608,7 +3608,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.5-rc.1.tgz",
       "integrity": "sha512-b5k6jS8AuW0avt0nRX2IrP38wt8sPL+vhYIE7f2kbdMfH9qcNgBegRh2DtcBLhtaf2E6fxQDQsvA6smOJeVYEA==",
       "license": "MIT",
       "dependencies": {
@@ -3625,7 +3625,7 @@
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.5-rc.1.tgz",
       "integrity": "sha512-Tp4rUwug/u3mV21ri++dN5kCXUecyiVTCeLs8OE/61HiPIUejr5deR54pZEwV+MPPymVOXrmR0V1dBSV0T7Jlw==",
       "license": "MIT",
       "dependencies": {
@@ -3644,7 +3644,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.5-rc.1.tgz",
       "integrity": "sha512-O98eATje45lNWJjIwzEjMULeDT5NnZr1LV3GMNd4PZJih9jfflKpuHnVMvRmyrhk6KRdO4tmsPRSs+Bij7wVUg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3656,7 +3656,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.5-rc.1.tgz",
       "integrity": "sha512-BfZ4R40I7AJFcjHgMkzh3unrp5S7mZT+szUUz4tkbMrAkgHfOdkIHhQ/BTgxWBuFzD18OfAMJ/RnegrBCFVKWw==",
       "license": "MIT",
       "dependencies": {
@@ -3678,7 +3678,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.5-rc.1.tgz",
       "integrity": "sha512-o1mu982ix8Re+84oxs1ZwFObwsEuvLymQlPb/qEJcRm82/Ui3rI0SByPbBHxiHrFp4PLB4WsWCzdKNfIuF8XKQ==",
       "license": "MIT",
       "dependencies": {
@@ -3694,7 +3694,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.5-rc.1.tgz",
       "integrity": "sha512-rx7nmu2fRWVXbprb950gXpoBxtTLCaJDSShXF73TURZtAjehr7PwMypwWdp4y0YBLfGpmFRjLy09/BK08RFnzw==",
       "license": "MIT",
       "peerDependencies": {
@@ -3706,7 +3706,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.5-rc.1.tgz",
       "integrity": "sha512-dGX+Q/7ggnoLRtofTUXmdTRgvpiWWl53ghpPZgj6lNAh91hjKSmAwxq8vV3fXARZif9OKDJVJ7k0YBaYswOLYg==",
       "license": "MIT",
       "peerDependencies": {
@@ -3722,7 +3722,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.5-rc.1.tgz",
       "integrity": "sha512-BWLWJCJxCECFHmS8gHbnyNJlSTG+KVbVMz73Qduoo+ABeDvWj6cFVXTewAUA9jFEIS3xzJcNilsV1g5DGaEnPw==",
       "license": "MIT",
       "dependencies": {
@@ -3744,7 +3744,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.5-rc.1.tgz",
       "integrity": "sha512-002xxeL5UD2QmssUbiI1mfVsP5hpPAmSM+RNPzlJoQ6OF5RwYjmbMeBhQ4mMlp170cyTLeOa6N6WRx+LnhQQcA==",
       "license": "MIT",
       "dependencies": {
@@ -3765,7 +3765,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.5-rc.1.tgz",
       "integrity": "sha512-5NCniCOoCeXYXMZNPCmGlrOYIGjnGddTJVOCXNqqAcwxtOxHAoEHTtphaohIa/4Vy7mmRIHgO1KUii443ky1Bw==",
       "license": "MIT",
       "dependencies": {
@@ -3784,7 +3784,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.5-rc.1.tgz",
       "integrity": "sha512-SIgxnjQHl6KE+kpt7VjYCI3aw5DCeztCKGxuJzpLdqJkSoVtewp1Ofz0/Pg1R4DIIaGR8unRyqpZH8qf8uIpzA==",
       "license": "MIT",
       "dependencies": {
@@ -3802,7 +3802,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-present": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-present/-/dsh-tool-present-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-present/-/dsh-tool-present-0.1.5-rc.1.tgz",
       "integrity": "sha512-sfYwTyynqM5ev2TnPXX1WKAwlhFa9msptC//qCxZTsCRCeWoaKwwPj+js0P1nGGV9gIy6QJoDh0uYOPMNlb/Jg==",
       "license": "MIT",
       "dependencies": {
@@ -3820,7 +3820,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.5-rc.1.tgz",
       "integrity": "sha512-UmWePfsJIUfFVj2UFyh8wacqxSXYrABGoBHXWjYFlfqpXt7rfJL31rOl8N1+uYypAVCxe4O2IquuJxfYAVhBLA==",
       "license": "MIT",
       "dependencies": {
@@ -3842,7 +3842,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.5-rc.1.tgz",
       "integrity": "sha512-oQdHTNNsEwdmKTUw7Ve8EkYCVs5hWb3yUxRQJt0E5qPfoTWPzmAUfYQxyZnJW4iKs9TARFKsnA0KjeOAaE4HQw==",
       "license": "MIT",
       "dependencies": {
@@ -3858,7 +3858,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.5-rc.1.tgz",
       "integrity": "sha512-WwLx1/AXydG76/OmLPJheCOlrGXerGyJ6DTbBu+i5/v1/KqHsmg2XbBSBQNaSS1oZcpslPA04+cCOKtL6Sl1rQ==",
       "license": "MIT",
       "dependencies": {
@@ -3876,7 +3876,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.5-rc.1.tgz",
       "integrity": "sha512-f/ulddbkhWXphLce3vlnie8bT9P0LuasehqG+qjsBEiZvGpCS23M3IJoh2j90sUgLhAgW5OSQ0qaut3cTgfAsg==",
       "license": "MIT",
       "dependencies": {
@@ -3892,7 +3892,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.5-rc.1.tgz",
       "integrity": "sha512-t0wme2aOdW7xhyxeH2T+fuR3CyA2lYVioqtrsMNnq9IqUGgoEqEl+pZMgOA9kx1NIxMRyn25vweJlgbm6NaxOw==",
       "license": "MIT",
       "dependencies": {
@@ -3908,7 +3908,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.5-rc.1.tgz",
       "integrity": "sha512-29xQqqjzmMP2A0qxlQpYdbH4Eg3G+FWGpCeRDW7oFq62K4jbOlv7iba8DbG35+Av+TpnXJvMM8j/6BkyLw+dkg==",
       "license": "MIT",
       "dependencies": {
@@ -3932,7 +3932,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.5-rc.1.tgz",
       "integrity": "sha512-vEztxH6ctHdDJFYQjxaOuecV9a9ia0R1eW4DPP5nuQdr1KeJeOl76d6h9KFPdk9gkqZjJwpkJzdH1rAYjkMDhw==",
       "license": "MIT",
       "dependencies": {
@@ -3949,7 +3949,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-todo": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.5-rc.1.tgz",
       "integrity": "sha512-JfVRK72J26j/ouEmzhvcHnVqfFa0jJAPGtrGS9QV1gyTXCVvjlZi1vf4Qihf08d9Kj4LLFybXaxGlh4KEnZkcg==",
       "license": "MIT",
       "dependencies": {
@@ -3967,7 +3967,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-web": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.5-rc.1.tgz",
       "integrity": "sha512-yWU58XcvtKdTT8Rn9f+dkN6IIFUbPd7iIuv9l4PmRMmC9MFT4eZjXABPo1yByVFsW1jjDJlm/XZVyNTnhGBBbw==",
       "license": "MIT",
       "dependencies": {
@@ -3986,7 +3986,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.5-rc.1.tgz",
       "integrity": "sha512-gO7kRxRMabznM4UCMrpG8/YHLP/L5K4ocTMb+EiL9OcwvTSWNORNM2Zz5DAPb/aidJDGY5khSV9G2JGabqA9eA==",
       "license": "MIT",
       "dependencies": {
@@ -4005,7 +4005,7 @@
     },
     "node_modules/@deepseek-ai/dsh-tools": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.5-rc.1.tgz",
       "integrity": "sha512-I5AUxKTqUrC0nvRO4UcpU+f65P+nKs5BUrS2nqZehhFZ2rVxhUAJ7YdORcY6pVkBTB15nPr5gK0WPgwyfS217w==",
       "license": "MIT",
       "dependencies": {
@@ -4027,7 +4027,7 @@
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.5-rc.1.tgz",
       "integrity": "sha512-5kTyT/ZIg8+LUpffO70zTvxPtcpiQPUqGNZCWLG9WrQZzHmOytgIdlGwlFg5Wc6T4JkyA7lXsm5BOn1jI1eJdA==",
       "license": "MIT",
       "dependencies": {
@@ -4041,7 +4041,7 @@
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.5-rc.1.tgz",
       "integrity": "sha512-HBxnSnvjiYPlir6An+/W+66dTRQnwpbNUbtOH6e5LHuV4CcHL5yrimTbMI04olJM9w2U9FyfwDOzmW6uqWjAew==",
       "license": "MIT",
       "peerDependencies": {
@@ -4050,7 +4050,7 @@
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.5-rc.1.tgz",
       "integrity": "sha512-h+lmV9FnNxtlZmY3vH9B4Sj49jt/I7mCPhGG2ffrA+K4twlOjB9TB2Eq9PMoHzWOoHoGoi5QeXDt0mH9fuj1lQ==",
       "license": "MIT",
       "dependencies": {
@@ -4062,7 +4062,7 @@
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.5-rc.1.tgz",
       "integrity": "sha512-fSxEBvHQnozIh5HV31t2BNodYzyv7iE2srna7p5k0Y/3R9c6DdoZyQZ9momcN9gloraq8HK5+cvrYHzgc4LYPQ==",
       "license": "MIT",
       "dependencies": {
@@ -4081,7 +4081,7 @@
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.5-rc.1.tgz",
       "integrity": "sha512-IqbMrL7qortyJGJs/H+iBbxiSke8x1csKxGDJmMmycvKOHo6RIwG5008JkZlEpmm9SU9aaJF1UzDfaGHJl10Tw==",
       "license": "MIT",
       "peerDependencies": {
@@ -4093,7 +4093,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-crypto": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.5-rc.1.tgz",
       "integrity": "sha512-8ZosLrwbXdsWRlZ/0Yu85GMhKbFHqGD+ayiFzABXGb3sxfG6nbQQWKtv1sRr77wJ6wYvM2R9rPOg+EDWkGocqQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -4102,7 +4102,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-time": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.5-rc.1.tgz",
       "integrity": "sha512-HXfJqKymuFv052hHzpHNvrHAcgMbx1BG0o9PiEGkqel9k0fXRBmhWGqrROebZxe5gpIotlVhq7QAXd36p/dyzA==",
       "license": "MIT",
       "peer": true,
@@ -4112,7 +4112,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-values": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.5-rc.1.tgz",
       "integrity": "sha512-iHH62b+Mc0ueLHn1OQGLOC6+WMqjyK2+wxCkaiQGoGHBAyRGQBnBWiFAOGxp2xIElCXsc1mU1nrkN8D6jppYQg==",
       "license": "MIT",
       "peerDependencies": {
@@ -4121,7 +4121,7 @@
     },
     "node_modules/@deepseek-ai/dsh-util-workspace-path": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.5-rc.1.tgz",
       "integrity": "sha512-yGU2meCr+8Ru+4WbMtKLlROxtuj9zGjJ6N6bJs20kRxIT0JNlZ6uwqnDQONgN8u44WdyKEaIwbv5IGjxIftLRw==",
       "license": "MIT",
       "peer": true,
@@ -4131,7 +4131,7 @@
     },
     "node_modules/@deepseek-ai/dsh-web": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.5-rc.1.tgz",
       "integrity": "sha512-kf57xP4cIsKK3DNRQ7jJaLQCA7u30xLRerd98epHDThcCLP8Ab8z7p2C0Xh1J4GdorDnU+jxQ1lae9svwGNmZA==",
       "license": "MIT",
       "dependencies": {
@@ -4144,7 +4144,7 @@
     },
     "node_modules/@deepseek-ai/dsh-web-app": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.5-rc.1.tgz",
       "integrity": "sha512-9V2GPqEs0A+LFJVVPt7FQK//U8oM9S0TDhl6MqO7zQftimfnH8ruQZkEZXg9zXXEWULCW0vY1DtsPjvMepA8Mw==",
       "license": "MIT",
       "dependencies": {
@@ -4238,7 +4238,7 @@
     },
     "node_modules/@deepseek-ai/dsh-web-fetch-http": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.5-rc.1.tgz",
       "integrity": "sha512-n3cdS8saCgRoTyoV/Jx1gnQV5/hZ0n1ejIMuFUieSMwWfS+8KQNHHB1M8DhCtZ+XpQx5tict0D07hwLdjmb15A==",
       "license": "MIT",
       "dependencies": {
@@ -4255,13 +4255,13 @@
     },
     "node_modules/@deepseek-ai/dsh-web-frontend": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.5-rc.1.tgz",
       "integrity": "sha512-N6WnubGkuOt62OSFVs3XFybh9/VnDy2yMqaAivr1pIp3YtLsMv9QEyYrgqUhsYsuqu1Tfr5GAVmmcNI5OA7i/Q==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.5-rc.1.tgz",
       "integrity": "sha512-/eu47plhOZLQcm+PeTh3hxSyaXpSJ+oEfVfWwfZ/TxEwbMKZm/mL/FTNnWtzvAhVB8e6nt0ERGVuQATco0k5lg==",
       "license": "MIT",
       "dependencies": {
@@ -4279,7 +4279,7 @@
     },
     "node_modules/@deepseek-ai/dsh-webhook": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.5-rc.1.tgz",
       "integrity": "sha512-Zj5cxTYweaC5sLnSHc26TZWY0PPJ+yCPSnuP2vrpn18FErMC539XfHN5+ann0iqK2fN7NKnxCqJmHHSI+Q43lw==",
       "license": "MIT",
       "dependencies": {
@@ -4301,7 +4301,7 @@
     },
     "node_modules/@deepseek-ai/dsh-webhook-github": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.5-rc.1.tgz",
       "integrity": "sha512-sroVKHjfsHAHnioMEmkSb7CJyJgFr44yISWv+d19SC2opcuo/1gcMqpbLMsbpxK1bODm2D9JR7W73TYJvF8ymA==",
       "license": "MIT",
       "dependencies": {
@@ -4319,7 +4319,7 @@
     },
     "node_modules/@deepseek-ai/dsh-win32-process": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.5-rc.1.tgz",
       "integrity": "sha512-bGRRprQhbSLqG4LjCJjAUyeVLCJibriNyR123xW50MhzX7Dvw6j8xG2saJ0HvQt8ak98RJYXeURVgD8HpDsgbA==",
       "license": "MIT",
       "dependencies": {
@@ -4331,7 +4331,7 @@
     },
     "node_modules/@deepseek-ai/dsh-workflow": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.5-rc.1.tgz",
       "integrity": "sha512-cIVts/XHHrrte0YRGixezFlLv0pVEsCzpqLvco24MCCFJrlpcJFkW44YTUJffUAYfpVq6O7MV6S4Y5f07sdsZA==",
       "license": "MIT",
       "peer": true,
@@ -4346,7 +4346,7 @@
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.5-rc.1.tgz",
       "integrity": "sha512-tXbav9wwZugtu1e09I4Y5gt8VyfmRlQPZkXYtOq+ltxwgZA0hJcaRV4UWpWCc0TSlSH155eAFS+yJnHQjBiuUQ==",
       "license": "MIT",
       "dependencies": {
@@ -4366,7 +4366,7 @@
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
       "version": "0.1.5-rc.1",
-      "resolved": "https://bnpm.byted.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.5-rc.1.tgz",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.5-rc.1.tgz",
       "integrity": "sha512-RR/PLSnpW9OrWJ0np1DlvIfi9nTA2a1rLqeOsko6tI2yW3p8F82ZkdE3wZ8DWMTBru12VMkY8SiDhXOxPyihfA==",
       "license": "MIT",
       "dependencies": {
@@ -6602,7 +6602,7 @@
     },
     "node_modules/@xterm/headless": {
       "version": "6.0.0",
-      "resolved": "https://bnpm.byted.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
       "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
       "license": "MIT",
       "workspaces": [
@@ -7487,7 +7487,7 @@
     },
     "node_modules/fflate": {
       "version": "0.8.3",
-      "resolved": "https://bnpm.byted.org/fflate/-/fflate-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },


### PR DESCRIPTION
## Problem
The root and TypeScript lockfiles contained 786 tarball URLs pointing at the private `bnpm.byted.org` host, so clean public npm installs failed with ENOTFOUND.

## Portable install
This PR changes only those `resolved` hosts to `https://registry.npmjs.org/`. Package versions, integrity values, dependency edges, and all other lock semantics are preserved. `pnpm-lock.yaml` is unchanged because it had no private tarball URL.

## Validation
- Node v24.20.0; root and `ts/` each installed from an independent git-archive snapshot with a fresh npm cache.
- `npm ci --strict-peer-deps --registry=https://registry.npmjs.org`: root exit 0; ts exit 0.
- Normalized semantic comparison: root 552/552 and ts 234/234 private URLs replaced; normalized equality true.
- dsh and dsh-acp versions match across root/ts.
- Isolated smoke: exit 0.
- `npx tsc --noEmit`: exit 2 due pre-existing missing declarations/modules (`playwright-core`, `lunar-typescript`, `better-sqlite3`); no lock URL failure.

Logs: `.omx/artifacts/issue414/` (local ignored evidence).

Authored and validated by actual Codex CLI gpt-5.6-luna. Issue #414 remains open.