### PR TITLE
docs(#432): correct seam routing claims, mark propagation TODO #436

### DIFF
--- a/docs/design/external-event-seam.md
+++ b/docs/design/external-event-seam.md
@@ -2,8 +2,9 @@
 
 # External-Event-Driven Seam Design (#82 world2agent compatibility direction, issue #119 / D-31)
 
-> Status: **design document (2026-09-04, issue #119; updated 2026-09-12)**. This document designs; it commits to no runtime implementation — for the landing sequence see §6,
-> which advances trigger-based (the first real sensor starts the first segment). Principle: **consume existing seams; build no new runtime**.
+> Status: **design document (2026-09-04, issue #119; updated 2026-09-12)**. This document designs; it commits to no runtime implementation — for the landing
+> sequence see §6, where segments 1-2 have already landed (local probe + wish-pool consumption) and only the remaining w2a sensor producer is trigger-gated.
+> Principle: **consume existing seams; build no new runtime**.
 > Already landed locally and preserved: the channel probe (§6.1) and the wish-pool consumer (§6.2). The w2a/0.1 envelope
 > **contract-only** slice is approved as an inert, default-off typing/validation contract (§5.1) that activates no live path;
 > real bridge/sensor/auth/consumer activation stays trigger-gated under issue #82. Nothing here claims any remote sensor path
@@ -24,16 +25,25 @@ the gotry-side seam form: **external events become new producers for two existin
 2. **Wish-pool conditions** (`wish-pool.ts`): events as a new fact source for recall evaluation (still a pull
    model, no push).
 
-## 2. Current state: an in-band verdict producer, a landed local probe, and no out-of-band producer
+## 2. Current state: in-process routing state vs. persisted out-of-band events, and the unconnected w2a producer
 
-`channelState`/`routingAdvice` today have two producers: the **tool-call verdict**
-(`noteChannelVerdict`: needs-setup→down, hit→clear, miss/error→no change, cooldown expiry) and the **landed local read-only probe**
-(`ts/scripts/channel-probe.ts`, §6.1), whose anomaly/recovery ticks use the same recording form. The wish pool consumes the channel
-condition at recall time (§6.2). What is still missing is the **out-of-band** entry point:
+Two surfaces are easy to conflate, so state them separately:
 
-- In-session facts like flyai quota exhaustion or Ctrip (携程) challenged propagate fine (#106-#108 already closed);
-- Out-of-band facts — a 12306 redesign, a Ctrip risk-control policy upgrade, an API going offline — have no entry point: the system has no way to know,
-  and can only wait for the next real search failure, with the user session bearing the discovery cost.
+- **Session verdict → in-process routing state**: `noteChannelVerdict` writes the in-process `channelState` map
+  (needs-setup→down, hit→clear, miss/error→no change, cooldown expiry), and `routingAdvice` reads **only that map**;
+- **Local probe → persisted health events**: the landed read-only probe (`ts/scripts/channel-probe.ts`, §6.1) is already an
+  **out-of-band local producer**. On anomaly it calls `recordChannelEvent` (down), on recovery it writes `'ok'` (latest-wins override),
+  landing persisted health. The readers of persisted health today are wish-pool recall (`ts/src/index.ts:780`) and the doctor's
+  existing persisted-health reader — **not** `routingAdvice`.
+
+What is still open:
+
+- In-session facts like flyai quota exhaustion or Ctrip (携程) challenged propagate fine through the verdict path (#106-#108 already closed);
+- Out-of-band facts — a 12306 redesign, a Ctrip risk-control policy upgrade, an API going offline — are only recorded where the local
+  probe covers them; the **remote w2a sensor producer is not connected** (issue #82);
+- **Persisted-health routing propagation is not implemented**: a persisted `down` event does not change `routingAdvice` today. Root's
+  Node 24 temp-state counterexample on `main` `8fed347` (2026-09-12T12:29:45Z, exit 0) shows a persisted `down` still included in
+  routing advice, while `markChannelDown` removes it. Tracked as **#436**; this document claims nothing beyond that.
 
 ## 3. Seam design: events as new producers for the health surface and the wish pool
 
@@ -46,8 +56,10 @@ recordChannelEvent(stateRoot, { channel: 'session:ctrip-flight', state: 'down',
                                reason: 'site-redesign', at: <iso> })
 ```
 
-- `routingAdvice`'s down-exclusion, the doctor's quota visibility rows, and the persona routing-card caliber — **all take effect
-  with zero changes** (they only read the event surface). Events are not a new mechanism; they are a second producer of an existing mechanism.
+- Events are not a new mechanism; they are a second producer of an existing recording form. Their consumers are not uniform today:
+  wish-pool recall (`ts/src/index.ts:780`) and the doctor's existing persisted-health reader already read persisted health, while
+  **`routingAdvice` reads only the in-process `channelState` map** — so persisted events do not reach routing or persona routing-card
+  calibers yet. That routing propagation is a desired TODO, tracked as **#436**.
 - Recovery likewise goes through events (`state: 'ok'`) or natural expiry (same semantics as cooldown expiry).
 
 ### 3.2 Three producer classes (trust tiers; decision point in §5)
@@ -89,8 +101,9 @@ appears**, do not preset. Until decided, the remote surface stays closed (the se
 
 ### 5.1 Approved contract-only slice (2026-09-12, issue #432)
 
-The founder authorized a **contract-only** slice for the w2a/0.1 envelope, with the reference pinned at `machinepulse-ai/world2agent`
-commit `7e5fc4d4` (`schema/0.1/schema.ts`). As scoped, the slice is a pure, deterministic adapter that projects only inert untrusted
+The founder authorized a **contract-only** slice for the w2a/0.1 envelope, with the reference pinned at
+[`schema/0.1/schema.ts`](https://github.com/machinepulse-ai/world2agent/blob/7e5fc4d441699993b8f1ef7d3b9776065b7a93e0/schema/0.1/schema.ts)
+(`machinepulse-ai/world2agent` commit `7e5fc4d441699993b8f1ef7d3b9776065b7a93e0`). As scoped, the slice is a pure, deterministic adapter that projects only inert untrusted
 event metadata; it invents no sensor-specific wire schema and installs no runtime dependency. Its boundary:
 
 - **Default off**: it is reachable only with an explicit caller-supplied enabled option — no environment-based product switch, no listener,
@@ -106,7 +119,8 @@ Implementation and its verification are tracked in issue #432.
 ## 6. Landing sequence (trigger-based; each segment an independent PR)
 
 1. **Minimal sensor probe row** ✅ (landed 2026-09-07: `ts/scripts/channel-probe.ts`, run-all §52): read-only probe ticks (drivable by loopx/cron) run
-   side-effect-free probes against key channels; on anomaly call `recordChannelEvent` (down), on recovery write `'ok'` (latest-wins override) — routing/doctor benefit immediately;
+   side-effect-free probes against key channels; on anomaly call `recordChannelEvent` (down), on recovery write `'ok'` (latest-wins override),
+   landing persisted health. Persisted-health readers (wish-pool recall, doctor) benefit immediately; **routing propagation is not implemented — TODO #436**;
 2. **Wish-pool consumption** ✅ (landed 2026-09-07: a `conditions.channels` optional condition + at recall time,
    a named channel being down refutes the feasibility condition, run-all §53; the "corroboration" render surface is left to a later slice);
 3. **w2a/0.1 envelope contract-only adapter** (approved 2026-09-12, issue #432): the inert, default-off slice in §5.1 — contract only;

--- a/docs/design/external-event-seam.zh-CN.md
+++ b/docs/design/external-event-seam.zh-CN.md
@@ -3,7 +3,7 @@
 # 外部事件驱动接缝设计（#82 world2agent 兼容方向，issue #119 / D-31）
 
 > 状态：**设计文档（2026-09-04，issue #119；2026-09-12 更新）**。本文只设计，不承诺任何运行时实现——落地序列见 §6，
-> 触发式推进（第一个真实 sensor 出现时启动第一段）。原则：**消费既有接缝，不建新运行时**。
+> 其中第 1、2 段已落地（本地探针 + 愿望池消费），仅剩 w2a sensor 生产者为触发式。原则：**消费既有接缝，不建新运行时**。
 > 本地已落地并保留：通道探针（§6.1）与愿望池消费（§6.2）。w2a/0.1 envelope 的**纯契约**切片已获批，
 > 定位为惰性、默认关闭的类型/校验契约（§5.1），不激活任何真实链路；真实 bridge/sensor/auth/消费者接入
 > 仍由 issue #82 触发式推进。本文不声称任何远程 sensor 路径已实现或已验证。
@@ -23,16 +23,23 @@ gotry 侧的接缝形态：**外部事件作为两个既有面的新生产者**�
 2. **愿望池 conditions**（`wish-pool.ts`）：事件作为召回评估的新事实源（仍是 pull
    模型，不做 push）。
 
-## 2. 现状：in-band verdict 生产者、已落地的本地探针，未接带外生产者
+## 2. 现状：in-process 路由态与已落地的持久化带外事件，w2a 生产者尚未接入
 
-`channelState`/`routingAdvice` 当前有两个生产者：**工具调用 verdict**
-（`noteChannelVerdict`：needs-setup→down、hit→清除、miss/error→不动、cooldown 过期）与**已落地的本地只读探针**
-（`ts/scripts/channel-probe.ts`，§6.1）——探针的异常/恢复 tick 走同一落账形态。愿望池在召回时消费通道条件（§6.2）。
-仍缺的是**带外**入口：
+两个面容易混为一谈，分开说：
 
-- flyai 达限、携程 challenged 这类**会话内**事实传导是通的（#106-#108 已收口）；
-- 12306 改版、携程风控策略升级、某接口下线这类**带外**事实没有入口，系统无从知晓，
-  只能等下一次真实检索失败，由用户会话承担发现成本。
+- **会话 verdict → in-process 路由态**：`noteChannelVerdict` 写 in-process `channelState` map
+  （needs-setup→down、hit→清除、miss/error→不动、cooldown 过期），而 `routingAdvice` **只读这张 map**；
+- **本地探针 → 持久化健康事件**：已落地的只读探针（`ts/scripts/channel-probe.ts`，§6.1）本身就是**带外本地生产者**：
+  异常时调 `recordChannelEvent`（down），恢复写 `'ok'`（latest-wins 超越），落持久化健康面。今天读持久化健康面的是
+  愿望池召回（`ts/src/index.ts:780`）与 doctor 既有持久化健康读取路径——**不含** `routingAdvice`。
+
+仍开放的部分：
+
+- flyai 达限、携程 challenged 这类**会话内**事实经 verdict 路径传导正常（#106-#108 已收口）；
+- 12306 改版、携程风控策略升级、某接口下线，只在本地探针覆盖到的范围内被落账；**远程 w2a sensor 生产者尚未接入**（issue #82）；
+- **持久化健康的 routing 传导未实现**：持久化的 `down` 事件当前不改变 `routingAdvice`。root 在 `main` `8fed347` 上的
+  Node 24 临时状态反例（2026-09-12T12:29:45Z，exit 0）显示：持久化 `down` 仍被 routing 建议采纳，而 `markChannelDown` 会摘除。
+  由 **#436** 跟踪，本文不声称更多。
 
 ## 3. 接缝设计：事件 = 健康面与愿望池的新生产者
 
@@ -45,8 +52,9 @@ recordChannelEvent(stateRoot, { channel: 'session:ctrip-flight', state: 'down',
                                reason: 'site-redesign', at: <iso> })
 ```
 
-- `routingAdvice` 的 down-排除、doctor 配额可见行、persona 路由卡口径——**全部零改动
-  生效**（它们只读事件面）。事件不是新机制，是既有机制的第二个生产者。
+- 事件不是新机制，是既有落账形态的第二个生产者；但今天各消费方并不齐整：愿望池召回（`ts/src/index.ts:780`）与
+  doctor 既有持久化健康读取路径已读持久化健康面，而 **`routingAdvice` 只读 in-process `channelState` map**——
+  故持久化事件当前到不了 routing 与 persona 路由卡口径。该 routing 传导是期望项，标记为 **TODO #436**。
 - 恢复同样走事件（`state: 'ok'`）或自然过期（与 cooldown 过期同语义）。
 
 ### 3.2 生产者三类（信任分级，决策点见 §5）
@@ -88,8 +96,9 @@ incident 同级）；world2agent 远程回调需要签名/通道绑定——**�
 
 ### 5.1 已获批的纯契约切片（2026-09-12，issue #432）
 
-founder 已授权 w2a/0.1 envelope 的**纯契约**切片，参考基准钉在 `machinepulse-ai/world2agent`
-commit `7e5fc4d4`（`schema/0.1/schema.ts`）。按获批范围，该切片是一个纯函数式、确定性的适配器，
+founder 已授权 w2a/0.1 envelope 的**纯契约**切片，参考基准钉在
+[`schema/0.1/schema.ts`](https://github.com/machinepulse-ai/world2agent/blob/7e5fc4d441699993b8f1ef7d3b9776065b7a93e0/schema/0.1/schema.ts)
+（`machinepulse-ai/world2agent` commit `7e5fc4d441699993b8f1ef7d3b9776065b7a93e0`）。按获批范围，该切片是一个纯函数式、确定性的适配器，
 只投影惰性的不可信事件元数据；不发明 sensor 专用 wire schema，不安装任何运行时依赖。其边界：
 
 - **默认关闭**：仅在调用方显式传入 enabled 选项时可达——无基于环境变量的产品开关、无常驻监听、无 token、无消费者/运行时注册；
@@ -104,7 +113,8 @@ commit `7e5fc4d4`（`schema/0.1/schema.ts`）。按获批范围，该切片是�
 ## 6. 落地序列（触发式，每段独立 PR）
 
 1. **sensor 探针最小行** ✅（2026-09-07 落地：`ts/scripts/channel-probe.ts`，run-all §52）：只读探针 tick（可由 loopx/cron 驱动）对关键通道做
-   无副作用探测，异常时调 `recordChannelEvent`（down），恢复写 `'ok'`（latest-wins 超越）——routing/doctor 即时受益；
+   无副作用探测，异常时调 `recordChannelEvent`（down），恢复写 `'ok'`（latest-wins 超越），落持久化健康面。
+   持久化健康读取方（愿望池召回、doctor）即时受益；**routing 传导未实现——TODO #436**；
 2. **愿望池消费** ✅（2026-09-07 落地：`conditions.channels` 可选条件 + 召回时
    命名通道处于 down 即否证成行条件，run-all §53；「佐证」渲染面留后续切片）；
 3. **w2a/0.1 envelope 纯契约适配器**（2026-09-12 获批，issue #432）：即 §5.1 的惰性、默认关闭切片——只落契约，


### PR DESCRIPTION
## What

Correction commit on top of the merged docs companion #434 (`701655c`), same four-file docs ownership, docs only.

- `docs/design/external-event-seam{,.zh-CN}.md`: status no longer says the first real sensor starts the first segment (segments 1-2 already landed); §2 separates the two surfaces — session verdict writes the in-process `channelState` map that `routingAdvice` reads, while the local probe is already an out-of-band producer writing **persisted** health (read by wish-pool recall `ts/src/index.ts:780` and the doctor's persisted-health reader); the unconnected remote w2a sensor producer is stated as the remaining gap; §3.1/§6.1 no longer claim immediate routing/doctor benefit — persisted-health routing propagation is marked **TODO #436** (root Node 24 temp-state counterexample on `main` `8fed347`: persisted `down` still included in routing advice, `markChannelDown` removes it); §5.1 now carries the full pinned upstream schema link.

No code changes; other approved inert contract boundaries unchanged; no new runtime authorization.

## Verification

- `node scripts/check-docs-i18n.mjs` exit 0 and `git diff --check` exit 0 on this SHA.

## TODO

1. Root folds this correction into the #432 code/state commit; combined gates (typecheck, focused tests, isolated smoke, docs check, full local regression) remain pending there.
2. Draft: do not merge independently.

Tracks #432, #436 and #82. Delivers the docs correction that could not be appended to the already-merged #434.
