### PR TITLE
Fix §67 shell heading command substitution

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -568,7 +568,7 @@ echo "=== 66. HotelByte 假 CLI spawn 级完整链路 E2E(issue #232 §5:本地 
 (cd ts && GOTRY_SESSION_LIVE=0 GOTRY_HBCLI_LIVE=0 GOTRY_HOTELBYTE_SKILLS_LIVE=0 npx tsx scripts/hotelbyte-spawn-e2e-tests.ts) || FAIL=1
 
 echo
-echo "=== 67. issue #436 持久健康面→注册工具 routing 建议 E2E(跨进程 fixture 探针子进程走真实 evaluateProbeResults+recordChannelEvent 写 channel-health.jsonl→真实注册工具 gotry_flyai_search/gotry_session_search 结果 `routing` 字段断言:持久 down 排除(本进程该通道会话态为空)/非会话通道同样生效/会话 down 优先于持久 'ok' 恢复/会话 hit 清除后有效持久 ok 恢复/独立根不串根/过期·未来·缺·坏时间戳均不压制且坏行不得在 latest-wins 前顶掉更早有效 down/同根追加可重复;夹具按产品真实操作标签登记并记录实际请求标签防错位;隔离临时 stateRoot+有界子进程,全离线无网络无真实供应商) ==="
+echo "=== 67. issue #436 持久健康面→注册工具 routing 建议 E2E(跨进程 fixture 探针子进程走真实 evaluateProbeResults+recordChannelEvent 写 channel-health.jsonl→真实注册工具 gotry_flyai_search/gotry_session_search 结果 \`routing\` 字段断言:持久 down 排除(本进程该通道会话态为空)/非会话通道同样生效/会话 down 优先于持久 'ok' 恢复/会话 hit 清除后有效持久 ok 恢复/独立根不串根/过期·未来·缺·坏时间戳均不压制且坏行不得在 latest-wins 前顶掉更早有效 down/同根追加可重复;夹具按产品真实操作标签登记并记录实际请求标签防错位;隔离临时 stateRoot+有界子进程,全离线无网络无真实供应商) ==="
 (cd ts && npx tsx scripts/issue436-persisted-routing-e2e.ts) || FAIL=1
 
 if [ "$FAIL" -ne 0 ]; then


### PR DESCRIPTION
Closes #446

This fixes the §67 shell heading in `scripts/run-all-tests.sh` by escaping the literal backticks around `routing` inside the double-quoted `echo` string. The §67 test command itself is unchanged.

Implementation attribution: actual Claude Code made the one-file commit in session `53ea2d9a-4b52-47f5-99fa-3e166dd1826b`; this fallback worker performed the SHA-bound verification and PR publication. The Claude launcher exited `1` after hitting the configured max-turn limit, after the successful commit already existed.

Evidence on `f3a6ec80eebb8175257ba53543da0bddc0679943` with Node `v24.20.0` / npm `11.19.0`:

- `bash -n scripts/run-all-tests.sh` → exit 0
- Old-form sentinel, `bash -c 'routing(){ printf OLD_TRIGGER; }; echo "heading `routing` tail"'` → output contained `OLD_TRIGGER`, exit 0
- Fixed-form sentinel, `bash -c 'routing(){ printf NEW_TRIGGER; }; echo "heading \`routing\` tail"'` → output preserved literal backticks and did not contain `NEW_TRIGGER`, exit 0
- Same-class scan for unescaped backticks in double-quoted `echo` headings → `0`, exit 0
- `cd ts && GOTRY_SESSION_LIVE=0 GOTRY_HBCLI_LIVE=0 GOTRY_HOTELBYTE_SKILLS_LIVE=0 npx tsx scripts/issue436-persisted-routing-e2e.ts` → exit 0
- `git diff --check HEAD~1..HEAD` → exit 0

Receipt: `/Users/danceiny/work/gotry/.omx/artifacts/continue-20260912T114928/worker446-shell-heading-f3a6ec80eebb8175257ba53543da0bddc0679943/receipt.txt`

No full regression was run because this is a pure shell heading quote fix and does not change any test entrypoint or TypeScript source.
