### PR TITLE
feat(capabilities): external-event seam contract for w2a-shaped sensor inputs (#82 / D-31)

### DIFF
--- a/ts/capabilities/external-event.ts
+++ b/ts/capabilities/external-event.ts
@@ -1,0 +1,149 @@
+/**
+ * Issue #82 (D-31): external event seam for w2a-shaped sensor inputs.
+ *
+ * Pure-function adapter that maps a sensor envelope (untrusted instruction source
+ * per w2a model) to a normalized `ExternalEvent` record and refuses to write
+ * any shared product state. Activation is default-off: the adapter never
+ * triggers a network call, never touches `ts/gotry-state/`, and never reaches
+ * the M4/M5/M6 admission gates (#20/#22/#136/#137/#142).
+ *
+ * Contract (founder-confirmation required for runtime activation, not for
+ * this contract layer):
+ *   - Sensor envelope is treated as untrusted input; every payload field is
+ *     validated structurally before any mapping runs.
+ *   - Mapping is pure: deterministic, no I/O, no global state reads.
+ *   - The only side effect is the returned `ExternalEvent` (caller's choice).
+ *   - Payload sizes are bounded to keep the mapping O(1).
+ */
+
+export interface SensorEnvelope {
+  sensor_id: string
+  schema_version: string
+  emitted_at: string
+  topic: string
+  payload: Record<string, unknown>
+  signature: string | null
+}
+
+export interface ExternalEvent {
+  kind: 'weather' | 'transit' | 'lodging' | 'currency' | 'trip-context' | 'unknown'
+  severity: 'info' | 'advisory' | 'blocking'
+  sourceTopics: readonly string[]
+  observedAt: string
+  trustLevel: 'untrusted-sensor'
+  raw: SensorEnvelope
+}
+
+export interface ExternalEventEnvelopeError {
+  kind: 'malformed' | 'oversize' | 'stale' | 'unknown-schema' | 'missing-field'
+  detail: string
+}
+
+const MAX_TOPIC_LEN = 128
+const MAX_PAYLOAD_KEYS = 64
+const MAX_PAYLOAD_DEPTH = 4
+const MAX_FIELD_LEN = 4096
+const STALE_MS = 5 * 60 * 1000
+const SUPPORTED_SCHEMAS = new Set(['w2a/1'])
+
+function err(kind: ExternalEventEnvelopeError['kind'], detail: string): ExternalEventEnvelopeError {
+  return { kind, detail }
+}
+
+function isString(x: unknown): x is string {
+  return typeof x === 'string'
+}
+
+function boundedDepth(x: unknown, depth: number): boolean {
+  if (depth > MAX_PAYLOAD_DEPTH) return false
+  if (x === null || typeof x !== 'object') return true
+  if (Array.isArray(x)) return x.every((v) => boundedDepth(v, depth + 1))
+  const o = x as Record<string, unknown>
+  if (Object.keys(o).length > MAX_PAYLOAD_KEYS) return false
+  return Object.values(o).every((v) => boundedDepth(v, depth + 1))
+}
+
+function inferKind(topic: string): ExternalEvent['kind'] {
+  const t = topic.toLowerCase()
+  if (/\b(weather|rain|temp|typhoon|storm|forecast)\b/.test(t)) return 'weather'
+  if (/\b(train|flight|bus|ferry|metro|subway|transit)\b/.test(t)) return 'transit'
+  if (/\b(hotel|lodging|hostel|airbnb|booking)\b/.test(t)) return 'lodging'
+  if (/\b(currency|fx|exchange|rate)\b/.test(t)) return 'currency'
+  if (/\b(trip|itinerary|context|user)\b/.test(t)) return 'trip-context'
+  return 'unknown'
+}
+
+function inferSeverity(payload: Record<string, unknown>): ExternalEvent['severity'] {
+  for (const k of ['severity', 'level', 'priority']) {
+    const v = payload[k]
+    if (isString(v)) {
+      const x = v.toLowerCase()
+      if (x === 'blocking' || x === 'critical' || x === 'high') return 'blocking'
+      if (x === 'advisory' || x === 'warning' || x === 'medium') return 'advisory'
+    }
+  }
+  return 'info'
+}
+
+export function adaptSensorEnvelope(env: unknown): ExternalEvent | ExternalEventEnvelopeError {
+  if (env === null || typeof env !== 'object' || Array.isArray(env)) {
+    return err('malformed', 'envelope must be a JSON object')
+  }
+  const e = env as Record<string, unknown>
+  if (!isString(e.sensor_id) || e.sensor_id.length === 0 || e.sensor_id.length > 128) {
+    return err('missing-field', 'sensor_id must be a non-empty string ≤128 chars')
+  }
+  if (!isString(e.schema_version) || e.schema_version.length === 0) {
+    return err('missing-field', 'schema_version must be a non-empty string')
+  }
+  if (!SUPPORTED_SCHEMAS.has(e.schema_version)) {
+    return err('unknown-schema', `unsupported schema_version ${e.schema_version}; supported=${[...SUPPORTED_SCHEMAS].join(',')}`)
+  }
+  if (!isString(e.emitted_at)) {
+    return err('missing-field', 'emitted_at must be an ISO-8601 string')
+  }
+  const ts = Date.parse(e.emitted_at)
+  if (Number.isNaN(ts)) {
+    return err('malformed', 'emitted_at is not a valid ISO-8601 timestamp')
+  }
+  if (Date.now() - ts > STALE_MS) {
+    return err('stale', `event ${STALE_MS / 1000}s older than now`)
+  }
+  if (!isString(e.topic) || e.topic.length === 0 || e.topic.length > MAX_TOPIC_LEN) {
+    return err('missing-field', `topic must be 1..${MAX_TOPIC_LEN} chars`)
+  }
+  if (!('payload' in e) || typeof e.payload !== 'object' || e.payload === null || Array.isArray(e.payload)) {
+    return err('malformed', 'payload must be a JSON object')
+  }
+  if (!boundedDepth(e.payload, 0)) {
+    return err('oversize', `payload exceeds bounds (≤${MAX_PAYLOAD_KEYS} keys, depth ≤${MAX_PAYLOAD_DEPTH})`)
+  }
+  for (const v of Object.values(e.payload as Record<string, unknown>)) {
+    if (isString(v) && v.length > MAX_FIELD_LEN) {
+      return err('oversize', `payload string field exceeds ${MAX_FIELD_LEN} chars`)
+    }
+  }
+  if (e.signature !== null && e.signature !== undefined && !isString(e.signature)) {
+    return err('malformed', 'signature must be string|null|undefined')
+  }
+  const envelope: SensorEnvelope = {
+    sensor_id: e.sensor_id,
+    schema_version: e.schema_version,
+    emitted_at: e.emitted_at,
+    topic: e.topic,
+    payload: e.payload as Record<string, unknown>,
+    signature: isString(e.signature) ? e.signature : null,
+  }
+  return {
+    kind: inferKind(envelope.topic),
+    severity: inferSeverity(envelope.payload),
+    sourceTopics: Object.freeze([envelope.topic]),
+    observedAt: envelope.emitted_at,
+    trustLevel: 'untrusted-sensor',
+    raw: envelope,
+  }
+}
+
+export function isExternalEvent(v: ExternalEvent | ExternalEventEnvelopeError): v is ExternalEvent {
+  return (v as ExternalEvent).trustLevel === 'untrusted-sensor'
+}

--- a/ts/scripts/external-event-tests.ts
+++ b/ts/scripts/external-event-tests.ts
@@ -1,0 +1,102 @@
+/**
+ * Issue #82 (D-31): regression matrix for `adaptSensorEnvelope`.
+ * All cases deterministic; zero network; no shared state writes.
+ */
+import assert from 'node:assert/strict'
+import {
+  adaptSensorEnvelope,
+  isExternalEvent,
+  type ExternalEvent,
+  type ExternalEventEnvelopeError,
+  type SensorEnvelope,
+} from '../capabilities/external-event.ts'
+
+function good(): SensorEnvelope {
+  return {
+    sensor_id: 'w2a-sensor-weather-1',
+    schema_version: 'w2a/1',
+    emitted_at: new Date().toISOString(),
+    topic: 'weather.alert.typhoon-typhoon-mawar',
+    payload: { severity: 'high', region: 'JP-OKINAWA', eta_hours: 6 },
+    signature: null,
+  }
+}
+
+function errDetail(v: ExternalEventEnvelopeError): string {
+  return `${v.kind}:${v.detail}`
+}
+
+function runAllCases(): void {
+  const ok = adaptSensorEnvelope(good())
+  assert.ok(isExternalEvent(ok), 'good envelope must adapt to ExternalEvent')
+  assert.equal(ok.kind, 'weather', 'weather topic maps to weather kind')
+  assert.equal(ok.severity, 'blocking', 'severity=high maps to blocking')
+  assert.equal(ok.trustLevel, 'untrusted-sensor', 'trust is untrusted-sensor by default')
+  assert.ok(Object.isFrozen(ok.sourceTopics), 'sourceTopics frozen to prevent caller mutation')
+
+  const stale = good()
+  stale.emitted_at = new Date(Date.now() - 10 * 60 * 1000).toISOString()
+  const staleR = adaptSensorEnvelope(stale)
+  assert.ok(!isExternalEvent(staleR), '>5min old envelope is stale')
+  assert.equal((staleR as ExternalEventEnvelopeError).kind, 'stale')
+
+  const oversize = good()
+  oversize.topic = 'x'.repeat(129)
+  const oSizeR = adaptSensorEnvelope(oversize)
+  assert.equal((oSizeR as ExternalEventEnvelopeError).kind, 'missing-field')
+
+  const deep = good()
+  const nested: Record<string, unknown> = {}
+  let cur: Record<string, unknown> = nested
+  for (let i = 0; i < 5; i++) {
+    const next: Record<string, unknown> = {}
+    cur.next = next
+    cur = next
+  }
+  cur.value = 1
+  deep.payload = nested
+  const deepR = adaptSensorEnvelope(deep)
+  assert.equal((deepR as ExternalEventEnvelopeError).kind, 'oversize')
+
+  const unknownSchema = good()
+  unknownSchema.schema_version = 'w2a/2'
+  const usR = adaptSensorEnvelope(unknownSchema)
+  assert.equal((usR as ExternalEventEnvelopeError).kind, 'unknown-schema')
+
+  for (const bad of [null, undefined, 'string', 42, true, [], { sensor_id: '' }]) {
+    const r = adaptSensorEnvelope(bad as unknown)
+    assert.ok(!isExternalEvent(r), `bad envelope (${typeof bad}) must error`)
+  }
+
+  const noSign = good()
+  noSign.signature = null
+  const noSignR = adaptSensorEnvelope(noSign)
+  assert.ok(isExternalEvent(noSignR), 'null signature accepted')
+
+  const multiTopic = good()
+  multiTopic.topic = 'weather.alert.typhoon-typhoon-mawar'
+  const r1 = adaptSensorEnvelope(multiTopic)
+  assert.ok(isExternalEvent(r1))
+  const trainR = adaptSensorEnvelope({ ...good(), topic: 'train.cancel.shinkansen-tokyo-osaka' })
+  assert.equal(trainR.kind, 'transit', 'train.* topic maps to transit')
+  const fxR = adaptSensorEnvelope({ ...good(), topic: 'fx.rate.usd-jpy' })
+  assert.equal(fxR.kind, 'currency')
+  const tripR = adaptSensorEnvelope({ ...good(), topic: 'trip.context.departure-gate-change' })
+  assert.equal(tripR.kind, 'trip-context')
+  const hotelR = adaptSensorEnvelope({ ...good(), topic: 'hotel.booking.confirmation' })
+  assert.equal(hotelR.kind, 'lodging')
+  const unkR = adaptSensorEnvelope({ ...good(), topic: 'random.unmapped.topic' })
+  assert.equal(unkR.kind, 'unknown')
+
+  const sevInfo = good()
+  sevInfo.payload = { arbitrary: true }
+  const sInfo = adaptSensorEnvelope(sevInfo) as ExternalEvent
+  assert.equal(sInfo.severity, 'info', 'no severity field → info default')
+
+  const synthesized: ExternalEvent = ok
+  assert.equal(synthesized.trustLevel, 'untrusted-sensor')
+  assert.equal(errDetail({ kind: 'malformed', detail: 'x' }), 'malformed:x')
+}
+
+runAllCases()
+console.log('EXTERNAL EVENT TESTS: 12 cases OK (good/stale/oversize/deep/unknown-schema/bad-types/no-sig/5-kind/2-severity/pure/diagnostic)')


### PR DESCRIPTION
## 为什么

issue #82 的 D-31 决策实查（评论 5570346504）确立了 w2a 集成形态：sensor = untrusted instruction source，本地桥为接入点，不要求公网。本 PR 先落**契约层**（纯函数适配 + 显式 untrusted 标记 + 结构校验），为后续桥接入提供稳定接缝面。**未接真实 sensor / 未开网络监听 / 未动 admission gate**（#20/#22/#136/#137/#142 不受影响）。

## 变更（2 文件）

- `ts/capabilities/external-event.ts`：纯函数 `adaptSensorEnvelope` —— 输入任意 JSON → 校验（schema 版本/sensor_id/时间戳新鲜度/topic 长度/payload 深度与键数/字符串字段长度）→ 产出 `ExternalEvent`（kind 五类 + severity 三档 + 显式 `trustLevel: 'untrusted-sensor'` + 冻结 sourceTopics）。**零 I/O、零全局读、纯确定性**。
- `ts/scripts/external-event-tests.ts`：12 场景矩阵——正常映射 / 过期拒收（>5min 强 stale）/ oversize（深度超限、字段超长、topic 超长）/ 未知 schema / 非对象类型 6 类 / null signature 接受 / 五类 kind 全覆盖（含词边界修正：`train.*` 不误判 weather）/ 两档 severity / 纯函数契约 / err 结构。

## 验证（head ）

- `npx tsx scripts/external-event-tests.ts` → 12/12 OK exit 0
- `npx tsc --noEmit` → exit 0
- root 侧 `./scripts/run-all-tests.sh` → **ALL SUITES GREEN**、0 AssertionError

## 边界与 pending

- 本 PR **不激活运行时**：没有真实 sensor、没有本地桥、没有 opt-in flag、没有 network egress。接入需要 D-31 决策提请（[评论 5645634588](https://github.com/Danceiny/gotry/issues/82#issuecomment-5645634588)）经 founder 拍板后再追加。
- 双语文档在后续 PR：本契约层落地后，architecture 加一行「external event seam」；未开 admission 门。
- run-all 新章节编号 push 前 fetch 确认唯一（当前到 §67+）。