### PR TITLE
docs(#432): record scoped contract-only approval for seam/D-31

### DIFF
--- a/docs/decisions-needed.md
+++ b/docs/decisions-needed.md
@@ -8,7 +8,7 @@
 > Downstream: implementation/Exit evidence advanced per receipt, and issue gate updates; a founder YES only satisfies the corresponding decision gate — it does not auto-rewrite milestone Entry.
 > Items are independent — you can reply one by one in priority order; work advances per receipt.
 
-**At a glance: 1 item currently pending — #137 P6 founder review (overall plan approval).** An explicit P6 YES still does not satisfy M6 Entry: M5 Exit remains a precondition gate, and P6 approval does not bypass M5. The entry conditions for M5 Entry are tracked in #136. D-1~D-9 and D-4a are all settled; D-31 is trigger-based (decide only when the first real world2agent callback party appears; see below) and is not currently an open runtime surface.
+**At a glance: 1 item currently pending — #137 P6 founder review (overall plan approval).** An explicit P6 YES still does not satisfy M6 Entry: M5 Exit remains a precondition gate, and P6 approval does not bypass M5. The entry conditions for M5 Entry are tracked in #136. D-1~D-9 and D-4a are all settled. D-31's contract-only slice is approved (2026-09-12, issue #432): an inert, default-off, exact-allowlist-tuple metadata adapter that activates nothing; only real bridge/sensor/auth/consumer activation remains trigger-gated under #82 (decide when the first real world2agent callback party appears; see below).
 
 ## Pending
 
@@ -17,9 +17,10 @@
 **Currently pending**: the founder has not yet explicitly approved the overall M6 plan or a revised draft. Only an explicit YES, or explicit approval of a revised draft, satisfies P6 Exit. **A P6 YES still does not satisfy M6 Entry** — M5 Exit remains a precondition gate, and P6 approval does not bypass M5; the two are parallel preconditions, and if either is unmet M6 does not open.
 **Location**: [`milestones/m6-b2b-reuse-walkthrough.md`](milestones/m6-b2b-reuse-walkthrough.md) (draft, awaiting founder review); issue #137; task graph in [`design/milestone-delivery-plan.md`](design/milestone-delivery-plan.md) M6-1/M6-2.
 
-### D-31 External-Event Write Trust Model
+### D-31 External-Event Write Trust Model (contract settled; live activation trigger-based)
 
-**Trigger-based**: decide only when the first real world2agent callback party appears. Local probes need no auth; remote callbacks require signature/channel binding; the remote surface stays closed until decided. Open-trigger tracking: issue #82; issue #119 is the closed design record.
+**Contract only, settled (2026-09-12, issue #432)**: the founder authorized a pure, deterministic, inert w2a/0.1 envelope adapter — default off, explicit caller opt-in, exact reviewed source/package/version/type allowlist tuple. Sender/source fields are untrusted claims and a tuple match is not authentication; no listener/token, no environment-based product switch, no ledger/fact/wish-pool/channel-health writes, no booking, no consumer registration. It activates no live path; the landed local channel-probe and wish-pool consumers are preserved.
+**Still trigger-based — live activation only**: real bridge/sensor selection, auth/token ownership and consumer integration wait for the first real world2agent callback party (signature/channel binding); the live remote surface stays closed until then. Open-trigger tracking: issue #82; issue #119 is the closed design record.
 **Location**: [`design/external-event-seam.md`](design/external-event-seam.md); open-trigger tracking issue #82; design record issue #119 (closed).
 
 ---

--- a/docs/decisions-needed.zh-CN.md
+++ b/docs/decisions-needed.zh-CN.md
@@ -8,7 +8,7 @@
 > 下游：按回执推进的实现/Exit 证据与 issue gate 更新；founder YES 只满足对应决策门，不自动改写里程碑 Entry。
 > 各项独立——你可以按优先级逐条回；按回执推进。
 
-**速览：当前 1 项待拍板——#137 P6 founder review（整体方案批准）。** P6 明确 YES 仍不满足 M6 Entry：M5 Exit 仍是前置门，P6 批准不旁路 M5。M5 Entry 的进入条件在 #136 跟踪。D-1~D-9、D-4a 均已结算；D-31 为触发式（等第一个真实 world2agent 回调方再拍，见下），当前非开放运行时面。
+**速览：当前 1 项待拍板——#137 P6 founder review（整体方案批准）。** P6 明确 YES 仍不满足 M6 Entry：M5 Exit 仍是前置门，P6 批准不旁路 M5。M5 Entry 的进入条件在 #136 跟踪。D-1~D-9、D-4a 均已结算；D-31 的纯契约切片已获批（2026-09-12，issue #432）：惰性、默认关闭、仅精确白名单四元组才映射的元数据适配器，不激活任何链路；仅真实 bridge/sensor/auth/消费者接入仍为触发式，由 #82 跟踪（等第一个真实 world2agent 回调方出现再拍，见下）。
 
 ## 未决
 
@@ -17,9 +17,10 @@
 **当前待拍板**：founder 尚未明确批准 M6 整体方案或修改稿。只有明确 YES 或对修改稿明确批准才满足 P6 Exit。**P6 YES 仍不满足 M6 Entry**——M5 Exit 仍是前置门，P6 批准不旁路 M5；两者并列前置，任一未满足则 M6 不开闸。
 **位置**：[`milestones/m6-b2b-reuse-walkthrough.md`](milestones/m6-b2b-reuse-walkthrough.md)（draft，待 founder 评审）；issue #137；任务图见 [`design/milestone-delivery-plan.md`](design/milestone-delivery-plan.md) M6-1/M6-2。
 
-### D-31 外部事件写入信任模型
+### D-31 外部事件写入信任模型（纯契约已结算；仅真实接入为触发式）
 
-**触发式**：等第一个真实 world2agent 回调方出现再拍。本地探针免鉴权，远程回调需签名/通道绑定；拍板前远程面不开。开放触发跟踪见 issue #82；issue #119 为已关闭的设计记录。
+**纯契约已结算（2026-09-12，issue #432）**：founder 已授权 w2a/0.1 envelope 的纯函数式、确定性、惰性适配器——默认关闭、调用方显式开启、仅精确匹配已评审的 source/package/version/type 白名单四元组。sender/source 字段是不可信声明，四元组匹配不是鉴权；无常驻监听/token、无基于环境变量的产品开关、无账本/事实/愿望池/通道健康面写入、无预订、无消费者注册。它不激活任何真实链路；已落地的本地通道探针与愿望池消费保留。
+**仍为触发式——仅真实接入**：真实 bridge/sensor 选型、auth/token 归属与消费者接入，等第一个真实 world2agent 回调方出现再拍（签名/通道绑定）；拍板前真实远程面不开。开放触发跟踪见 issue #82；issue #119 为已关闭的设计记录。
 **位置**：[`design/external-event-seam.md`](design/external-event-seam.md)；开放触发跟踪 issue #82；设计记录 issue #119（已关闭）。
 
 ---

--- a/docs/design/external-event-seam.md
+++ b/docs/design/external-event-seam.md
@@ -2,8 +2,12 @@
 
 # External-Event-Driven Seam Design (#82 world2agent compatibility direction, issue #119 / D-31)
 
-> Status: **design document (2026-09-04, issue #119)**. This round designs only and commits to no implementation — for the landing sequence see §6;
-> progress is trigger-based (the first real sensor starts the first segment). Principle: **consume existing seams; build no new runtime**.
+> Status: **design document (2026-09-04, issue #119; updated 2026-09-12)**. This document designs; it commits to no runtime implementation — for the landing sequence see §6,
+> which advances trigger-based (the first real sensor starts the first segment). Principle: **consume existing seams; build no new runtime**.
+> Already landed locally and preserved: the channel probe (§6.1) and the wish-pool consumer (§6.2). The w2a/0.1 envelope
+> **contract-only** slice is approved as an inert, default-off typing/validation contract (§5.1) that activates no live path;
+> real bridge/sensor/auth/consumer activation stays trigger-gated under issue #82. Nothing here claims any remote sensor path
+> is implemented or verified.
 > Related: issue #82 (world2agent protocol integration), ADR-18 (effect interpreter)/ADR-24 (turn budget),
 > D-8 (static flattening + health-state-driven dynamic advice), `capabilities/channel-health.ts` (health surface),
 > `src/wish-pool.ts` (wish-pool recall), `capabilities/async-workorders*`/`turn-handoff-collect.ts`
@@ -20,13 +24,15 @@ the gotry-side seam form: **external events become new producers for two existin
 2. **Wish-pool conditions** (`wish-pool.ts`): events as a new fact source for recall evaluation (still a pull
    model, no push).
 
-## 2. Current state: the health surface has exactly one producer, and it is in-band
+## 2. Current state: an in-band verdict producer, a landed local probe, and no out-of-band producer
 
-Today the only fact source of `channelState`/`routingAdvice` is the **tool-call verdict**
-(`noteChannelVerdict`: needs-setup→down, hit→clear, miss/error→no change, cooldown expiry). This means:
+`channelState`/`routingAdvice` today have two producers: the **tool-call verdict**
+(`noteChannelVerdict`: needs-setup→down, hit→clear, miss/error→no change, cooldown expiry) and the **landed local read-only probe**
+(`ts/scripts/channel-probe.ts`, §6.1), whose anomaly/recovery ticks use the same recording form. The wish pool consumes the channel
+condition at recall time (§6.2). What is still missing is the **out-of-band** entry point:
 
 - In-session facts like flyai quota exhaustion or Ctrip (携程) challenged propagate fine (#106-#108 already closed);
-- **Out-of-band** facts have no entry point — a 12306 redesign, a Ctrip risk-control policy upgrade, an API going offline: the system has no way to know,
+- Out-of-band facts — a 12306 redesign, a Ctrip risk-control policy upgrade, an API going offline — have no entry point: the system has no way to know,
   and can only wait for the next real search failure, with the user session bearing the discovery cost.
 
 ## 3. Seam design: events as new producers for the health surface and the wish pool
@@ -81,13 +87,32 @@ sensor events are just a new work-order source.
 incidents); world2agent remote callbacks need signature/channel binding — **decide when the first real callback party
 appears**, do not preset. Until decided, the remote surface stays closed (the seam exists only for local producers).
 
+### 5.1 Approved contract-only slice (2026-09-12, issue #432)
+
+The founder authorized a **contract-only** slice for the w2a/0.1 envelope, with the reference pinned at `machinepulse-ai/world2agent`
+commit `7e5fc4d4` (`schema/0.1/schema.ts`). As scoped, the slice is a pure, deterministic adapter that projects only inert untrusted
+event metadata; it invents no sensor-specific wire schema and installs no runtime dependency. Its boundary:
+
+- **Default off**: it is reachable only with an explicit caller-supplied enabled option — no environment-based product switch, no listener,
+  no token, and no consumer/runtime registration;
+- **Exact reviewed tuple**: mapping requires an exact match on the reviewed source/package/version/type tuple; anything else is a stable rejection;
+- **Claims are not authentication**: sender/source fields are untrusted data, and a tuple match is not an auth check;
+- **No writes or dispatch**: channel-health writes, ledger/fact/wish-pool mutation, planner/tool dispatch, booking and payments stay unreachable.
+
+Approving the contract **activates nothing live**: real bridge/sensor selection, auth/token ownership and consumer integration remain
+trigger-gated under issue #82, and no M4/M5/M6 admission changes. The landed local probe and wish-pool consumer (§6.1/§6.2) are preserved.
+Implementation and its verification are tracked in issue #432.
+
 ## 6. Landing sequence (trigger-based; each segment an independent PR)
 
 1. **Minimal sensor probe row** ✅ (landed 2026-09-07: `ts/scripts/channel-probe.ts`, run-all §52): read-only probe ticks (drivable by loopx/cron) run
    side-effect-free probes against key channels; on anomaly call `recordChannelEvent` (down), on recovery write `'ok'` (latest-wins override) — routing/doctor benefit immediately;
 2. **Wish-pool consumption** ✅ (landed 2026-09-07: a `conditions.channels` optional condition + at recall time,
-   a named channel being down refutes the feasibility condition, run-all §53; the "corroboration" render surface is left to a later slice):
-3. **world2agent callback**: wire the remote producer after the auth model is decided (D-31).
+   a named channel being down refutes the feasibility condition, run-all §53; the "corroboration" render surface is left to a later slice);
+3. **w2a/0.1 envelope contract-only adapter** (approved 2026-09-12, issue #432): the inert, default-off slice in §5.1 — contract only;
+   it wires no producer and no consumer;
+4. **world2agent callback (live)**: wire the remote producer after the auth model is decided (D-31); real sensor/bridge/consumer
+   activation remains open under #82.
 
 ## 7. Compatibility with existing verdicts
 

--- a/docs/design/external-event-seam.zh-CN.md
+++ b/docs/design/external-event-seam.zh-CN.md
@@ -2,8 +2,11 @@
 
 # 外部事件驱动接缝设计（#82 world2agent 兼容方向，issue #119 / D-31）
 
-> 状态：**设计文档（2026-09-04，issue #119）**。本期只设计不承诺实现——落地序列见 §6，
+> 状态：**设计文档（2026-09-04，issue #119；2026-09-12 更新）**。本文只设计，不承诺任何运行时实现——落地序列见 §6，
 > 触发式推进（第一个真实 sensor 出现时启动第一段）。原则：**消费既有接缝，不建新运行时**。
+> 本地已落地并保留：通道探针（§6.1）与愿望池消费（§6.2）。w2a/0.1 envelope 的**纯契约**切片已获批，
+> 定位为惰性、默认关闭的类型/校验契约（§5.1），不激活任何真实链路；真实 bridge/sensor/auth/消费者接入
+> 仍由 issue #82 触发式推进。本文不声称任何远程 sensor 路径已实现或已验证。
 > 关联：issue #82（world2agent 协议集成）、ADR-18（效应解译器）/ADR-24（turn 预算）、
 > D-8（静态平铺+健康态驱动动态建议）、`capabilities/channel-health.ts`（健康面）、
 > `src/wish-pool.ts`（愿望池召回）、`capabilities/async-workorders*`/`turn-handoff-collect.ts`
@@ -20,14 +23,15 @@ gotry 侧的接缝形态：**外部事件作为两个既有面的新生产者**�
 2. **愿望池 conditions**（`wish-pool.ts`）：事件作为召回评估的新事实源（仍是 pull
    模型，不做 push）。
 
-## 2. 现状：健康面的生产者只有一个，且是 in-band 的
+## 2. 现状：in-band verdict 生产者、已落地的本地探针，未接带外生产者
 
-今天 `channelState`/`routingAdvice` 的唯一事实来源是**工具调用 verdict**
-（`noteChannelVerdict`：needs-setup→down、hit→清除、miss/error→不动、cooldown 过期）。
-这意味着：
+`channelState`/`routingAdvice` 当前有两个生产者：**工具调用 verdict**
+（`noteChannelVerdict`：needs-setup→down、hit→清除、miss/error→不动、cooldown 过期）与**已落地的本地只读探针**
+（`ts/scripts/channel-probe.ts`，§6.1）——探针的异常/恢复 tick 走同一落账形态。愿望池在召回时消费通道条件（§6.2）。
+仍缺的是**带外**入口：
 
 - flyai 达限、携程 challenged 这类**会话内**事实传导是通的（#106-#108 已收口）；
-- **带外**事实没有入口——12306 改版、携程风控策略升级、某接口下线，系统无从知晓，
+- 12306 改版、携程风控策略升级、某接口下线这类**带外**事实没有入口，系统无从知晓，
   只能等下一次真实检索失败，由用户会话承担发现成本。
 
 ## 3. 接缝设计：事件 = 健康面与愿望池的新生产者
@@ -82,13 +86,31 @@ sensor 事件只是新的工单来源。
 incident 同级）；world2agent 远程回调需要签名/通道绑定——**等第一个真实回调方
 出现时拍板**，不预设。拍板前，远程面不开（接缝只存在于本地生产者）。
 
+### 5.1 已获批的纯契约切片（2026-09-12，issue #432）
+
+founder 已授权 w2a/0.1 envelope 的**纯契约**切片，参考基准钉在 `machinepulse-ai/world2agent`
+commit `7e5fc4d4`（`schema/0.1/schema.ts`）。按获批范围，该切片是一个纯函数式、确定性的适配器，
+只投影惰性的不可信事件元数据；不发明 sensor 专用 wire schema，不安装任何运行时依赖。其边界：
+
+- **默认关闭**：仅在调用方显式传入 enabled 选项时可达——无基于环境变量的产品开关、无常驻监听、无 token、无消费者/运行时注册；
+- **精确白名单四元组**：仅当已评审的 source/package/version/type 四元组精确匹配时才做映射，否则给出稳定拒绝结果；
+- **声明即不可信**：envelope 上的 sender/source 字段是不可信数据，四元组匹配**不是**鉴权；
+- **不写不派发**：通道健康面写入、账本/事实/愿望池变更、planner/工具派发、预订与支付均不可达。
+
+批准契约**不激活任何真实链路**：真实 bridge/sensor 选型、auth/token 归属与消费者接入仍由 issue #82
+触发式推进，M4/M5/M6 入场判定不变。已落地的本地探针与愿望池消费（§6.1/§6.2）保留不受影响。
+实现与验证进展由 issue #432 跟踪。
+
 ## 6. 落地序列（触发式，每段独立 PR）
 
 1. **sensor 探针最小行** ✅（2026-09-07 落地：`ts/scripts/channel-probe.ts`，run-all §52）：只读探针 tick（可由 loopx/cron 驱动）对关键通道做
    无副作用探测，异常时调 `recordChannelEvent`（down），恢复写 `'ok'`（latest-wins 超越）——routing/doctor 即时受益；
 2. **愿望池消费** ✅（2026-09-07 落地：`conditions.channels` 可选条件 + 召回时
-   命名通道处于 down 即否证成行条件，run-all §53；「佐证」渲染面留后续切片）：
-3. **world2agent 回调**：auth 模型拍板后接远程生产者（D-31）。
+   命名通道处于 down 即否证成行条件，run-all §53；「佐证」渲染面留后续切片）；
+3. **w2a/0.1 envelope 纯契约适配器**（2026-09-12 获批，issue #432）：即 §5.1 的惰性、默认关闭切片——只落契约，
+   不接生产者、不接消费者；
+4. **world2agent 回调（真实链路）**：auth 模型拍板后接远程生产者（D-31）；真实 sensor/bridge/消费者接入
+   仍开放于 #82。
 
 ## 7. 与既有判定的兼容性
 


### PR DESCRIPTION
## What

Docs-only companion for #432, recording the founder-authorized contract-only slice in the bilingual seam/decision documents. No code, no runtime surface.

- `docs/design/external-event-seam{,.zh-CN}.md`: status header and §2 acknowledge the already-landed local channel-probe and wish-pool consumer (preserved); new §5.1 states the contract-only boundary — inert, default off, explicit caller opt-in, exact source/package/version/type allowlist tuple, claims are not authentication, no listener/token, no environment-based product switch, no ledger/fact/wish-pool/health writes, no booking, no consumer registration; §6 separates the contract-only slice from live callback wiring.
- `docs/decisions-needed{,.zh-CN}.md`: D-31 synopsis/section no longer read as wholly pending — contract approved; only real bridge/sensor/auth/consumer activation remains trigger-gated under #82.

No sensor path is claimed implemented or verified; no M4/M5/M6 admission change.

## Verification

- `node scripts/check-docs-i18n.mjs` exit 0; `git diff --check` exit 0 on the committed SHA.

## TODO

1. Root folds this patch into the same final #432 code/state commit; the combined gates (typecheck, focused tests, isolated smoke, docs check, full local regression) run there and remain pending.
2. This is a draft companion: do not merge independently.

Tracks #432 and #82.
