### PR TITLE
feat(capabilities): local Lavish Editor session adapter (issue #443)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,7 @@ Readability is not polish; it is a usability metric of documentation. Rules:
 | [design/itinerary-html-renderer.md](design/itinerary-html-renderer.md) | Itinerary HTML renderer contract + product generation entry (internal slice, issue #442/parent #438): pure bounded renderer, plan plane vs evidence plane, rejection set; `gotry_itinerary_render` writes one new non-overwriting HTML file from registry-selected facts; browser/native-preview acceptance open |
 | [design/hotelbyte-skills-design.md](design/hotelbyte-skills-design.md) | hotelbyte-skills architecture (knowledge enters the repo / execution stays in gotry, issue #5) |
 | [design/stage1-top-down-design.md](design/stage1-top-down-design.md) | Stage 1 top-level design (historical original); **its status header is state face ⑥ of §11** |
+| [design/lavish-local.md](design/lavish-local.md) | Lavish local session adapter (#443, parent #438): owned-process/port/state boundary, TOON protocol facts, untrusted feedback, bounded polling |
 
 ### rfc/ (proposal originals)
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -125,6 +125,7 @@
 | [design/itinerary-html-renderer.md](design/itinerary-html-renderer.zh-CN.md) | 行程 HTML 渲染器合同 + 产品生成入口（内部切片，issue #442/父 #438）：纯有界渲染器、计划面与证据面分离、拒绝集；`gotry_itinerary_render` 从注册表选出的事实在会话工作目录仅新建一个不覆盖的 HTML 文件；浏览器/原生预览验收待完成 |
 | [design/hotelbyte-skills-design.md](design/hotelbyte-skills-design.zh-CN.md) | hotelbyte-skills 架构（知识进仓/执行留 gotry，issue #5） |
 | [design/stage1-top-down-design.md](design/stage1-top-down-design.zh-CN.md) | Stage 1 顶层设计（历史原文）；**状态头是 §11 状态面⑥** |
+| [design/lavish-local.md](design/lavish-local.zh-CN.md) | Lavish 本地会话适配器（#443，父需求 #438）：自有进程/端口/状态边界、TOON 协议事实、不可信反馈、有界轮询 |
 
 ### rfc/（提案原文）
 

--- a/docs/design/lavish-local.md
+++ b/docs/design/lavish-local.md
@@ -1,0 +1,167 @@
+[English](lavish-local.md) | [简体中文](lavish-local.zh-CN.md)
+
+# Lavish Local Session Adapter (#443, parent #438)
+
+> Status: **bounded adapter slice (2026-09-12, issue #443)**. This document covers the local
+> `lavish-axi` session lifecycle adapter that landed as `ts/capabilities/lavish-local.ts` with
+> `ts/scripts/lavish-local-tests.ts`. Product registration (plugin wiring, the six state surfaces,
+> `run-all-tests.sh`) belongs to issue #442/#438 and is deliberately **not** part of this slice, and
+> the real browser feedback path is still unverified — see §7.
+> Every protocol claim in §2 was read from the installed `lavish-axi@0.1.67` tarball, not from prose.
+
+## 1. What this answers
+
+GoTry needs to hand a generated HTML artifact to a human for visual review and get feedback back
+without inventing a review UI. Lavish Editor ships that UI as a local CLI (`lavish-axi`) with a real
+open/poll/reply/end/stop protocol. This adapter is the seam that lets GoTry drive that protocol
+**without** becoming a second owner of Lavish's browser surface, watcher, session store, or HTTP
+control plane.
+
+The adapter is deliberately narrow: it owns the process group it spawns, the state directory it
+creates, and the loopback port it allocates. It owns nothing else, and it never reaches outside that
+boundary — see §5.
+
+## 2. Verified protocol facts
+
+Pinned upstream: `lavish-axi@0.1.67` (MIT, `engines.node >= 22`), published `bin` entry
+`dist/cli.mjs`. Facts confirmed by reading the installed package and by running it:
+
+- **Output is TOON, decoded with the official decoder.** `axi-sdk-js@0.1.11` pulls
+  `@toon-format/toon@^2.1.0`, which resolves to `2.3.1`; the adapter depends on that exact version.
+  There is no `--json` switch and no YAML. **Failures also arrive on stdout** as a TOON
+  `{error, code, help?}` object with a non-zero exit code (2 for `VALIDATION_ERROR`, 1 otherwise), so
+  the adapter checks for the `error` key rather than trusting the exit code alone.
+- **Command vocabulary:** `open`, `poll`, `end`, `stop`, `server`. `update` is the SDK's own
+  self-upgrade and is never invoked by this adapter; neither are `setup hooks`, `setup plugin`,
+  `share`, or `export`.
+- **`open`** returns `session.status` of `opened` or `user-ended`. Only a user-initiated end blocks a
+  plain reopen — the adapter never passes `--reopen`.
+- **`poll`** statuses are `waiting`, `feedback`, `ended`, `browser_disconnected`. A `waiting` result
+  consumed nothing and is safe to poll again; a `feedback` delivery **is** the consumption. A missing
+  session is reported as a `NOT_FOUND` error object, not as a status.
+- **`server`** is the long-running HTTP control plane. `stop` is well-defined when nothing is
+  running (`server.status: not-running`).
+- **The server self-exits once the last session ends with nothing connected.** The adapter therefore
+  treats "the owned server is already gone" as a normal outcome of `stop`, not as an error.
+
+## 3. Adapter API
+
+`LavishLocalSession.create(options)` returns an instance. Every method performs at most one CLI
+invocation and returns a discriminated result — an `ok: true` value or a
+`{ ok: false, code, detail }` failure. The adapter never retries internally.
+
+| method | protocol call | result |
+| --- | --- | --- |
+| `open(path)` | `open <realpath> --no-open` | `opened` / `user-ended` plus the loopback session url |
+| `poll(path, {timeoutMs})` | `poll <realpath> --timeout-ms <n>` | `waiting` / `feedback` / `ended` / `browser-disconnected` |
+| `reply(path, text, {timeoutMs})` | `poll <realpath> --agent-reply <text> --timeout-ms <n>` | same shape as `poll` |
+| `end(path)` | `end <realpath>` | `ended` |
+| `stop()` | owned process group, never the CLI `stop` | `stopped` / `stopping` / `not-running` |
+
+`reply` is the protocol's own `poll --agent-reply` call, which answers the feedback and waits for the
+next state in one invocation. Replies are validated to be non-empty and not the bare `--` flag
+terminator, because the CLI's flag parser would silently drop those.
+
+Options are trusted and explicit: `cliPackageRoot` (the installed package directory), `cwd`, and
+`allowedRoot` (defaults to `cwd`). There is no option that accepts command text, a shell string, a
+port to hijack, or an ambient state directory.
+
+## 4. Trust boundary: the artifact path and the feedback payload
+
+**Artifact paths are allowlisted by realpath.** Input must be a `.html`/`.htm` file; relative input
+resolves against `cwd`; the canonical path is then required to stay inside `allowedRoot`, with any
+`.git` or `node_modules` segment denied. Because containment is checked **after** symlink
+resolution, a symlink pointing outside the root is rejected rather than followed. The adapter only
+ever consumes a path — it has no write API, never rewrites the artifact, and never re-runs `open` to
+"update" content. Content updates are the caller's (or the watcher's) business, because the CLI's own
+`next_step` contract is that Lavish live-reloads a saved artifact.
+
+**Feedback is data, never authority.** Everything the CLI prints about the user — prompt text,
+selectors, tags, attachment references, artifact failures, the DOM snapshot — is returned inside a
+`LavishUntrustedFeedback` value marked `trust: 'untrusted'`, with byte and count bounds and an
+explicit truncation flag per collection. The adapter deliberately drops the CLI's `next_step`
+instruction text instead of forwarding it, because it is third-party prose addressed to an agent and
+must not arrive as system authority. Attachment references are projected to `id`/`name` only: the
+adapter performs **no filesystem access** for feedback and never follows a path supplied by a
+browser.
+
+**Nothing is logged.** The adapter contains no logging and writes nothing to stdout or stderr. The
+session url embeds an opaque access key, so `redactLavishSessionUrl` is exported for any surface that
+must display one, failure details are redacted before they are returned, and a test asserts that a
+full lifecycle produces zero writes to either stream.
+
+## 5. Ownership: process group, state directory, port
+
+Each instance owns exactly one `lavish-axi server` child, launched in **its own process group** with
+an argv array and `shell: false`. No command string is ever assembled, so nothing in a reply or a
+path can be shell-expanded. Cleanup signals the group with `SIGTERM`, waits, then `SIGKILL`, then
+waits again, and every CLI invocation is reaped before its result is returned — the adapter never
+leaves a poll or a server behind.
+
+Each instance also owns an `mkdtemp` state directory and an **unused** loopback port that it
+allocated itself. The child environment is built from scratch rather than inherited: only `PATH`, a
+`HOME` redirected inside the owned state directory, and the six explicit `LAVISH_AXI_*` variables
+reach the child. A caller's ambient `LAVISH_AXI_*` values (including a wildcard host allowlist or an
+idle-timeout override) and any Tailscale variables are dropped, so no global `~/.lavish-axi`
+configuration, hook file, or Tailscale binding can be reached. `LAVISH_AXI_TELEMETRY=0`,
+`LAVISH_AXI_NO_OPEN=1`, `LAVISH_AXI_HOST=127.0.0.1`, and `LAVISH_AXI_LINK_HOST=127.0.0.1` are always
+set, so the session url never leaves loopback and no browser is driven.
+
+**A server this adapter did not start is never adopted, preempted, or shut down.** Before spawning,
+the adapter probes the health endpoint on its port; if anything answers, it fails closed. After
+spawning, a server only counts as ours when our own child is still alive **and** the health payload
+reports the pinned `app`/`version`; the same check gates every later command, so the CLI's
+`ensureServer` always reuses our child instead of spawning a detached one of its own. `stop` signals
+only our process group and reports `not-running` when there is nothing of ours to reap. Tests cover
+both a foreign listener and a pre-existing **same-version** `lavish-axi` server and assert that
+neither is signalled.
+
+## 6. Bounded behavior and unknown outcomes
+
+Responses are bounded in bytes on both streams and in wall-clock time per invocation. A poll always
+carries an explicit `--timeout-ms` (bounded by `maxPollTimeoutMs`), so a poll returns cleanly with
+`waiting` instead of running forever; a `waiting` result consumed nothing and may be polled again.
+
+The one dangerous case is deliberately not silent. If the adapter's own deadline fires and kills a
+poll, the outcome is genuinely unknown — the delivery may or may not have consumed feedback. The
+adapter records that and refuses the next `poll` with `poll-outcome-unknown` rather than risking a
+double-consume; the caller must decide explicitly, which usually means a fresh instance. A
+user-initiated end is likewise sticky: once `open` returns `user-ended`, or a poll reports
+`ended_by: 'user'`, the instance latches closed and later `open` calls fail with
+`session-user-ended` instead of reopening.
+
+## 7. Not in this slice (explicit TODO)
+
+- **Real browser feedback is unverified.** The `feedback` payload shape, the `--agent-reply` echo,
+  and the `browser_disconnected` grace behaviour have only been exercised against synthetic fixture
+  payloads, never through a real browser session. A "true browser feedback E2E" is required before
+  any product claim, and is root-owned follow-up on issue #438.
+- **No product wiring.** Nothing in `ts/src/index.ts`, the client surfaces, the six state surfaces,
+  or `run-all-tests.sh` is touched by this slice; registration is issue #442/#438 work.
+- **Lavish is not a product dependency.** Only the decoder (`@toon-format/toon@2.3.1`) is added to
+  the manifests and locks. The adapter is handed an installed CLI path at runtime; the CLI itself is
+  not vendored into the product dependency tree, and DSH client-side card registration
+  (`tool.call.toolview`) is untouched.
+- **Unsupported feedback shapes stay opaque.** Whiteboard/excalidraw targets and attachments are
+  bounded and marked untrusted rather than deeply modelled, so the product surface must not rely on
+  fields beyond `id`/`name`/`type`.
+
+## 8. Evidence and how to run
+
+`ts/scripts/lavish-local-tests.ts` has two parts. The offline part is deterministic and needs no
+network: it builds a synthetic `lavish-axi` package tree and covers CLI trust refusal (wrong name,
+unpinned version, non-pinned entry, missing entry, escaping entry), the path allowlist, argv shape,
+the no-shell guarantee, byte/timeout bounds, malformed and unexpected CLI states, feedback bounds,
+process-group reaping, user-ended latching, foreign-port refusal, two-instance isolation, and the
+zero-write assertion.
+
+The live part is opt-in (`GOTRY_LAVISH_LIVE=1`) and installs the pinned version into a unique
+`mkdtemp` npm prefix from the public registry (`--no-save`, `--ignore-scripts`, never global), then
+runs the real CLI `open` / `poll --timeout-ms` / `end` / `stop` protocol against a synthetic HTML
+fixture on the adapter's own port, including reaping a live owned server. It prints its argv and exit
+codes as a transcript.
+
+```
+cd ts && npx tsx scripts/lavish-local-tests.ts
+cd ts && GOTRY_LAVISH_LIVE=1 npx tsx scripts/lavish-local-tests.ts
+```

--- a/docs/design/lavish-local.md
+++ b/docs/design/lavish-local.md
@@ -85,6 +85,19 @@ must not arrive as system authority. Attachment references are projected to `id`
 adapter performs **no filesystem access** for feedback and never follows a path supplied by a
 browser.
 
+**Prompt vs text: two distinct fields.** Each projected prompt carries both `text` (the
+selected-element context — for freeform chat input upstream sets this to the placeholder
+`"Freeform message"`, for an annotation it is the lower-cased element `tagName` plus
+`el.innerText.trim()` of the selected element) and `prompt` (the user's actual instruction from the
+chat input). The upstream chat filter is
+`acceptedPrompts.filter((p) => p.tag === "message" && p.prompt)` (see lavish-axi `dist/cli.mjs`
+near the user-message projection, ~7720), so without `prompt` the request is dropped on the floor.
+The adapter never substitutes `text` for `prompt`: a missing or non-string `prompt` is exposed as
+`prompt: ''` and counted in `LavishUntrustedFeedback.promptsMalformed` so the drop is auditable.
+An empty-string `prompt` (a legitimate "no text, attachments only" request) is preserved as data
+and is **not** counted as malformed. Annotation tags are real HTML element names (`h1`, `div`, …)
+— see upstream `context()` at ~5359 — not a literal `"text"`.
+
 **Nothing is logged.** The adapter contains no logging and writes nothing to stdout or stderr. The
 session url embeds an opaque access key, so `redactLavishSessionUrl` is exported for any surface that
 must display one, failure details are redacted before they are returned, and a test asserts that a

--- a/docs/design/lavish-local.zh-CN.md
+++ b/docs/design/lavish-local.zh-CN.md
@@ -63,6 +63,15 @@ DOM 快照——都在标记为 `trust: 'untrusted'` 的 `LavishUntrustedFeedbac
 适配器刻意丢弃 CLI 的 `next_step` 指令文本而不转发：那是直接写给 agent 的第三方措辞，不能以系统权威的身份抵达。
 附件引用只投影 `id`/`name`：适配器对反馈**不做任何文件系统访问**，也从不跟随浏览器给出的路径。
 
+**Prompt vs text：两个独立字段。** 每个投影出的 prompt 都同时携带 `text`（选中元素的上下文——自由输入时上游把它置为占位
+字符串 `"Freeform message"`，批注时是元素的 `tagName` 小写加上 `el.innerText.trim()` 的选中片段）与 `prompt`（用户在聊天框里
+实际提交的指令）。上游从 prompt 提炼聊天消息的过滤器是
+`acceptedPrompts.filter((p) => p.tag === "message" && p.prompt)`（见 lavish-axi `dist/cli.mjs` 用户消息投影处，约 7720），
+因此没有 `prompt` 字段就把请求丢在了地上。适配器**绝不**用 `text` 替代 `prompt`：缺字段或非字符串的 `prompt` 在投影中以
+`prompt: ''` 呈现，并计入 `LavishUntrustedFeedback.promptsMalformed`，让丢弃可被审查。空串 `prompt`（合法的「不带文字、
+只要附件」请求）按数据原样保留，**不**计为畸形。批注 tag 是真实的 HTML 元素名（`h1`、`div`…）——见上游 `context()` 约 5359——
+并非字面量 `"text"`。
+
 **什么都不打日志。** 适配器不含日志，不向 stdout 或 stderr 写任何字节。会话 url 内嵌不透明访问键，因此导出了
 `redactLavishSessionUrl` 供需要展示的界面使用；失败详情在返回前即已打码；并有测试断言一次完整生命周期对两个流零写入。
 

--- a/docs/design/lavish-local.zh-CN.md
+++ b/docs/design/lavish-local.zh-CN.md
@@ -1,0 +1,119 @@
+[English](lavish-local.md) | [简体中文](lavish-local.zh-CN.md)
+
+# Lavish 本地会话适配器（#443，父需求 #438）
+
+> 状态：**有界适配器切片（2026-09-12，issue #443）**。本文对应已落地的本地 `lavish-axi` 会话生命周期适配器
+> `ts/capabilities/lavish-local.ts` 与测试 `ts/scripts/lavish-local-tests.ts`。产品注册（插件接线、六处状态面、
+> `run-all-tests.sh`）属于 issue #442/#438，**刻意不属本切片**；真实浏览器反馈路径仍未验证，见 §7。
+> §2 的每一条协议事实都读自已安装的 `lavish-axi@0.1.67` 包本体，而非文档描述。
+
+## 1. 本切片回答什么
+
+GoTry 需要把生成的 HTML 产物交给真人做视觉评审并取回反馈，同时不自建评审 UI。Lavish Editor 以一个本地 CLI
+（`lavish-axi`）提供该 UI，并带真实可用的 open/poll/reply/end/stop 协议。本适配器就是让 GoTry 驱动该协议的接缝，
+且**不**成为 Lavish 浏览器界面、 watcher、会话存储或 HTTP 控制面的第二个所有者。
+
+适配器的边界刻意收窄：它只拥有自己启动的进程组、自己创建的 state 目录、自己分配的回环端口，别的一概不碰，见 §5。
+
+## 2. 已核实的协议事实
+
+上游 pin：`lavish-axi@0.1.67`（MIT，`engines.node >= 22`），发布包的 `bin` 指向 `dist/cli.mjs`。以下事实来自读源码与实跑：
+
+- **输出是 TOON，用官方解码器解析。** `axi-sdk-js@0.1.11` 依赖 `@toon-format/toon@^2.1.0`，实际解析到 `2.3.1`；
+  适配器按该精确版本引依赖。没有 `--json` 开关，也不是 YAML。**失败同样走 stdout**，形态为 TOON 的
+  `{error, code, help?}` 对象并带非零退出码（`VALIDATION_ERROR` 为 2，其余为 1），因此适配器检查 `error` 键，
+  而不是只信退出码。
+- **命令集：** `open`、`poll`、`end`、`stop`、`server`。`update` 是 SDK 自升级，本适配器从不调用；`setup hooks`、
+  `setup plugin`、`share`、`export` 同样从不调用。
+- **`open`** 返回的 `session.status` 只有 `opened` 与 `user-ended`。只有用户主动结束才会阻止普通重开——适配器从不传 `--reopen`。
+- **`poll`** 的状态为 `waiting`、`feedback`、`ended`、`browser_disconnected`。`waiting` 什么都没消费，可以安全地再轮询；
+  而 `feedback` 的投递**本身即消费**。会话不存在时返回的是 `NOT_FOUND` 错误对象，不是某个状态。
+- **`server`** 是长期运行的 HTTP 控制面。没有进程在跑时 `stop` 依然有明确定义（`server.status: not-running`）。
+- **最后一个会话结束且无连接时，server 会自行退出。** 因此适配器把「自己启动的 server 已经不在」当作 `stop` 的正常结果，
+  而不是错误。
+
+## 3. 适配器 API
+
+`LavishLocalSession.create(options)` 返回实例。每个方法最多执行一次 CLI 调用，并返回可判别结果——`ok: true` 的值，
+或 `{ ok: false, code, detail }` 失败。适配器内部不重试。
+
+| 方法 | 协议调用 | 结果 |
+| --- | --- | --- |
+| `open(path)` | `open <realpath> --no-open` | `opened` / `user-ended`，附回环会话 url |
+| `poll(path, {timeoutMs})` | `poll <realpath> --timeout-ms <n>` | `waiting` / `feedback` / `ended` / `browser-disconnected` |
+| `reply(path, text, {timeoutMs})` | `poll <realpath> --agent-reply <text> --timeout-ms <n>` | 与 `poll` 同形 |
+| `end(path)` | `end <realpath>` | `ended` |
+| `stop()` | 只对自己拥有的进程组，绝不调用 CLI 的 `stop` | `stopped` / `stopping` / `not-running` |
+
+`reply` 就是协议自身的 `poll --agent-reply` 调用：一次调用内既回答反馈又等待下一个状态。回复文本会被校验为非空、
+且不是裸的 `--` 终止符，因为 CLI 的参数解析会静默丢弃这两种。
+
+选项都可信且显式：`cliPackageRoot`（已安装包目录）、`cwd`、`allowedRoot`（默认取 `cwd`）。不存在任何接受命令文本、
+shell 字符串、待劫持端口或环境态 state 目录的选项。
+
+## 4. 信任边界：产物路径与反馈载荷
+
+**产物路径按 realpath 走白名单。** 输入必须是 `.html`/`.htm` 文件；相对输入按 `cwd` 解析；随后要求规范路径落在
+`allowedRoot` 内，且任何 `.git` 或 `node_modules` 路径段都被拒绝。由于包含性检查发生在**符号链接解析之后**，
+指向根之外的符号链接会被拒绝而不是被跟随。适配器只消费路径——它没有写 API，从不改写产物，也从不为了「更新内容」
+重跑 `open`。内容更新是调用方（或 watcher）的事，因为 CLI 自身的 `next_step` 契约就是 Lavish 会对已保存的产物自动 live-reload。
+
+**反馈是数据，永远不是权威。** CLI 打印的关于用户的一切——prompt 文本、selector、tag、附件引用、artifact failure、
+DOM 快照——都在标记为 `trust: 'untrusted'` 的 `LavishUntrustedFeedback` 值里返回，并带字节/数量上界与逐集合的截断标志。
+适配器刻意丢弃 CLI 的 `next_step` 指令文本而不转发：那是直接写给 agent 的第三方措辞，不能以系统权威的身份抵达。
+附件引用只投影 `id`/`name`：适配器对反馈**不做任何文件系统访问**，也从不跟随浏览器给出的路径。
+
+**什么都不打日志。** 适配器不含日志，不向 stdout 或 stderr 写任何字节。会话 url 内嵌不透明访问键，因此导出了
+`redactLavishSessionUrl` 供需要展示的界面使用；失败详情在返回前即已打码；并有测试断言一次完整生命周期对两个流零写入。
+
+## 5. 所有权：进程组、state 目录、端口
+
+每个实例恰好拥有一个 `lavish-axi server` 子进程，以 **自己的进程组** 启动，参数用数组传、`shell: false`，
+从不拼接命令字符串，因此回复文本或路径都无法被 shell 展开。清理时先向进程组发 `SIGTERM`，等待，再 `SIGKILL`，再等待；
+每次 CLI 调用都在返回结果前完成回收——适配器不会留下任何 poll 或 server 残留。
+
+每个实例还拥有一个 `mkdtemp` state 目录和一个**自己分配的、未被占用**的回环端口。子进程环境是从零构造而非继承：
+只有 `PATH`、被重定向到自有 state 目录内的 `HOME`，以及六个显式 `LAVISH_AXI_*` 变量会到达子进程。调用方环境里的
+`LAVISH_AXI_*`（含通配 host 白名单或 idle-timeout 覆盖）与任何 Tailscale 变量都被丢弃，因此全局 `~/.lavish-axi`
+配置、hook 文件与 Tailscale 绑定都无法被触达。`LAVISH_AXI_TELEMETRY=0`、`LAVISH_AXI_NO_OPEN=1`、
+`LAVISH_AXI_HOST=127.0.0.1`、`LAVISH_AXI_LINK_HOST=127.0.0.1` 恒被设置，因此会话 url 不会离开回环，也不会驱动浏览器。
+
+**本适配器没有启动的 server，绝不被接管、抢占或关闭。** 启动前先探测自己端口上的健康端点，只要有应答就失败关闭。
+启动后，只有当自有子进程仍存活**且**健康载荷报告 pin 住的 `app`/`version` 时，该 server 才算「我们的」；后续每条命令都受同一
+检查约束，因此 CLI 的 `ensureServer` 总会复用我们的子进程，而不会自行另起一个 detached server。`stop` 只对自己进程组发信号，
+当没有属于我们的东西可回收时报告 `not-running`。测试同时覆盖外来监听者与**既有同版本** `lavish-axi` server，并断言两者都未被发信号。
+
+## 6. 有界行为与未知结果
+
+两条流的响应都有字节上界，每次调用也有墙钟上界。poll 总是带显式 `--timeout-ms`（受 `maxPollTimeoutMs` 约束），
+因此 poll 会以 `waiting` 干净返回而不是永久挂起；`waiting` 没有消费任何东西，可以再次轮询。
+
+唯一危险的情形被刻意做成不静默：若适配器自身 deadline 触发并杀死 poll，结果就**真的未知**——投递可能已消费反馈，也可能没有。
+适配器记录该状态，并以下一个 `poll` 返回 `poll-outcome-unknown` 的方式拒绝继续，而不是冒重复消费的风险；必须由调用方显式决定，
+通常意味着新建实例。用户主动结束同样粘滞：一旦 `open` 返回 `user-ended`，或某次 poll 报告 `ended_by: 'user'`，实例即闭锁，
+后续 `open` 以 `session-user-ended` 失败而不会重开。
+
+## 7. 不在本切片内（显式 TODO）
+
+- **真实浏览器反馈未验证。** `feedback` 载荷形状、`--agent-reply` 回显、`browser_disconnected` 宽限行为，目前只在合成
+  fixture 载荷上演练过，从未经过真实浏览器会话。「真实浏览器反馈 E2E」在任何产品口径之前都是必需的，属 root 负责的 #438 后续。
+- **无产品接线。** 本切片不触碰 `ts/src/index.ts`、client 界面、六处状态面与 `run-all-tests.sh`；接线是 #442/#438 的工作。
+- **Lavish 不是产品依赖。** 只有解码器（`@toon-format/toon@2.3.1`）进入 manifest 与锁文件。适配器在运行时被交付一个已安装 CLI 路径；
+  CLI 本身不被 vendor 进产品依赖树，DSH 客户端卡片注册（`tool.call.toolview`）也未被触碰。
+- **不支持的反馈形状保持不透明。** whiteboard/excalidraw target 与附件只做有界化并标记为不可信，不做深度建模，
+  因此产品界面不得依赖 `id`/`name`/`type` 之外的字段。
+
+## 8. 证据与运行方式
+
+`ts/scripts/lavish-local-tests.ts` 分两部分。离线部分确定性强且不需要网络：构造一棵合成的 `lavish-axi` 包树，覆盖
+CLI 可信性拒绝（错包名、非 pin 版本、非 pin 入口、入口缺失、入口逃逸）、路径白名单、argv 形态、无 shell 保证、
+字节/超时上界、畸形与意外 CLI 状态、反馈上界、进程组回收、user-ended 闭锁、外来端口拒绝、双实例隔离，以及零写入断言。
+
+在线部分为显式启用（`GOTRY_LAVISH_LIVE=1`），从公共 registry 把 pin 版本安装进唯一的 `mkdtemp` npm 前缀
+（`--no-save`、`--ignore-scripts`、绝不全局），然后在适配器自有端口上对合成 HTML 产物实跑真实 CLI 的
+`open` / `poll --timeout-ms` / `end` / `stop` 协议，包括回收一个活着的自有 server。它会打印 argv 与退出码作为 transcript。
+
+```
+cd ts && npx tsx scripts/lavish-local-tests.ts
+cd ts && GOTRY_LAVISH_LIVE=1 npx tsx scripts/lavish-local-tests.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,6 +245,7 @@
         "@deepseek-ai/dsh-workflow-worker-thread": "0.1.5-rc.1",
         "@deepseek-ai/dsh-workspace": "0.1.5-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
+        "@toon-format/toon": "2.3.1",
         "ajv": "^8.17.1",
         "better-sqlite3": "^13.0.3",
         "dsh-calendar": "^0.3.2",
@@ -6131,6 +6132,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@toon-format/toon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.1.tgz",
+      "integrity": "sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==",
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -355,6 +355,7 @@
     "@deepseek-ai/dsh-workflow-worker-thread": "0.1.5-rc.1",
     "@deepseek-ai/dsh-workspace": "0.1.5-rc.1",
     "@deepseek-ai/schemastery": "^3.18.1",
+    "@toon-format/toon": "2.3.1",
     "ajv": "^8.17.1",
     "better-sqlite3": "^13.0.3",
     "dsh-calendar": "^0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,9 @@ importers:
       '@deepseek-ai/schemastery':
         specifier: ^3.18.1
         version: 3.18.2
+      '@toon-format/toon':
+        specifier: 2.3.1
+        version: 2.3.1
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
@@ -3298,6 +3301,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@toon-format/toon@2.3.1':
+    resolution: {integrity: sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==}
 
   '@types/node@26.4.0':
     resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
@@ -7408,6 +7414,8 @@ snapshots:
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@toon-format/toon@2.3.1': {}
 
   '@types/node@26.4.0':
     dependencies:

--- a/ts/capabilities/lavish-local.ts
+++ b/ts/capabilities/lavish-local.ts
@@ -50,6 +50,8 @@ const MAX_ATTACHMENT_REFS_PER_PROMPT = 16
 const MAX_ARTIFACT_FAILURES = 16
 const MAX_DOM_SNAPSHOT_BYTES = 256 * 1024
 const MAX_DETAIL_CHARS = 512
+const MAX_REPLY_CHARS = 16_384
+const MAX_REPLY_BYTES = 24 * 1024
 
 export type LavishLocalErrorCode =
   | 'invalid-options'
@@ -252,12 +254,10 @@ export class LavishLocalSession {
     const run = await this.runCli(['open', resolved.file, '--no-open'])
     if ('code' in run) return run
 
-    const decoded = decodeCliOutput(run.stdout)
+    const decoded = readCliBody(run)
     if ('code' in decoded) return decoded
 
     const body = decoded.value
-    if ('error' in body) return cliFailure(body)
-
     const session = readRecord(body.session)
     if (!session) return fail('malformed-output', 'open response has no session object')
     if (session.file !== resolved.file) {
@@ -305,6 +305,13 @@ export class LavishLocalSession {
     if (text === '--') {
       return fail('invalid-reply', 'reply text must not be the bare flag terminator')
     }
+    // Bounded before any argv or spawn: `shell: false` prevents interpretation, not resource use.
+    if (text.length > MAX_REPLY_CHARS) {
+      return fail('invalid-reply', `reply text must not exceed ${MAX_REPLY_CHARS} characters`)
+    }
+    if (Buffer.byteLength(text, 'utf8') > MAX_REPLY_BYTES) {
+      return fail('invalid-reply', `reply text must not exceed ${MAX_REPLY_BYTES} bytes`)
+    }
     return this.pollLike('reply', artifactPath, text, options)
   }
 
@@ -322,12 +329,10 @@ export class LavishLocalSession {
     const run = await this.runCli(['end', resolved.file])
     if ('code' in run) return run
 
-    const decoded = decodeCliOutput(run.stdout)
+    const decoded = readCliBody(run)
     if ('code' in decoded) return decoded
 
     const body = decoded.value
-    if ('error' in body) return cliFailure(body)
-
     const session = readRecord(body.session)
     const status = session ? readString(session.status) : null
     if (status !== 'ended') {
@@ -397,27 +402,29 @@ export class LavishLocalSession {
     const run = await this.runCli(argv, timeoutMs.value + this.options.commandTimeoutMs)
     if ('code' in run) {
       // A killed long-poll may or may not have consumed feedback; never retry silently.
-      if (run.code === 'command-timeout') this.pollOutcomeUnknown = true
+      // A spawn failure is the one case where the CLI never ran, so nothing was consumed.
+      if (run.code !== 'command-failed') this.pollOutcomeUnknown = true
       return run
     }
 
-    const decoded = decodeCliOutput(run.stdout)
-    if ('code' in decoded) {
+    const body = readCliBody(run)
+    if ('code' in body) {
       this.pollOutcomeUnknown = true
-      return decoded
+      return body
     }
 
-    const body = decoded.value
-    if ('error' in body) {
+    const session = readRecord(body.value.session)
+    if (!session) {
+      // A zero-exit response we cannot read may still have consumed a delivery.
       this.pollOutcomeUnknown = true
-      return cliFailure(body)
+      return fail('malformed-output', 'poll response has no session object')
     }
-
-    const session = readRecord(body.session)
-    if (!session) return fail('malformed-output', 'poll response has no session object')
     const raw = readString(session.status)
     const status = normalizePollStatus(raw)
-    if (!status) return fail('unexpected-status', `unsupported poll status ${quote(raw)}`)
+    if (!status) {
+      this.pollOutcomeUnknown = true
+      return fail('unexpected-status', `unsupported poll status ${quote(raw)}`)
+    }
 
     const endedBy = readString(session.ended_by) ?? undefined
     if (endedBy === 'user' && (status === 'ended' || session.session_ended === true)) {
@@ -432,7 +439,7 @@ export class LavishLocalSession {
       status,
       sessionEnded: session.session_ended === true,
       ...(endedBy ? { endedBy } : {}),
-      feedback: projectFeedback(body),
+      feedback: projectFeedback(body.value),
     }
   }
 
@@ -849,6 +856,21 @@ function decodeCliOutput(stdout: string): { value: Record<string, unknown> } | L
   }
   if (!isPlainObject(decoded)) return fail('malformed-output', 'the Lavish CLI stdout was not a TOON object')
   return { value: decoded }
+}
+
+/**
+ * Reads one CLI result. A structured error object wins over the exit code because
+ * it carries the real reason; otherwise a non-zero exit code always fails closed,
+ * so well-formed stdout from a failed run is never mistaken for success.
+ */
+function readCliBody(run: OwnedRun): { value: Record<string, unknown> } | LavishLocalFailure {
+  const decoded = decodeCliOutput(run.stdout)
+  if (!('code' in decoded) && 'error' in decoded.value) return cliFailure(decoded.value)
+  if (run.exitCode !== 0) {
+    const exit = run.exitCode === null ? 'no exit code (signalled)' : `exit code ${run.exitCode}`
+    return fail('command-failed', `the Lavish CLI reported ${exit}`)
+  }
+  return decoded
 }
 
 function cliFailure(body: Record<string, unknown>): LavishLocalFailure {

--- a/ts/capabilities/lavish-local.ts
+++ b/ts/capabilities/lavish-local.ts
@@ -46,6 +46,7 @@ const KILL_GRACE_MS = 2_000
 
 const MAX_PROMPTS = 64
 const MAX_PROMPT_FIELD_CHARS = 16 * 1024
+const MAX_PROMPT_FIELD_BYTES = 16 * 1024
 const MAX_ATTACHMENT_REFS_PER_PROMPT = 16
 const MAX_ARTIFACT_FAILURES = 16
 const MAX_DOM_SNAPSHOT_BYTES = 256 * 1024
@@ -87,11 +88,45 @@ export interface LavishPromptTarget {
   type: string
 }
 
+/**
+ * One untrusted prompt projected from the CLI's normalized prompt list.
+ *
+ * Two distinct fields model the upstream shape (see lavish-axi
+ * `normalizePrompt` at `dist/cli.mjs` near `function normalizePrompt`):
+ *
+ * - `text` is the **selected-element context** — for freeform chat input upstream
+ *   sets this to the placeholder `"Freeform message"`, for an annotation it is
+ *   `el.innerText.trim()` of the element that was selected (capped at 240 chars
+ *   upstream). It is not the user's request.
+ * - `prompt` is the **user instruction** that the chat input submitted. The
+ *   real upstream filter that turns prompts into chat messages is
+ *   `acceptedPrompts.filter((prompt) => prompt.tag === "message" && prompt.prompt)`,
+ *   so without this field the request is dropped on the floor.
+ *
+ * Both fields are bounded by chars and bytes; each carries its own `*Truncated`
+ * flag so a consumer can never mistake a clipped value for a complete one.
+ *
+ * Shape semantics:
+ * - `prompt` is a non-empty string: the user instruction is preserved as data.
+ * - `prompt` is the empty string `""`: a legitimate request with no text but
+ *   possibly attachments (e.g. "comment on this image"). The adapter does
+ *   **not** fall back to the context `text`; the empty `prompt` is the truth.
+ * - `prompt` is missing or non-string at the upstream boundary: malformed.
+ *   The prompt is still projected (its `uid`, `tag`, `selector`, `text`, and
+ *   attachments survive) with `prompt: ''` and `promptTruncated: false`, and
+ *   counted in `LavishUntrustedFeedback.promptsMalformed` so the drop is
+ *   auditable rather than a silent text substitution.
+ */
 export interface LavishPrompt {
   uid: string
   tag: string
   selector: string
+  /** Selected-element context (freeform placeholder or annotation snippet). */
   text: string
+  textTruncated: boolean
+  /** User instruction. Empty when the upstream prompt carried no user content. */
+  prompt: string
+  promptTruncated: boolean
   target?: LavishPromptTarget
   attachments: LavishAttachmentRef[]
 }
@@ -106,6 +141,15 @@ export interface LavishUntrustedFeedback {
   trust: 'untrusted'
   prompts: LavishPrompt[]
   promptsTruncated: boolean
+  /**
+   * Number of prompts whose `prompt` field was missing or non-string at the
+   * upstream boundary. These prompts are still projected (their `uid`, `tag`,
+   * `selector`, `text`, and attachments survive) with `prompt: ''` and
+   * `promptTruncated: false`, and the count is exposed so the drop is
+   * auditable rather than a silent text substitution. An empty-string `prompt`
+   * (a legitimate "no text, attachments only" request) is **not** counted.
+   */
+  promptsMalformed: number
   artifactFailures: LavishArtifactFailure[]
   artifactFailuresTruncated: boolean
   domSnapshot: string
@@ -882,9 +926,11 @@ function cliFailure(body: Record<string, unknown>): LavishLocalFailure {
 function projectFeedback(body: Record<string, unknown>): LavishUntrustedFeedback {
   const rawPrompts = Array.isArray(body.prompts) ? body.prompts : []
   const prompts: LavishPrompt[] = []
+  let promptsMalformed = 0
   for (const raw of rawPrompts.slice(0, MAX_PROMPTS)) {
     const record = readRecord(raw)
     if (!record) continue
+    const tag = bound(readString(record.tag) ?? '', 64)
     const target = readRecord(record.target)
     const attachments: LavishAttachmentRef[] = []
     if (Array.isArray(record.attachments)) {
@@ -895,11 +941,18 @@ function projectFeedback(body: Record<string, unknown>): LavishUntrustedFeedback
         attachments.push({ id: bound(id, 128), name: bound(ref ? readString(ref.name) ?? '' : '', 256) })
       }
     }
+    const textRaw = readString(record.text)
+    const text = boundField(textRaw ?? '', MAX_PROMPT_FIELD_CHARS, MAX_PROMPT_FIELD_BYTES)
+    const promptProjection = projectUserPrompt(record.prompt)
+    if (promptProjection.malformed) promptsMalformed += 1
     prompts.push({
       uid: bound(readString(record.uid) ?? '', 128),
-      tag: bound(readString(record.tag) ?? '', 64),
+      tag,
       selector: bound(readString(record.selector) ?? '', 512),
-      text: bound(readString(record.text) ?? '', MAX_PROMPT_FIELD_CHARS),
+      text: text.value,
+      textTruncated: text.truncated,
+      prompt: promptProjection.value,
+      promptTruncated: promptProjection.truncated,
       ...(target && readString(target.type) ? { target: { type: bound(readString(target.type) as string, 64) } } : {}),
       attachments,
     })
@@ -926,11 +979,59 @@ function projectFeedback(body: Record<string, unknown>): LavishUntrustedFeedback
     trust: 'untrusted',
     prompts,
     promptsTruncated: rawPrompts.length > prompts.length,
+    promptsMalformed,
     artifactFailures,
     artifactFailuresTruncated: rawFailures.length > artifactFailures.length,
     domSnapshot,
     domSnapshotTruncated: snapshotBytes > MAX_DOM_SNAPSHOT_BYTES,
   }
+}
+
+/**
+ * Projects the upstream `prompt` field (the user instruction) without ever
+ * falling back to the `text` (selected-element context) field. A missing,
+ * empty, or non-string `prompt` is reported as malformed so the consumer can
+ * audit the drop instead of acting on a value that was substituted for it.
+ */
+function projectUserPrompt(raw: unknown): { value: string; truncated: boolean; malformed: boolean } {
+  if (typeof raw !== 'string') return { value: '', truncated: false, malformed: true }
+  return { ...boundField(raw, MAX_PROMPT_FIELD_CHARS, MAX_PROMPT_FIELD_BYTES), malformed: false }
+}
+
+/**
+ * Char- and byte-bounded string projection with an explicit truncation flag.
+ * Multi-byte UTF-8 sequences are never split: if the byte cap lands inside a
+ * sequence, the cut backs up to the start of that sequence.
+ */
+function boundField(raw: string, maxChars: number, maxBytes: number): { value: string; truncated: boolean } {
+  const charClipped = raw.length > maxChars
+  const charBounded = charClipped ? raw.slice(0, maxChars) : raw
+  if (!charClipped && Buffer.byteLength(charBounded, 'utf8') <= maxBytes) {
+    return { value: charBounded, truncated: false }
+  }
+  if (Buffer.byteLength(charBounded, 'utf8') <= maxBytes) {
+    return { value: charBounded, truncated: true }
+  }
+  return { value: truncateUtf8Bytes(charBounded, maxBytes), truncated: true }
+}
+
+function truncateUtf8Bytes(text: string, maxBytes: number): string {
+  const bytes = Buffer.from(text, 'utf8')
+  if (bytes.length <= maxBytes) return text
+  let pos = 0
+  while (pos < bytes.length) {
+    const byte = bytes[pos]
+    if (byte === undefined) break
+    const seqLen =
+      (byte & 0x80) === 0 ? 1 :
+      (byte & 0xE0) === 0xC0 ? 2 :
+      (byte & 0xF0) === 0xE0 ? 3 :
+      (byte & 0xF8) === 0xF0 ? 4 : -1
+    if (seqLen < 0) break
+    if (pos + seqLen > maxBytes) break
+    pos += seqLen
+  }
+  return bytes.subarray(0, pos).toString('utf8')
 }
 
 function normalizePollStatus(raw: string | null): LavishPollStatus | null {

--- a/ts/capabilities/lavish-local.ts
+++ b/ts/capabilities/lavish-local.ts
@@ -989,9 +989,11 @@ function projectFeedback(body: Record<string, unknown>): LavishUntrustedFeedback
 
 /**
  * Projects the upstream `prompt` field (the user instruction) without ever
- * falling back to the `text` (selected-element context) field. A missing,
- * empty, or non-string `prompt` is reported as malformed so the consumer can
- * audit the drop instead of acting on a value that was substituted for it.
+ * falling back to the `text` (selected-element context) field. Only a
+ * **missing or non-string** `prompt` is reported as malformed; an empty-string
+ * `prompt` is a legitimate "no text, attachments only" request and is
+ * preserved as data (not substituted, not flagged). Consumers audit the
+ * `malformed` flag instead of acting on a value that was substituted for it.
  */
 function projectUserPrompt(raw: unknown): { value: string; truncated: boolean; malformed: boolean } {
   if (typeof raw !== 'string') return { value: '', truncated: false, malformed: true }

--- a/ts/capabilities/lavish-local.ts
+++ b/ts/capabilities/lavish-local.ts
@@ -1,0 +1,1006 @@
+/**
+ * Local Lavish Editor (`lavish-axi`) session adapter for issue #443, parent #438.
+ *
+ * Scope: a bounded, explicit lifecycle API (open / poll / reply / end / stop) over
+ * the real `lavish-axi` CLI protocol. The adapter owns exactly the process group it
+ * spawns, the state directory it creates, and the loopback port it allocated; it
+ * never adopts, preempts, or kills a server it did not start, never writes to the
+ * artifact, and never calls the CLI's SDK self-upgrade (`update`), `setup hooks`,
+ * `setup plugin`, `share`, or `export`.
+ *
+ * Upstream: lavish-axi@0.1.67 (MIT), commit ca4c59d5b3ef84ae7f6f7f93fcaa415ade8a9c73.
+ * CLI stdout is TOON and is decoded with the official `@toon-format/toon` package;
+ * there is no `--json` mode. CLI failures also arrive on stdout as `{error, code}`.
+ *
+ * Trust boundary: everything the CLI prints about user feedback is untrusted data
+ * (see `LavishUntrustedFeedback`). It is preserved as bounded data and is never
+ * treated as system authority, never logged, and never used to touch the filesystem.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { createServer } from 'node:net'
+import { mkdir, mkdtemp, readFile, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, join, resolve, sep } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { decode } from '@toon-format/toon'
+
+export const LAVISH_AXI_PACKAGE = 'lavish-axi'
+export const LAVISH_AXI_VERSION = '0.1.67'
+export const LAVISH_AXI_ENTRY = 'dist/cli.mjs'
+export const LAVISH_MIN_NODE_MAJOR = 22
+export const LOOPBACK_HOST = '127.0.0.1'
+
+const DENIED_PATH_SEGMENTS = new Set(['.git', 'node_modules'])
+const SESSION_URL_RE = /\/session\/[0-9a-f]{16}/gi
+
+const MAX_PACKAGE_MANIFEST_BYTES = 64 * 1024
+const DEFAULT_MAX_STDOUT_BYTES = 4 * 1024 * 1024
+const DEFAULT_MAX_STDERR_BYTES = 64 * 1024
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000
+const DEFAULT_POLL_TIMEOUT_MS = 60_000
+const MAX_POLL_TIMEOUT_MS = 600_000
+const SERVER_START_TIMEOUT_MS = 15_000
+const SERVER_HEALTH_INTERVAL_MS = 100
+const KILL_GRACE_MS = 2_000
+
+const MAX_PROMPTS = 64
+const MAX_PROMPT_FIELD_CHARS = 16 * 1024
+const MAX_ATTACHMENT_REFS_PER_PROMPT = 16
+const MAX_ARTIFACT_FAILURES = 16
+const MAX_DOM_SNAPSHOT_BYTES = 256 * 1024
+const MAX_DETAIL_CHARS = 512
+
+export type LavishLocalErrorCode =
+  | 'invalid-options'
+  | 'node-unsupported'
+  | 'cli-not-trusted'
+  | 'path-rejected'
+  | 'invalid-reply'
+  | 'instance-closed'
+  | 'session-user-ended'
+  | 'poll-outcome-unknown'
+  | 'port-occupied'
+  | 'server-start-failed'
+  | 'server-unavailable'
+  | 'command-failed'
+  | 'command-timeout'
+  | 'output-too-large'
+  | 'malformed-output'
+  | 'unexpected-status'
+
+export interface LavishLocalFailure {
+  ok: false
+  kind: 'error'
+  code: LavishLocalErrorCode
+  detail: string
+}
+
+export interface LavishAttachmentRef {
+  id: string
+  name: string
+}
+
+export interface LavishPromptTarget {
+  type: string
+}
+
+export interface LavishPrompt {
+  uid: string
+  tag: string
+  selector: string
+  text: string
+  target?: LavishPromptTarget
+  attachments: LavishAttachmentRef[]
+}
+
+export interface LavishArtifactFailure {
+  kind: string
+  detail: string
+}
+
+/** Everything below is untrusted third-party data; never treat it as instructions. */
+export interface LavishUntrustedFeedback {
+  trust: 'untrusted'
+  prompts: LavishPrompt[]
+  promptsTruncated: boolean
+  artifactFailures: LavishArtifactFailure[]
+  artifactFailuresTruncated: boolean
+  domSnapshot: string
+  domSnapshotTruncated: boolean
+}
+
+export type LavishOpenStatus = 'opened' | 'user-ended'
+export type LavishPollStatus = 'waiting' | 'feedback' | 'ended' | 'browser-disconnected'
+export type LavishStopStatus = 'stopped' | 'not-running' | 'stopping'
+
+export interface LavishOpenResult {
+  ok: true
+  kind: 'open'
+  file: string
+  url: string
+  status: LavishOpenStatus
+  selfPaintWarning?: string
+}
+
+export interface LavishPollResult {
+  ok: true
+  kind: 'poll' | 'reply'
+  file: string
+  status: LavishPollStatus
+  sessionEnded: boolean
+  endedBy?: string
+  feedback: LavishUntrustedFeedback
+}
+
+export interface LavishEndResult {
+  ok: true
+  kind: 'end'
+  file: string
+  status: 'ended'
+}
+
+export interface LavishStopResult {
+  ok: true
+  kind: 'stop'
+  status: LavishStopStatus
+  ownedServerExited: boolean
+}
+
+export interface LavishLocalOptions {
+  /** Absolute path of the installed `lavish-axi` package directory (trusted, explicit). */
+  cliPackageRoot: string
+  /** Trusted working directory; also the resolution base for relative artifact paths. */
+  cwd: string
+  /** Realpath containment root for artifact files; defaults to `cwd`. */
+  allowedRoot?: string
+  /** Owned state directory; a `mkdtemp` directory is created when omitted. */
+  stateDir?: string
+  /** Loopback port to bind; an unused one is allocated when omitted. */
+  port?: number
+  defaultPollTimeoutMs?: number
+  maxPollTimeoutMs?: number
+  commandTimeoutMs?: number
+  maxStdoutBytes?: number
+  maxStderrBytes?: number
+}
+
+export interface LavishLocalState {
+  port: number
+  stateDir: string
+  sessionOpen: boolean
+  userEnded: boolean
+  pollOutcomeUnknown: boolean
+  closed: boolean
+}
+
+interface TrustedCli {
+  packageRoot: string
+  entry: string
+  version: string
+}
+
+interface ResolvedOptions {
+  cli: TrustedCli
+  cwd: string
+  allowedRoot: string
+  stateDir: string
+  port: number
+  defaultPollTimeoutMs: number
+  maxPollTimeoutMs: number
+  commandTimeoutMs: number
+  maxStdoutBytes: number
+  maxStderrBytes: number
+}
+
+interface OwnedRun {
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  timedOut: boolean
+  outputExceeded: boolean
+}
+
+/**
+ * Bounded local session over one owned `lavish-axi server` child process.
+ *
+ * One instance == one state directory + one loopback port + one owned process group.
+ * Every method performs at most one CLI invocation; the adapter never retries.
+ */
+export class LavishLocalSession {
+  private readonly options: ResolvedOptions
+  private server: ChildProcess | null = null
+  private serverDead = false
+  private sessionOpen = false
+  private userEnded = false
+  private pollOutcomeUnknown = false
+  private closed = false
+
+  private constructor(options: ResolvedOptions) {
+    this.options = options
+  }
+
+  static async create(options: LavishLocalOptions): Promise<LavishLocalSession> {
+    return new LavishLocalSession(await resolveOptions(options))
+  }
+
+  state(): LavishLocalState {
+    return {
+      port: this.options.port,
+      stateDir: this.options.stateDir,
+      sessionOpen: this.sessionOpen,
+      userEnded: this.userEnded,
+      pollOutcomeUnknown: this.pollOutcomeUnknown,
+      closed: this.closed,
+    }
+  }
+
+  /** Opens (or re-attaches to) the review session for an accepted HTML artifact path. */
+  async open(artifactPath: string): Promise<LavishOpenResult | LavishLocalFailure> {
+    const guard = this.guardNewCommand()
+    if (guard) return guard
+    if (this.userEnded) {
+      return fail('session-user-ended', 'the user ended this session; the adapter never reopens it')
+    }
+
+    const resolved = await this.resolveArtifact(artifactPath)
+    if ('code' in resolved) return resolved
+
+    const ready = await this.ensureServer()
+    if ('code' in ready) return ready
+
+    const run = await this.runCli(['open', resolved.file, '--no-open'])
+    if ('code' in run) return run
+
+    const decoded = decodeCliOutput(run.stdout)
+    if ('code' in decoded) return decoded
+
+    const body = decoded.value
+    if ('error' in body) return cliFailure(body)
+
+    const session = readRecord(body.session)
+    if (!session) return fail('malformed-output', 'open response has no session object')
+    if (session.file !== resolved.file) {
+      return fail('malformed-output', 'open response reported a different artifact path')
+    }
+    const status = readString(session.status)
+    if (status !== 'opened' && status !== 'user-ended') {
+      return fail('unexpected-status', `unsupported open status ${quote(status)}`)
+    }
+    const url = readString(session.url)
+    if (!url || !isLoopbackSessionUrl(url, this.options.port)) {
+      return fail('malformed-output', 'open response carried no loopback session url for this port')
+    }
+
+    this.sessionOpen = status === 'opened'
+    this.userEnded = status === 'user-ended'
+
+    const warning = readString(body.self_paint_warning)
+    return {
+      ok: true,
+      kind: 'open',
+      file: resolved.file,
+      url,
+      status,
+      ...(warning ? { selfPaintWarning: bound(warning, MAX_PROMPT_FIELD_CHARS) } : {}),
+    }
+  }
+
+  /**
+   * Waits up to `timeoutMs` for feedback, an end, or a browser disconnect.
+   * A `waiting` result consumed nothing and is safe to poll again.
+   */
+  async poll(artifactPath: string, options: { timeoutMs?: number } = {}): Promise<LavishPollResult | LavishLocalFailure> {
+    return this.pollLike('poll', artifactPath, undefined, options)
+  }
+
+  /**
+   * Answers feedback and waits for the next state in the same CLI invocation,
+   * mirroring the protocol's `poll <file> --agent-reply <text>`.
+   */
+  async reply(artifactPath: string, text: string, options: { timeoutMs?: number } = {}): Promise<LavishPollResult | LavishLocalFailure> {
+    if (typeof text !== 'string' || text.trim().length === 0) {
+      return fail('invalid-reply', 'reply text must be a non-empty string')
+    }
+    if (text === '--') {
+      return fail('invalid-reply', 'reply text must not be the bare flag terminator')
+    }
+    return this.pollLike('reply', artifactPath, text, options)
+  }
+
+  /** Ends the session. The owned server may exit on its own right after this. */
+  async end(artifactPath: string): Promise<LavishEndResult | LavishLocalFailure> {
+    const guard = this.guardNewCommand()
+    if (guard) return guard
+
+    const resolved = await this.resolveArtifact(artifactPath)
+    if ('code' in resolved) return resolved
+
+    const ready = await this.ensureServer()
+    if ('code' in ready) return ready
+
+    const run = await this.runCli(['end', resolved.file])
+    if ('code' in run) return run
+
+    const decoded = decodeCliOutput(run.stdout)
+    if ('code' in decoded) return decoded
+
+    const body = decoded.value
+    if ('error' in body) return cliFailure(body)
+
+    const session = readRecord(body.session)
+    const status = session ? readString(session.status) : null
+    if (status !== 'ended') {
+      return fail('unexpected-status', `unsupported end status ${quote(status)}`)
+    }
+    this.sessionOpen = false
+    this.userEnded = false
+    return { ok: true, kind: 'end', file: resolved.file, status: 'ended' }
+  }
+
+  /**
+   * Reaps only the server this instance started (process group SIGTERM, then
+   * SIGKILL, then a bounded wait). Idempotent: a server that already exited on its
+   * own yields `not-running`. A port held by anything else is reported, never touched.
+   */
+  async stop(): Promise<LavishStopResult | LavishLocalFailure> {
+    if (this.closed) return { ok: true, kind: 'stop', status: 'not-running', ownedServerExited: true }
+
+    const child = this.server
+    this.sessionOpen = false
+    this.pollOutcomeUnknown = false
+    this.server = null
+    this.closed = true
+
+    if (!child) return { ok: true, kind: 'stop', status: 'not-running', ownedServerExited: true }
+
+    const alreadyExited = this.serverDead || child.exitCode !== null || child.signalCode !== null
+    if (!alreadyExited) await terminateOwnedGroup(child)
+    const exited = child.exitCode !== null || child.signalCode !== null
+
+    if (await this.portIsFree()) {
+      return { ok: true, kind: 'stop', status: alreadyExited ? 'not-running' : 'stopped', ownedServerExited: true }
+    }
+    if (!exited) return { ok: true, kind: 'stop', status: 'stopping', ownedServerExited: false }
+    return fail('port-occupied', `loopback port ${this.options.port} is still held by a process this adapter does not own`)
+  }
+
+  private async pollLike(
+    kind: 'poll' | 'reply',
+    artifactPath: string,
+    replyText: string | undefined,
+    options: { timeoutMs?: number },
+  ): Promise<LavishPollResult | LavishLocalFailure> {
+    const guard = this.guardNewCommand()
+    if (guard) return guard
+
+    if (this.pollOutcomeUnknown) {
+      return fail(
+        'poll-outcome-unknown',
+        'the previous poll ended without a delivered outcome; polling again could double-consume feedback',
+      )
+    }
+
+    const timeoutMs = this.normalizePollTimeout(options.timeoutMs)
+    if ('code' in timeoutMs) return timeoutMs
+
+    const resolved = await this.resolveArtifact(artifactPath)
+    if ('code' in resolved) return resolved
+
+    const ready = await this.ensureServer()
+    if ('code' in ready) return ready
+
+    const argv = ['poll', resolved.file]
+    if (replyText !== undefined) argv.push('--agent-reply', replyText)
+    argv.push('--timeout-ms', String(timeoutMs.value))
+
+    const run = await this.runCli(argv, timeoutMs.value + this.options.commandTimeoutMs)
+    if ('code' in run) {
+      // A killed long-poll may or may not have consumed feedback; never retry silently.
+      if (run.code === 'command-timeout') this.pollOutcomeUnknown = true
+      return run
+    }
+
+    const decoded = decodeCliOutput(run.stdout)
+    if ('code' in decoded) {
+      this.pollOutcomeUnknown = true
+      return decoded
+    }
+
+    const body = decoded.value
+    if ('error' in body) {
+      this.pollOutcomeUnknown = true
+      return cliFailure(body)
+    }
+
+    const session = readRecord(body.session)
+    if (!session) return fail('malformed-output', 'poll response has no session object')
+    const raw = readString(session.status)
+    const status = normalizePollStatus(raw)
+    if (!status) return fail('unexpected-status', `unsupported poll status ${quote(raw)}`)
+
+    const endedBy = readString(session.ended_by) ?? undefined
+    if (endedBy === 'user' && (status === 'ended' || session.session_ended === true)) {
+      this.userEnded = true
+    }
+    if (status === 'ended') this.sessionOpen = false
+
+    return {
+      ok: true,
+      kind,
+      file: resolved.file,
+      status,
+      sessionEnded: session.session_ended === true,
+      ...(endedBy ? { endedBy } : {}),
+      feedback: projectFeedback(body),
+    }
+  }
+
+  private guardNewCommand(): LavishLocalFailure | null {
+    if (this.closed) return fail('instance-closed', 'this session was stopped; create a new instance')
+    return null
+  }
+
+  private normalizePollTimeout(value: unknown): { value: number } | LavishLocalFailure {
+    const requested = value === undefined ? this.options.defaultPollTimeoutMs : value
+    if (typeof requested !== 'number' || !Number.isInteger(requested) || requested <= 0) {
+      return fail('invalid-options', 'timeoutMs must be a positive integer')
+    }
+    if (requested > this.options.maxPollTimeoutMs) {
+      return fail('invalid-options', `timeoutMs must not exceed ${this.options.maxPollTimeoutMs}`)
+    }
+    return { value: requested }
+  }
+
+  private async resolveArtifact(input: unknown): Promise<{ file: string } | LavishLocalFailure> {
+    return resolveArtifactPath(input, this.options.cwd, this.options.allowedRoot)
+  }
+
+  private async runCli(argv: string[], timeoutMs = this.options.commandTimeoutMs): Promise<OwnedRun | LavishLocalFailure> {
+    return runOwnedProcess(process.execPath, [this.options.cli.entry, ...argv], {
+      cwd: this.options.cwd,
+      env: this.childEnv(),
+      timeoutMs,
+      maxStdoutBytes: this.options.maxStdoutBytes,
+      maxStderrBytes: this.options.maxStderrBytes,
+    })
+  }
+
+  private childEnv(): Record<string, string> {
+    return buildChildEnvironment(this.options.stateDir, this.options.port)
+  }
+
+  private async ensureServer(): Promise<{ ok: true } | LavishLocalFailure> {
+    if (this.ownedServerLive()) {
+      const health = await this.readHealth()
+      if (health === 'ours') return { ok: true }
+      if (health === 'foreign') {
+        return fail('port-occupied', `loopback port ${this.options.port} answered but is not this adapter's server`)
+      }
+      return fail('server-unavailable', 'the owned Lavish server stopped answering; create a new instance')
+    }
+
+    const probe = await this.readHealth()
+    if (probe !== 'free') {
+      return fail('port-occupied', `loopback port ${this.options.port} was already in use; this adapter never adopts it`)
+    }
+
+    const child = spawn(process.execPath, [this.options.cli.entry, 'server', '--port', String(this.options.port)], {
+      cwd: this.options.cwd,
+      env: this.childEnv(),
+      shell: false,
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    child.stdout?.resume()
+    child.stderr?.resume()
+    this.server = child
+    this.serverDead = false
+    child.once('close', () => {
+      this.serverDead = true
+    })
+    child.once('error', () => {
+      this.serverDead = true
+    })
+
+    const deadline = Date.now() + SERVER_START_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      if (this.serverDead) break
+      if ((await this.readHealth()) === 'ours') return { ok: true }
+      await delay(SERVER_HEALTH_INTERVAL_MS)
+    }
+
+    await terminateOwnedGroup(child)
+    this.server = null
+    return fail('server-start-failed', 'the owned Lavish server did not become healthy on the pinned version')
+  }
+
+  private ownedServerLive(): boolean {
+    const child = this.server
+    if (!child || this.serverDead) return false
+    return child.exitCode === null && child.signalCode === null
+  }
+
+  /**
+   * Own-port health probe. Only a live child of this instance plus a matching
+   * `app`/`version` payload counts as ours; any other answer is a foreign server
+   * this adapter must never adopt, preempt, or shut down.
+   */
+  private async readHealth(): Promise<'ours' | 'foreign' | 'free'> {
+    const body = await fetchHealth(this.options.port)
+    if (!body) return 'free'
+    if (!this.ownedServerLive()) return 'foreign'
+    if (body.app === LAVISH_AXI_PACKAGE && body.version === this.options.cli.version) return 'ours'
+    return 'foreign'
+  }
+
+  private async portIsFree(): Promise<boolean> {
+    return (await fetchHealth(this.options.port)) === null
+  }
+}
+
+async function resolveOptions(options: LavishLocalOptions): Promise<ResolvedOptions> {
+  if (!isPlainObject(options)) throw invalidOptions('options must be a plain object')
+
+  const nodeMajor = Number(process.versions.node.split('.')[0])
+  if (!Number.isInteger(nodeMajor) || nodeMajor < LAVISH_MIN_NODE_MAJOR) {
+    throw new LavishLocalError('node-unsupported', `${LAVISH_AXI_PACKAGE} requires Node >= ${LAVISH_MIN_NODE_MAJOR}`)
+  }
+
+  const cwd = await requireDirectory(options.cwd, 'cwd')
+  const allowedRoot = options.allowedRoot === undefined ? cwd : await requireDirectory(options.allowedRoot, 'allowedRoot')
+  const cli = await readTrustedCli(options.cliPackageRoot)
+  const stateDir = options.stateDir === undefined
+    ? await mkdtemp(join(tmpdir(), 'gotry-lavish-local-'))
+    : await requireDirectory(options.stateDir, 'stateDir')
+  await mkdir(join(stateDir, 'home'), { recursive: true })
+
+  const port = options.port === undefined ? await allocateUnusedLoopbackPort() : requirePort(options.port)
+
+  return {
+    cli,
+    cwd,
+    allowedRoot,
+    stateDir,
+    port,
+    defaultPollTimeoutMs: positiveInt(options.defaultPollTimeoutMs, DEFAULT_POLL_TIMEOUT_MS, 'defaultPollTimeoutMs'),
+    maxPollTimeoutMs: positiveInt(options.maxPollTimeoutMs, MAX_POLL_TIMEOUT_MS, 'maxPollTimeoutMs'),
+    commandTimeoutMs: positiveInt(options.commandTimeoutMs, DEFAULT_COMMAND_TIMEOUT_MS, 'commandTimeoutMs'),
+    maxStdoutBytes: positiveInt(options.maxStdoutBytes, DEFAULT_MAX_STDOUT_BYTES, 'maxStdoutBytes'),
+    maxStderrBytes: positiveInt(options.maxStderrBytes, DEFAULT_MAX_STDERR_BYTES, 'maxStderrBytes'),
+  }
+}
+
+export class LavishLocalError extends Error {
+  readonly code: LavishLocalErrorCode
+  constructor(code: LavishLocalErrorCode, detail: string) {
+    super(detail)
+    this.name = 'LavishLocalError'
+    this.code = code
+  }
+}
+
+/** Resolves the trusted CLI: exact package name, exact pinned version, exact entry. */
+export async function readTrustedCli(cliPackageRoot: unknown): Promise<TrustedCli> {
+  const packageRoot = await requireDirectory(cliPackageRoot, 'cliPackageRoot')
+
+  const manifestPath = join(packageRoot, 'package.json')
+  let raw: string
+  try {
+    const info = await stat(manifestPath)
+    if (!info.isFile() || info.size > MAX_PACKAGE_MANIFEST_BYTES) {
+      throw new LavishLocalError('cli-not-trusted', 'the lavish-axi package.json is not a bounded regular file')
+    }
+    raw = await readFile(manifestPath, 'utf8')
+  } catch (error) {
+    if (error instanceof LavishLocalError) throw error
+    throw new LavishLocalError('cli-not-trusted', 'no readable package.json in the supplied lavish-axi package root')
+  }
+
+  let manifest: unknown
+  try {
+    manifest = JSON.parse(raw)
+  } catch {
+    throw new LavishLocalError('cli-not-trusted', 'the lavish-axi package.json is not valid JSON')
+  }
+  if (!isPlainObject(manifest)) throw new LavishLocalError('cli-not-trusted', 'the lavish-axi package.json is not an object')
+
+  if (manifest.name !== LAVISH_AXI_PACKAGE) {
+    throw new LavishLocalError('cli-not-trusted', `expected package ${LAVISH_AXI_PACKAGE}, refused`)
+  }
+  if (manifest.version !== LAVISH_AXI_VERSION) {
+    throw new LavishLocalError('cli-not-trusted', `expected ${LAVISH_AXI_PACKAGE}@${LAVISH_AXI_VERSION}, refused`)
+  }
+
+  const bin = isPlainObject(manifest.bin) ? manifest.bin[LAVISH_AXI_PACKAGE] : undefined
+  if (typeof bin !== 'string' || bin !== LAVISH_AXI_ENTRY) {
+    throw new LavishLocalError('cli-not-trusted', `expected bin.${LAVISH_AXI_PACKAGE} to be ${LAVISH_AXI_ENTRY}, refused`)
+  }
+
+  const entryPath = join(packageRoot, LAVISH_AXI_ENTRY)
+  let entry: string
+  try {
+    entry = await realpath(entryPath)
+  } catch {
+    throw new LavishLocalError('cli-not-trusted', `the declared entry ${LAVISH_AXI_ENTRY} is missing`)
+  }
+  if (!isInside(packageRoot, entry)) {
+    throw new LavishLocalError('cli-not-trusted', 'the declared entry escapes the package root')
+  }
+  const info = await stat(entry)
+  if (!info.isFile()) throw new LavishLocalError('cli-not-trusted', 'the declared entry is not a regular file')
+
+  return { packageRoot, entry, version: LAVISH_AXI_VERSION }
+}
+
+/**
+ * Accepts only `.html`/`.htm` files whose realpath stays inside `allowedRoot`,
+ * with `.git`/`node_modules` denied. Relative input resolves against `cwd`. Both
+ * roots are canonicalised first and symlinks are resolved before containment, so a
+ * symlink pointing outside the root is rejected rather than followed.
+ */
+export async function resolveArtifactPath(input: unknown, cwd: string, allowedRoot: string): Promise<{ ok: true; file: string } | LavishLocalFailure> {
+  if (typeof input !== 'string' || input.length === 0) {
+    return fail('path-rejected', 'artifact path must be a non-empty string')
+  }
+  if (input.includes('\0')) return fail('path-rejected', 'artifact path must not contain NUL')
+
+  const lower = input.toLowerCase()
+  if (!lower.endsWith('.html') && !lower.endsWith('.htm')) {
+    return fail('path-rejected', 'only .html/.htm artifacts are accepted')
+  }
+
+  const realCwd = await safeRealpath(cwd)
+  const realRoot = await safeRealpath(allowedRoot)
+  const absolute = isAbsolute(input) ? resolve(input) : resolve(realCwd, input)
+
+  let file: string
+  try {
+    file = await realpath(absolute)
+  } catch {
+    return fail('path-rejected', 'artifact path does not exist')
+  }
+
+  if (!isInside(realRoot, file)) return fail('path-rejected', 'artifact real path escapes allowedRoot')
+  const info = await stat(file)
+  if (!info.isFile()) return fail('path-rejected', 'artifact path is not a regular file')
+
+  const segments = file.slice(realRoot.length).split(sep).filter(Boolean)
+  for (const segment of segments) {
+    if (DENIED_PATH_SEGMENTS.has(segment)) {
+      return fail('path-rejected', `artifact path must not pass through ${segment}`)
+    }
+  }
+  return { ok: true, file }
+}
+
+async function safeRealpath(path: string): Promise<string> {
+  try {
+    return await realpath(path)
+  } catch {
+    return resolve(path)
+  }
+}
+
+/**
+ * Minimal, explicit child environment. Nothing is inherited except PATH, so no
+ * ambient `LAVISH_AXI_*` (host/telemetry/state overrides) or Tailscale variables
+ * can reach the child. `HOME` points at the owned state directory so no global
+ * `~/.lavish-axi` configuration or hook file can be read or written.
+ */
+export function buildChildEnvironment(stateDir: string, port: number): Record<string, string> {
+  return {
+    PATH: process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin',
+    HOME: join(stateDir, 'home'),
+    LAVISH_AXI_STATE_DIR: stateDir,
+    LAVISH_AXI_PORT: String(port),
+    LAVISH_AXI_HOST: LOOPBACK_HOST,
+    LAVISH_AXI_LINK_HOST: LOOPBACK_HOST,
+    LAVISH_AXI_TELEMETRY: '0',
+    LAVISH_AXI_NO_OPEN: '1',
+  }
+}
+
+export async function allocateUnusedLoopbackPort(): Promise<number> {
+  const probe = createServer()
+  try {
+    await new Promise<void>((resolveListen, rejectListen) => {
+      probe.once('error', rejectListen)
+      probe.listen(0, LOOPBACK_HOST, resolveListen)
+    })
+    const address = probe.address()
+    if (!address || typeof address === 'string') throw new LavishLocalError('invalid-options', 'no loopback port was allocated')
+    return address.port
+  } finally {
+    await new Promise<void>((resolveClose) => probe.close(() => resolveClose()))
+  }
+}
+
+async function fetchHealth(port: number): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${port}/health`, {
+      signal: AbortSignal.timeout(2_000),
+    })
+    if (!response.ok) return null
+    const body: unknown = await response.json()
+    return isPlainObject(body) ? body : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Runs one CLI invocation in its own process group and always reaps it before
+ * returning. Arguments are passed as an array with `shell: false`; no command
+ * string is ever assembled.
+ */
+async function runOwnedProcess(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: Record<string, string>; timeoutMs: number; maxStdoutBytes: number; maxStderrBytes: number },
+): Promise<OwnedRun | LavishLocalFailure> {
+  let child: ChildProcess
+  try {
+    child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: false,
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch {
+    return fail('command-failed', 'the Lavish CLI could not be started')
+  }
+
+  const stdoutChunks: Buffer[] = []
+  const stderrChunks: Buffer[] = []
+  let stdoutBytes = 0
+  let stderrBytes = 0
+  let outputExceeded = false
+  let timedOut = false
+
+  const closePromise = new Promise<void>((resolveClose) => {
+    child.once('close', () => resolveClose())
+    child.once('error', () => resolveClose())
+  })
+
+  const kill = (reason: 'timeout' | 'overflow'): void => {
+    if (reason === 'timeout') timedOut = true
+    else outputExceeded = true
+    void terminateOwnedGroup(child)
+  }
+
+  const timer = setTimeout(() => kill('timeout'), options.timeoutMs)
+  child.stdout?.on('data', (chunk: Buffer) => {
+    stdoutBytes += chunk.length
+    if (stdoutBytes > options.maxStdoutBytes) {
+      kill('overflow')
+      return
+    }
+    stdoutChunks.push(chunk)
+  })
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderrBytes += chunk.length
+    if (stderrBytes > options.maxStderrBytes) {
+      kill('overflow')
+      return
+    }
+    stderrChunks.push(chunk)
+  })
+
+  await closePromise
+  clearTimeout(timer)
+
+  if (timedOut) return fail('command-timeout', 'the Lavish CLI exceeded the adapter deadline')
+  if (outputExceeded) return fail('output-too-large', 'the Lavish CLI wrote more bytes than the adapter accepts')
+
+  return {
+    exitCode: child.exitCode,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8'),
+    timedOut,
+    outputExceeded,
+  }
+}
+
+/** SIGTERM to the owned process group, then SIGKILL, then a bounded wait. */
+async function terminateOwnedGroup(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  signalGroup(child, 'SIGTERM')
+  if (await settledWithin(child, KILL_GRACE_MS)) return
+  signalGroup(child, 'SIGKILL')
+  await settledWithin(child, KILL_GRACE_MS)
+}
+
+function signalGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  const pid = child.pid
+  if (pid !== undefined) {
+    try {
+      process.kill(-pid, signal)
+      return
+    } catch {
+      // fall through to the direct kill below
+    }
+  }
+  try {
+    child.kill(signal)
+  } catch {
+    // the process is already gone
+  }
+}
+
+function settledWithin(child: ChildProcess, ms: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true)
+  return new Promise<boolean>((resolveSettled) => {
+    const timer = setTimeout(() => resolveSettled(false), ms)
+    child.once('close', () => {
+      clearTimeout(timer)
+      resolveSettled(true)
+    })
+  })
+}
+
+function decodeCliOutput(stdout: string): { value: Record<string, unknown> } | LavishLocalFailure {
+  let decoded: unknown
+  try {
+    decoded = decode(stdout)
+  } catch {
+    return fail('malformed-output', 'the Lavish CLI stdout was not decodable TOON')
+  }
+  if (!isPlainObject(decoded)) return fail('malformed-output', 'the Lavish CLI stdout was not a TOON object')
+  return { value: decoded }
+}
+
+function cliFailure(body: Record<string, unknown>): LavishLocalFailure {
+  const code = readString(body.code) ?? 'UNKNOWN'
+  const message = readString(body.error) ?? 'the Lavish CLI reported an error'
+  return fail('command-failed', `${bound(code, 64)}: ${bound(redact(message), MAX_DETAIL_CHARS)}`)
+}
+
+function projectFeedback(body: Record<string, unknown>): LavishUntrustedFeedback {
+  const rawPrompts = Array.isArray(body.prompts) ? body.prompts : []
+  const prompts: LavishPrompt[] = []
+  for (const raw of rawPrompts.slice(0, MAX_PROMPTS)) {
+    const record = readRecord(raw)
+    if (!record) continue
+    const target = readRecord(record.target)
+    const attachments: LavishAttachmentRef[] = []
+    if (Array.isArray(record.attachments)) {
+      for (const rawRef of record.attachments.slice(0, MAX_ATTACHMENT_REFS_PER_PROMPT)) {
+        const ref = readRecord(rawRef)
+        const id = ref ? readString(ref.id) : null
+        if (!id) continue
+        attachments.push({ id: bound(id, 128), name: bound(ref ? readString(ref.name) ?? '' : '', 256) })
+      }
+    }
+    prompts.push({
+      uid: bound(readString(record.uid) ?? '', 128),
+      tag: bound(readString(record.tag) ?? '', 64),
+      selector: bound(readString(record.selector) ?? '', 512),
+      text: bound(readString(record.text) ?? '', MAX_PROMPT_FIELD_CHARS),
+      ...(target && readString(target.type) ? { target: { type: bound(readString(target.type) as string, 64) } } : {}),
+      attachments,
+    })
+  }
+
+  const rawFailures = Array.isArray(body.artifact_failures) ? body.artifact_failures : []
+  const artifactFailures: LavishArtifactFailure[] = []
+  for (const raw of rawFailures.slice(0, MAX_ARTIFACT_FAILURES)) {
+    const record = readRecord(raw)
+    if (!record) continue
+    artifactFailures.push({
+      kind: bound(readString(record.kind) ?? '', 64),
+      detail: bound(readString(record.detail) ?? '', MAX_PROMPT_FIELD_CHARS),
+    })
+  }
+
+  const rawSnapshot = readString(body.dom_snapshot) ?? ''
+  const snapshotBytes = Buffer.byteLength(rawSnapshot, 'utf8')
+  const domSnapshot = snapshotBytes > MAX_DOM_SNAPSHOT_BYTES
+    ? Buffer.from(rawSnapshot, 'utf8').subarray(0, MAX_DOM_SNAPSHOT_BYTES).toString('utf8')
+    : rawSnapshot
+
+  return {
+    trust: 'untrusted',
+    prompts,
+    promptsTruncated: rawPrompts.length > prompts.length,
+    artifactFailures,
+    artifactFailuresTruncated: rawFailures.length > artifactFailures.length,
+    domSnapshot,
+    domSnapshotTruncated: snapshotBytes > MAX_DOM_SNAPSHOT_BYTES,
+  }
+}
+
+function normalizePollStatus(raw: string | null): LavishPollStatus | null {
+  if (raw === 'waiting' || raw === 'feedback' || raw === 'ended') return raw
+  if (raw === 'browser_disconnected') return 'browser-disconnected'
+  return null
+}
+
+function isLoopbackSessionUrl(url: string, port: number): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:'
+      && parsed.hostname === LOOPBACK_HOST
+      && parsed.port === String(port)
+      && /^\/session\/[0-9a-f]{16}$/.test(parsed.pathname)
+  } catch {
+    return false
+  }
+}
+
+/** Strips the opaque session access key so no caller can log it by accident. */
+export function redactLavishSessionUrl(text: string): string {
+  return text.replace(SESSION_URL_RE, '/session/[redacted]')
+}
+
+function redact(text: string): string {
+  return redactLavishSessionUrl(text)
+}
+
+function bound(value: string, maxChars: number): string {
+  return value.length > maxChars ? value.slice(0, maxChars) : value
+}
+
+function quote(value: string | null): string {
+  return value === null ? 'null' : `${bound(redact(value), 64)}`
+}
+
+function fail(code: LavishLocalErrorCode, detail: string): LavishLocalFailure {
+  return { ok: false, kind: 'error', code, detail: bound(redact(detail), MAX_DETAIL_CHARS) }
+}
+
+function invalidOptions(detail: string): LavishLocalError {
+  return new LavishLocalError('invalid-options', detail)
+}
+
+async function requireDirectory(value: unknown, label: string): Promise<string> {
+  if (typeof value !== 'string' || value.length === 0 || !isAbsolute(value)) {
+    throw invalidOptions(`${label} must be an absolute path`)
+  }
+  let resolved: string
+  try {
+    resolved = await realpath(value)
+  } catch {
+    throw invalidOptions(`${label} does not exist`)
+  }
+  const info = await stat(resolved)
+  if (!info.isDirectory()) throw invalidOptions(`${label} is not a directory`)
+  return resolved
+}
+
+function requirePort(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 65535) {
+    throw invalidOptions('port must be an integer in [1, 65535]')
+  }
+  return value
+}
+
+function positiveInt(value: unknown, fallback: number, label: string): number {
+  if (value === undefined) return fallback
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw invalidOptions(`${label} must be a positive integer`)
+  }
+  return value
+}
+
+function isInside(root: string, candidate: string): boolean {
+  if (candidate === root) return false
+  return candidate.startsWith(root.endsWith(sep) ? root : root + sep)
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms))
+}

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -13,6 +13,7 @@
         "@deepseek-ai/dsh-session": "0.1.5-rc.1",
         "@deepseek-ai/dsh-tools": "0.1.5-rc.1",
         "@deepseek-ai/schemastery": "^3.18.2",
+        "@toon-format/toon": "2.3.1",
         "@types/better-sqlite3": "^9.6.0",
         "better-sqlite3": "^13.0.3",
         "z3-solver": "^5.2.0"
@@ -6398,6 +6399,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@toon-format/toon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.1.tgz",
+      "integrity": "sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==",
       "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -15,6 +15,7 @@
     "@deepseek-ai/dsh-session": "0.1.5-rc.1",
     "@deepseek-ai/dsh-tools": "0.1.5-rc.1",
     "@deepseek-ai/schemastery": "^3.18.2",
+    "@toon-format/toon": "2.3.1",
     "@types/better-sqlite3": "^9.6.0",
     "better-sqlite3": "^13.0.3",
     "z3-solver": "^5.2.0"

--- a/ts/scripts/lavish-local-tests.ts
+++ b/ts/scripts/lavish-local-tests.ts
@@ -127,6 +127,7 @@ if (command === 'server') {
     next_step: 'synthetic next_step must never be surfaced as authority',
     ...(open.self_paint_warning ? { self_paint_warning: open.self_paint_warning } : {}),
   })
+  if (open.exitCode) process.exitCode = open.exitCode
 } else if (command === 'poll') {
   writeFileSync(join(stateDir, 'poll.pid'), String(process.pid))
   const poll = cfg.poll || {}
@@ -147,6 +148,7 @@ if (command === 'server') {
         dom_snapshot: poll.dom_snapshot || '',
       })
     }
+    if (poll.exitCode) process.exitCode = poll.exitCode
   }
   const sleepMs = Number(poll.sleepMs || 0)
   if (sleepMs > 0) setTimeout(finish, sleepMs)
@@ -155,6 +157,7 @@ if (command === 'server') {
   const end = cfg.end || {}
   if (end.error) emit({ error: end.error, code: end.code || 'SERVER_ERROR' })
   else emit({ session: { file: end.file || argv[1], status: end.status || 'ended' } })
+  if (end.exitCode) process.exitCode = end.exitCode
 } else {
   emit({ error: 'Unknown command: ' + command, code: 'VALIDATION_ERROR' })
   process.exitCode = 2
@@ -501,6 +504,92 @@ try {
     const cliError = expectFailure(await errorSession.open(ARTIFACT), 'command-failed')
     ok(cliError.detail.includes('SERVER_ERROR'), `the CLI error code is preserved: ${cliError.detail}`)
     await errorSession.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 5b. an unreadable poll response locks consumption, because it may already
+  //     have consumed a once-only feedback delivery
+  // -------------------------------------------------------------------------
+
+  {
+    const unreadable = await controlSession('poll-missing-session', { poll: { stdoutRaw: 'status: whatever\n' } })
+    expectFailure(await unreadable.poll(ARTIFACT), 'malformed-output')
+    ok(unreadable.state().pollOutcomeUnknown === true, 'a poll response with no session object latches the unknown outcome')
+    const argvAfterFirst = (await readJsonl(join(unreadable.state().stateDir, 'argv.jsonl'))).length
+    expectFailure(await unreadable.poll(ARTIFACT), 'poll-outcome-unknown')
+    expectFailure(await unreadable.reply(ARTIFACT, 'a reply that must not be sent'), 'poll-outcome-unknown')
+    const argvAfterRefusals = (await readJsonl(join(unreadable.state().stateDir, 'argv.jsonl'))).length
+    ok(argvAfterRefusals === argvAfterFirst, `no further CLI invocation was made: ${argvAfterFirst} -> ${argvAfterRefusals}`)
+    await unreadable.stop()
+
+    const mystery = await controlSession('poll-mystery-latch', { poll: { status: 'mystery' } })
+    expectFailure(await mystery.poll(ARTIFACT), 'unexpected-status')
+    ok(mystery.state().pollOutcomeUnknown === true, 'an unreadable poll status latches the unknown outcome')
+    const argvAfterMystery = (await readJsonl(join(mystery.state().stateDir, 'argv.jsonl'))).length
+    expectFailure(await mystery.poll(ARTIFACT), 'poll-outcome-unknown')
+    expectFailure(await mystery.reply(ARTIFACT, 'another reply that must not be sent'), 'poll-outcome-unknown')
+    ok(
+      (await readJsonl(join(mystery.state().stateDir, 'argv.jsonl'))).length === argvAfterMystery,
+      'a latched instance spawns nothing further',
+    )
+    await mystery.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 5c. a non-zero exit code is never accepted as success, even with
+  //     well-formed TOON on stdout
+  // -------------------------------------------------------------------------
+
+  {
+    const openExit = await controlSession('open-exit2', { open: { status: 'opened', exitCode: 2 } })
+    expectFailure(await openExit.open(ARTIFACT), 'command-failed')
+    ok(openExit.state().sessionOpen === false, 'a failed open never marks the session open')
+    await openExit.stop()
+
+    const endExit = await controlSession('end-exit2', { end: { status: 'ended', exitCode: 2 } })
+    expectFailure(await endExit.end(ARTIFACT), 'command-failed')
+    await endExit.stop()
+
+    const pollExit = await controlSession('poll-exit2', { poll: { status: 'waiting', exitCode: 2 } })
+    expectFailure(await pollExit.poll(ARTIFACT), 'command-failed')
+    ok(pollExit.state().pollOutcomeUnknown === true, 'a non-zero poll exit latches the unknown outcome')
+    const argvAfterPoll = (await readJsonl(join(pollExit.state().stateDir, 'argv.jsonl'))).length
+    expectFailure(await pollExit.poll(ARTIFACT), 'poll-outcome-unknown')
+    ok(
+      (await readJsonl(join(pollExit.state().stateDir, 'argv.jsonl'))).length === argvAfterPoll,
+      'a poll that exited non-zero is not retried',
+    )
+    await pollExit.stop()
+
+    const feedbackExit = await controlSession('feedback-exit2', {
+      poll: { status: 'feedback', prompts: [{ uid: 'u', tag: 'note', text: PROMPT_TEXT_SENTINEL, selector: '#a' }], exitCode: 2 },
+    })
+    const feedbackFailure = expectFailure(await feedbackExit.poll(ARTIFACT), 'command-failed')
+    ok(!feedbackFailure.detail.includes(PROMPT_TEXT_SENTINEL), 'a rejected feedback payload is not echoed into the failure detail')
+    ok(feedbackExit.state().pollOutcomeUnknown === true, 'a rejected feedback delivery also latches')
+    await feedbackExit.stop()
+
+    const structured = await controlSession('exit-with-error', {
+      open: { error: 'Lavish Editor request failed: 500', code: 'SERVER_ERROR', exitCode: 2 },
+    })
+    const structuredFailure = expectFailure(await structured.open(ARTIFACT), 'command-failed')
+    ok(structuredFailure.detail.includes('SERVER_ERROR'), `the structured CLI error wins over the exit code: ${structuredFailure.detail}`)
+    await structured.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 5d. reply text is bounded at runtime, before any argv or spawn
+  // -------------------------------------------------------------------------
+
+  {
+    const session = await controlSession('oversized-reply', {})
+    expectFailure(await session.reply(ARTIFACT, 'x'.repeat(2 * 1024 * 1024)), 'invalid-reply')
+    expectFailure(await session.reply(ARTIFACT, 'x'.repeat(20_000)), 'invalid-reply')
+    expectFailure(await session.reply(ARTIFACT, '\u{1D11E}'.repeat(8_000)), 'invalid-reply')
+    const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
+    ok(argv.length === 0, `an oversized or over-bytes reply spawns nothing: ${JSON.stringify(argv)}`)
+    const stopped = await session.stop()
+    ok(stopped.ok === true, 'an instance that only rejected replies still stops cleanly')
   }
 
   // -------------------------------------------------------------------------

--- a/ts/scripts/lavish-local-tests.ts
+++ b/ts/scripts/lavish-local-tests.ts
@@ -1,0 +1,854 @@
+/**
+ * Local Lavish Editor adapter tests (issue #443, parent #438).
+ *
+ * Offline section: a synthetic `lavish-axi` package tree exercises the adapter's
+ * trust checks, path allowlist, argv shape, byte/timeout bounds, state machine,
+ * process-group reaping, and lifecycle rules. Nothing here touches the network,
+ * a real browser, or any real Lavish installation.
+ *
+ * Live section (opt-in, GOTRY_LAVISH_LIVE=1): installs the pinned `lavish-axi@0.1.67`
+ * into a unique mkdtemp-scoped npm prefix from the public registry and runs the real
+ * CLI open / poll(waiting) / end / stop protocol against a synthetic HTML fixture.
+ *
+ * Run: cd ts && npx tsx scripts/lavish-local-tests.ts
+ *      cd ts && GOTRY_LAVISH_LIVE=1 npx tsx scripts/lavish-local-tests.ts
+ */
+
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { spawn, spawnSync } from 'node:child_process'
+import { createServer } from 'node:http'
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  LAVISH_AXI_VERSION,
+  LavishLocalError,
+  LavishLocalSession,
+  allocateUnusedLoopbackPort,
+  buildChildEnvironment,
+  readTrustedCli,
+  resolveArtifactPath,
+  type LavishLocalFailure,
+} from '../capabilities/lavish-local.ts'
+
+const TOON_ENTRY = createRequire(import.meta.url).resolve('@toon-format/toon')
+const workRoot = await mkdtemp(join(tmpdir(), 'gotry-lavish-local-tests-'))
+
+let assertions = 0
+function ok(condition: unknown, detail: string): void {
+  assertions += 1
+  assert.ok(condition, detail)
+}
+
+function expectFailure(result: { ok: boolean }, code: string): LavishLocalFailure {
+  assertions += 1
+  assert.equal(result.ok, false, `expected failure(${code}), got ${JSON.stringify(result)}`)
+  const failure = result as LavishLocalFailure
+  assert.equal(failure.code, code, `expected code ${code}, got ${failure.code} (${failure.detail})`)
+  assertNoLeak(failure.detail)
+  return failure
+}
+
+const PROMPT_TEXT_SENTINEL = 'prompt-text-sentinel-must-not-leak'
+const REPLY_SENTINEL = 'reply-sentinel-must-not-leak'
+
+function assertNoLeak(text: string): void {
+  assertions += 1
+  assert.ok(!text.includes(PROMPT_TEXT_SENTINEL), `leaked prompt text: ${text}`)
+  assert.ok(!text.includes(REPLY_SENTINEL), `leaked reply text: ${text}`)
+}
+
+// ---------------------------------------------------------------------------
+// synthetic lavish-axi package
+// ---------------------------------------------------------------------------
+
+const FAKE_CLI_BODY = `
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { join } from 'node:path'
+import { encode } from ${JSON.stringify(TOON_ENTRY)}
+
+const stateDir = process.env.LAVISH_AXI_STATE_DIR
+const port = Number(process.env.LAVISH_AXI_PORT)
+const argv = process.argv.slice(2)
+
+appendFileSync(join(stateDir, 'argv.jsonl'), JSON.stringify(argv) + '\\n')
+appendFileSync(join(stateDir, 'env.jsonl'), JSON.stringify(process.env) + '\\n')
+
+function control() {
+  try {
+    return JSON.parse(readFileSync(join(stateDir, 'control.json'), 'utf8'))
+  } catch {
+    return {}
+  }
+}
+function emit(value) {
+  process.stdout.write(encode(value) + '\\n')
+}
+function sessionUrl() {
+  return 'http://127.0.0.1:' + port + '/session/' + 'a'.repeat(16)
+}
+function writeOversize(stream, bytes) {
+  const chunk = 'x'.repeat(64 * 1024)
+  let written = 0
+  while (written < bytes) {
+    stream.write(chunk)
+    written += chunk.length
+  }
+}
+
+const command = argv[0]
+const cfg = control()
+
+if (command === 'server') {
+  writeFileSync(join(stateDir, 'server.pid'), String(process.pid))
+  const server = createServer((req, res) => {
+    if (req.url && req.url.indexOf('/health') === 0) {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ ok: true, app: 'lavish-axi', version: '${LAVISH_AXI_VERSION}' }))
+      return
+    }
+    res.statusCode = 404
+    res.end('{}')
+  })
+  server.listen(port, '127.0.0.1')
+  process.on('SIGTERM', () => { server.close(() => process.exit(0)); setTimeout(() => process.exit(0), 200) })
+} else if (command === 'open') {
+  const file = argv[1]
+  const open = cfg.open || {}
+  if (open.oversizeStdout) writeOversize(process.stdout, open.oversizeStdout)
+  else if (open.oversizeStderr) writeOversize(process.stderr, open.oversizeStderr)
+  else if (open.stdoutRaw !== undefined) process.stdout.write(open.stdoutRaw)
+  else if (open.error) emit({ error: open.error, code: open.code || 'SERVER_ERROR' })
+  else emit({
+    session: { file: open.file || file, url: open.url || sessionUrl(), status: open.status || 'opened' },
+    next_step: 'synthetic next_step must never be surfaced as authority',
+    ...(open.self_paint_warning ? { self_paint_warning: open.self_paint_warning } : {}),
+  })
+} else if (command === 'poll') {
+  writeFileSync(join(stateDir, 'poll.pid'), String(process.pid))
+  const poll = cfg.poll || {}
+  const finish = () => {
+    if (poll.oversizeStdout) writeOversize(process.stdout, poll.oversizeStdout)
+    else if (poll.oversizeStderr) writeOversize(process.stderr, poll.oversizeStderr)
+    else if (poll.stdoutRaw !== undefined) process.stdout.write(poll.stdoutRaw)
+    else if (poll.error) emit({ error: poll.error, code: poll.code || 'SERVER_ERROR' })
+    else {
+      const status = poll.status || 'waiting'
+      emit({
+        session: {
+          file: poll.file || argv[1],
+          status,
+          ...(poll.session_ended ? { session_ended: true, ended_by: poll.ended_by || 'user' } : {}),
+        },
+        ...(status === 'feedback' ? { prompts: poll.prompts || [], artifact_failures: poll.artifact_failures || [] } : {}),
+        dom_snapshot: poll.dom_snapshot || '',
+      })
+    }
+  }
+  const sleepMs = Number(poll.sleepMs || 0)
+  if (sleepMs > 0) setTimeout(finish, sleepMs)
+  else finish()
+} else if (command === 'end') {
+  const end = cfg.end || {}
+  if (end.error) emit({ error: end.error, code: end.code || 'SERVER_ERROR' })
+  else emit({ session: { file: end.file || argv[1], status: end.status || 'ended' } })
+} else {
+  emit({ error: 'Unknown command: ' + command, code: 'VALIDATION_ERROR' })
+  process.exitCode = 2
+}
+`
+
+const fakePackageRoot = join(workRoot, 'fake-package', LAVISH_AXI_VERSION)
+await mkdir(join(fakePackageRoot, 'dist'), { recursive: true })
+await writeFile(join(fakePackageRoot, 'dist', 'cli.mjs'), FAKE_CLI_BODY)
+
+function writeManifest(root: string, manifest: unknown): Promise<void> {
+  return writeFile(join(root, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+}
+await writeManifest(fakePackageRoot, {
+  name: 'lavish-axi',
+  version: LAVISH_AXI_VERSION,
+  bin: { 'lavish-axi': 'dist/cli.mjs' },
+})
+
+await mkdir(join(workRoot, 'artifacts'), { recursive: true })
+const artifactRoot = await realpath(join(workRoot, 'artifacts'))
+const ARTIFACT = join(artifactRoot, 'card.html')
+const ARTIFACT_BODY = '<!doctype html><html><body><h1>synthetic card</h1></body></html>\n'
+await writeFile(ARTIFACT, ARTIFACT_BODY)
+
+async function freshStateDir(label: string): Promise<string> {
+  return mkdtemp(join(workRoot, `state-${label}-`))
+}
+
+async function sessionFor(stateDir: string, extra: Record<string, unknown> = {}): Promise<LavishLocalSession> {
+  return LavishLocalSession.create({
+    cliPackageRoot: fakePackageRoot,
+    cwd: artifactRoot,
+    allowedRoot: artifactRoot,
+    stateDir,
+    defaultPollTimeoutMs: 300,
+    maxPollTimeoutMs: 5_000,
+    commandTimeoutMs: 3_000,
+    ...extra,
+  })
+}
+
+/** Creates a session whose control file is already in place. */
+async function controlSession(label: string, control: unknown, extra: Record<string, unknown> = {}): Promise<LavishLocalSession> {
+  const stateDir = await freshStateDir(label)
+  await writeControl(stateDir, control)
+  return sessionFor(stateDir, extra)
+}
+
+async function readJsonl(path: string): Promise<string[][]> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return raw.split('\n').filter(Boolean).map((line) => JSON.parse(line) as string[])
+  } catch {
+    return []
+  }
+}
+
+async function writeControl(stateDir: string, control: unknown): Promise<void> {
+  await writeFile(join(stateDir, 'control.json'), JSON.stringify(control))
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readPid(stateDir: string, name: string): Promise<number | null> {
+  try {
+    return Number(await readFile(join(stateDir, name), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+async function waitForHealth(port: number): Promise<boolean> {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`)
+      if (response.ok) return true
+    } catch {
+      // keep waiting
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100))
+  }
+  return false
+}
+
+try {
+  // -------------------------------------------------------------------------
+  // 1. trusted CLI resolution
+  // -------------------------------------------------------------------------
+
+  {
+    const good = await readTrustedCli(fakePackageRoot)
+    ok(good.version === LAVISH_AXI_VERSION, 'the pinned version resolves')
+    ok(good.entry.endsWith('dist/cli.mjs'), `the entry resolves to the declared bin: ${good.entry}`)
+
+    await assert.rejects(() => readTrustedCli(join(workRoot, 'missing-package')), (error: unknown) => {
+      ok(error instanceof LavishLocalError && error.code === 'invalid-options', 'a missing package root is refused')
+      return true
+    })
+    await assert.rejects(() => readTrustedCli('relative/path'), (error: unknown) => {
+      ok(error instanceof LavishLocalError && error.code === 'invalid-options', 'a relative cli root is refused')
+      return true
+    })
+
+    const cases: Array<[string, unknown, string]> = [
+      ['wrong-name', { name: 'not-lavish', version: LAVISH_AXI_VERSION, bin: { 'lavish-axi': 'dist/cli.mjs' } }, 'wrong package name'],
+      ['wrong-version', { name: 'lavish-axi', version: '0.1.66', bin: { 'lavish-axi': 'dist/cli.mjs' } }, 'unpinned version'],
+      ['wrong-bin', { name: 'lavish-axi', version: LAVISH_AXI_VERSION, bin: { 'lavish-axi': 'dist/other.mjs' } }, 'non-pinned entry'],
+      ['no-bin', { name: 'lavish-axi', version: LAVISH_AXI_VERSION }, 'missing bin declaration'],
+    ]
+    for (const [label, manifest, description] of cases) {
+      const root = join(workRoot, label)
+      await mkdir(join(root, 'dist'), { recursive: true })
+      await writeManifest(root, manifest)
+      await writeFile(join(root, 'dist', 'cli.mjs'), '')
+      await writeFile(join(root, 'dist', 'other.mjs'), '')
+      await assert.rejects(() => readTrustedCli(root), (error: unknown) => {
+        ok(error instanceof LavishLocalError && error.code === 'cli-not-trusted', `${description} is refused`)
+        return true
+      })
+    }
+
+    const missingEntry = join(workRoot, 'missing-entry')
+    await mkdir(missingEntry, { recursive: true })
+    await writeManifest(missingEntry, { name: 'lavish-axi', version: LAVISH_AXI_VERSION, bin: { 'lavish-axi': 'dist/cli.mjs' } })
+    await assert.rejects(() => readTrustedCli(missingEntry), (error: unknown) => {
+      ok(error instanceof LavishLocalError && error.code === 'cli-not-trusted', 'a missing declared entry is refused')
+      return true
+    })
+
+    const escapingEntry = join(workRoot, 'escaping-entry')
+    await mkdir(join(escapingEntry, 'dist'), { recursive: true })
+    await writeManifest(escapingEntry, { name: 'lavish-axi', version: LAVISH_AXI_VERSION, bin: { 'lavish-axi': 'dist/cli.mjs' } })
+    await writeFile(join(workRoot, 'escape-target.mjs'), '')
+    await symlink(join(workRoot, 'escape-target.mjs'), join(escapingEntry, 'dist', 'cli.mjs')).catch(() => undefined)
+    await assert.rejects(() => readTrustedCli(escapingEntry), (error: unknown) => {
+      ok(error instanceof LavishLocalError && error.code === 'cli-not-trusted', 'an entry escaping the package root is refused')
+      return true
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. artifact path allowlist
+  // -------------------------------------------------------------------------
+
+  {
+    const accepted = await resolveArtifactPath(ARTIFACT, artifactRoot, artifactRoot)
+    ok(accepted.ok && accepted.file === ARTIFACT, 'an absolute html file inside the root is accepted')
+    const relative = await resolveArtifactPath('card.html', artifactRoot, artifactRoot)
+    ok(relative.ok && relative.file === ARTIFACT, 'a relative html file resolves against cwd')
+
+    expectFailure(await resolveArtifactPath('', artifactRoot, artifactRoot), 'path-rejected')
+    expectFailure(await resolveArtifactPath(42, artifactRoot, artifactRoot), 'path-rejected')
+    expectFailure(await resolveArtifactPath(`${artifactRoot}/car\0d.html`, artifactRoot, artifactRoot), 'path-rejected')
+    expectFailure(await resolveArtifactPath(join(artifactRoot, 'notes.txt'), artifactRoot, artifactRoot), 'path-rejected')
+    expectFailure(await resolveArtifactPath('../outside.html', artifactRoot, artifactRoot), 'path-rejected')
+    expectFailure(await resolveArtifactPath('/etc/hosts.html', artifactRoot, artifactRoot), 'path-rejected')
+    expectFailure(await resolveArtifactPath(artifactRoot, artifactRoot, artifactRoot), 'path-rejected')
+
+    const nested = join(artifactRoot, 'nested')
+    for (const denied of ['.git', 'node_modules']) {
+      await mkdir(join(nested, denied), { recursive: true })
+      const path = join(nested, denied, 'card.html')
+      await writeFile(path, ARTIFACT_BODY)
+      expectFailure(await resolveArtifactPath(path, artifactRoot, artifactRoot), 'path-rejected')
+    }
+
+    const outside = join(workRoot, 'outside.html')
+    await writeFile(outside, ARTIFACT_BODY)
+    expectFailure(await resolveArtifactPath(outside, artifactRoot, artifactRoot), 'path-rejected')
+
+    const escapeLink = join(artifactRoot, 'escape.html')
+    await symlink(outside, escapeLink).catch(() => undefined)
+    expectFailure(await resolveArtifactPath(escapeLink, artifactRoot, artifactRoot), 'path-rejected')
+
+    const directoryArtifact = join(artifactRoot, 'carddir.html')
+    await mkdir(directoryArtifact, { recursive: true })
+    expectFailure(await resolveArtifactPath(directoryArtifact, artifactRoot, artifactRoot), 'path-rejected')
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. minimal child environment (no inherited LAVISH / Tailscale variables)
+  // -------------------------------------------------------------------------
+
+  {
+    const env = buildChildEnvironment('/tmp/owned-state', 4444)
+    assert.deepEqual(Object.keys(env).sort(), [
+      'HOME',
+      'LAVISH_AXI_HOST',
+      'LAVISH_AXI_LINK_HOST',
+      'LAVISH_AXI_NO_OPEN',
+      'LAVISH_AXI_PORT',
+      'LAVISH_AXI_STATE_DIR',
+      'LAVISH_AXI_TELEMETRY',
+      'PATH',
+    ].sort())
+    assertions += 1
+    ok(env.LAVISH_AXI_HOST === '127.0.0.1' && env.LAVISH_AXI_LINK_HOST === '127.0.0.1', 'both hosts are forced to loopback')
+    ok(env.LAVISH_AXI_TELEMETRY === '0' && env.LAVISH_AXI_NO_OPEN === '1', 'telemetry is off and browser opening is off')
+    ok(env.LAVISH_AXI_STATE_DIR === '/tmp/owned-state' && env.LAVISH_AXI_PORT === '4444', 'the owned state dir and port are used')
+    ok(env.HOME === '/tmp/owned-state/home', 'HOME is redirected into the owned state dir')
+
+    const stateDir = await freshStateDir('env')
+    const hostile = {
+      LAVISH_AXI_HOST: '0.0.0.0',
+      LAVISH_AXI_ALLOWED_HOSTS: '*',
+      LAVISH_AXI_TELEMETRY: '1',
+      LAVISH_AXI_STATE_DIR: '/tmp/hostile-state',
+      LAVISH_AXI_PORT: '1',
+      LAVISH_AXI_IDLE_TIMEOUT_MS: '1',
+      TS_SOCKET: '/tmp/hostile-tailscale.sock',
+    }
+    const previous = new Map(Object.keys(hostile).map((key) => [key, process.env[key]]))
+    Object.assign(process.env, hostile)
+    try {
+      const session = await sessionFor(stateDir)
+      const opened = await session.open(ARTIFACT)
+      ok(opened.ok === true, `open works despite a hostile ambient environment: ${JSON.stringify(opened)}`)
+      const observed = JSON.parse((await readFile(join(stateDir, 'env.jsonl'), 'utf8')).trim().split('\n')[0]) as Record<string, string>
+      const allowedLavishKeys = new Set(Object.keys(buildChildEnvironment(stateDir, 0)))
+      const inherited = Object.keys(observed).filter((key) => key.startsWith('LAVISH_AXI_') && !allowedLavishKeys.has(key))
+      ok(inherited.length === 0, `no ambient LAVISH_AXI_* reached the child: ${inherited.join(',')}`)
+      ok(observed.LAVISH_AXI_HOST === '127.0.0.1', 'an ambient 0.0.0.0 host is overridden')
+      ok(observed.LAVISH_AXI_ALLOWED_HOSTS === undefined, 'an ambient DNS-rebinding allowlist is dropped')
+      ok(Object.keys(observed).filter((key) => key.startsWith('TS_')).length === 0, 'no Tailscale variables reach the child')
+      await session.stop()
+    } finally {
+      for (const [key, value] of previous) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. argv shape, lifecycle, and the no-shell guarantee
+  // -------------------------------------------------------------------------
+
+  {
+    const session = await controlSession('lifecycle', {})
+    const port = session.state().port
+
+    const opened = await session.open(ARTIFACT)
+    ok(opened.ok === true, `open succeeds: ${JSON.stringify(opened)}`)
+    if (opened.ok) {
+      ok(opened.status === 'opened', 'open reports opened')
+      ok(opened.file === ARTIFACT, 'open echoes the resolved realpath')
+      ok(opened.url === `http://127.0.0.1:${port}/session/${'a'.repeat(16)}`, 'open returns the loopback session url')
+      ok(!('nextStep' in opened), 'the CLI next_step text is never surfaced as authority')
+    }
+
+    const state = session.state()
+    ok(state.sessionOpen === true && state.userEnded === false, 'instance state tracks the open session')
+    ok(state.stateDir.length > 0, 'the instance owns a state directory')
+    ok(state.port > 0 && state.port !== 4387, `the instance allocated an unused port: ${state.port}`)
+
+    const polled = await session.poll(ARTIFACT)
+    ok(polled.ok === true && polled.status === 'waiting', `poll reports waiting: ${JSON.stringify(polled)}`)
+    if (polled.ok) {
+      ok(polled.feedback.trust === 'untrusted', 'feedback carries an explicit untrusted marker')
+      ok(polled.feedback.prompts.length === 0 && polled.feedback.domSnapshot === '', 'a waiting poll carries no feedback')
+    }
+
+    const replyText = `${REPLY_SENTINEL}; $(touch ${workRoot}/pwned); rm -rf /`
+    const replied = await session.reply(ARTIFACT, replyText)
+    ok(replied.ok === true && replied.kind === 'reply', `reply round-trips: ${JSON.stringify(replied)}`)
+    ok(!(await stat(join(workRoot, 'pwned')).then(() => true).catch(() => false)), 'reply text is never shell-expanded')
+
+    const ended = await session.end(ARTIFACT)
+    ok(ended.ok === true && ended.status === 'ended', `end reports ended: ${JSON.stringify(ended)}`)
+
+    const stopped = await session.stop()
+    ok(stopped.ok === true && stopped.status === 'stopped', `stop reaps the owned server: ${JSON.stringify(stopped)}`)
+    const serverPid = await readPid(session.state().stateDir, 'server.pid')
+    ok(serverPid !== null, 'the owned server recorded its pid')
+    if (serverPid !== null) ok(!isProcessAlive(serverPid), 'the owned server process is gone after stop')
+
+    const stopAgain = await session.stop()
+    ok(stopAgain.ok === true && stopAgain.status === 'not-running', 'stop is idempotent')
+    expectFailure(await session.poll(ARTIFACT), 'instance-closed')
+    expectFailure(await session.open(ARTIFACT), 'instance-closed')
+
+    const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
+    assert.deepEqual(argv, [
+      ['server', '--port', String(port)],
+      ['open', ARTIFACT, '--no-open'],
+      ['poll', ARTIFACT, '--timeout-ms', '300'],
+      ['poll', ARTIFACT, '--agent-reply', replyText, '--timeout-ms', '300'],
+      ['end', ARTIFACT],
+    ], `unexpected argv transcript: ${JSON.stringify(argv)}`)
+    assertions += 1
+    const forbidden = argv.filter((line) => ['update', 'setup', 'share', 'export', 'playbook', 'design'].includes(line[0] ?? ''))
+    ok(forbidden.length === 0, `no self-upgrade, hook, or share command was ever invoked: ${JSON.stringify(forbidden)}`)
+    const transcript = await readFile(join(session.state().stateDir, 'argv.jsonl'), 'utf8')
+    ok(!transcript.includes('--reopen'), 'the adapter never passes --reopen')
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. reply validation, malformed output, and unexpected states
+  // -------------------------------------------------------------------------
+
+  {
+    const session = await controlSession('validation', {})
+    ok((await session.open(ARTIFACT)).ok === true, 'the validation fixture opens')
+
+    expectFailure(await session.reply(ARTIFACT, ''), 'invalid-reply')
+    expectFailure(await session.reply(ARTIFACT, '   '), 'invalid-reply')
+    expectFailure(await session.reply(ARTIFACT, '--'), 'invalid-reply')
+    expectFailure(await session.reply(ARTIFACT, 7 as unknown as string), 'invalid-reply')
+
+    expectFailure(await session.poll(ARTIFACT, { timeoutMs: 0 }), 'invalid-options')
+    expectFailure(await session.poll(ARTIFACT, { timeoutMs: -1 }), 'invalid-options')
+    expectFailure(await session.poll(ARTIFACT, { timeoutMs: 1.5 }), 'invalid-options')
+    expectFailure(await session.poll(ARTIFACT, { timeoutMs: 99_999 }), 'invalid-options')
+    await session.stop()
+
+    const scenarios: Array<[string, unknown, string]> = [
+      ['not-toon', { open: { stdoutRaw: 'this is not toon {{{\n' } }, 'malformed-output'],
+      ['toon-array', { open: { stdoutRaw: '- a\n- b\n' } }, 'malformed-output'],
+      ['unknown-status', { open: { status: 'mystery' } }, 'unexpected-status'],
+      ['foreign-url', { open: { url: `http://evil.example/session/${'b'.repeat(16)}` } }, 'malformed-output'],
+      ['wrong-port-url', { open: { url: `http://127.0.0.1:1/session/${'c'.repeat(16)}` } }, 'malformed-output'],
+      ['wrong-file', { open: { file: join(artifactRoot, 'other.html') } }, 'malformed-output'],
+      ['poll-unknown-status', { poll: { status: 'nonsense' } }, 'unexpected-status'],
+    ]
+    for (const [label, control, code] of scenarios) {
+      const scenarioSession = await controlSession(label, control)
+      const result = label.startsWith('poll-') ? await scenarioSession.poll(ARTIFACT) : await scenarioSession.open(ARTIFACT)
+      expectFailure(result, code)
+      await scenarioSession.stop()
+    }
+
+    const errorSession = await controlSession('cli-error', {
+      open: { error: 'Lavish Editor request failed: 500', code: 'SERVER_ERROR' },
+    })
+    const cliError = expectFailure(await errorSession.open(ARTIFACT), 'command-failed')
+    ok(cliError.detail.includes('SERVER_ERROR'), `the CLI error code is preserved: ${cliError.detail}`)
+    await errorSession.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 6. byte and time bounds, timeouts, and reaping
+  // -------------------------------------------------------------------------
+
+  {
+    const overflow = await controlSession('overflow', { open: { oversizeStdout: 512 * 1024 } }, { maxStdoutBytes: 4_096 })
+    expectFailure(await overflow.open(ARTIFACT), 'output-too-large')
+    await overflow.stop()
+
+    const stderrOverflow = await controlSession('stderr-overflow', { open: { oversizeStderr: 512 * 1024 } }, { maxStderrBytes: 4_096 })
+    expectFailure(await stderrOverflow.open(ARTIFACT), 'output-too-large')
+    await stderrOverflow.stop()
+
+    const hang = await controlSession('hang', {}, { defaultPollTimeoutMs: 200, maxPollTimeoutMs: 1_000, commandTimeoutMs: 400 })
+    ok((await hang.open(ARTIFACT)).ok === true, 'the fixture opens before the hang probe')
+    const hangStateDir = hang.state().stateDir
+    await writeControl(hangStateDir, { poll: { sleepMs: 60_000 } })
+    const startedAt = Date.now()
+    expectFailure(await hang.poll(ARTIFACT), 'command-timeout')
+    ok(Date.now() - startedAt < 5_000, 'the adapter deadline fires long before the fixture would wake')
+    const pollPid = await readPid(hangStateDir, 'poll.pid')
+    ok(pollPid !== null, 'the hanging poll recorded its pid')
+    if (pollPid !== null) ok(!isProcessAlive(pollPid), 'the timed-out poll process group was reaped')
+
+    const unknownOutcome = expectFailure(await hang.poll(ARTIFACT), 'poll-outcome-unknown')
+    ok(unknownOutcome.detail.length > 0, 'the unknown-outcome refusal explains itself')
+
+    const stopAfterTimeout = await hang.stop()
+    ok(stopAfterTimeout.ok === true, `stop still works after a timeout: ${JSON.stringify(stopAfterTimeout)}`)
+    const hangServerPid = await readPid(hangStateDir, 'server.pid')
+    if (hangServerPid !== null) ok(!isProcessAlive(hangServerPid), 'the owned server is reaped after a timeout stop')
+  }
+
+  // -------------------------------------------------------------------------
+  // 7. feedback projection: bounded untrusted data, no filesystem access
+  // -------------------------------------------------------------------------
+
+  {
+    const attachmentTarget = join(artifactRoot, 'attachment.png')
+    const prompts = Array.from({ length: 80 }, (_value, index) => ({
+      uid: `uid-${index}`,
+      tag: index === 0 ? 'layout-warnings' : 'note',
+      selector: '#card',
+      text: index === 0 ? PROMPT_TEXT_SENTINEL : `feedback ${index}`,
+      target: { type: 'layout-warnings', warnings: [{ id: 'w1' }] },
+      attachments: Array.from({ length: 20 }, (_v, refIndex) => ({
+        id: `att-${index}-${refIndex}`,
+        name: 'screenshot.png',
+        path: attachmentTarget,
+        mime: 'image/png',
+        width: 10,
+        height: 10,
+      })),
+    }))
+    const session = await controlSession('feedback', {
+      poll: {
+        status: 'feedback',
+        prompts,
+        artifact_failures: Array.from({ length: 40 }, (_v, index) => ({ kind: 'missing-asset', detail: `failure ${index}` })),
+        dom_snapshot: 'd'.repeat(400 * 1024),
+        session_ended: true,
+        ended_by: 'user',
+      },
+    })
+
+    const result = await session.poll(ARTIFACT)
+    ok(result.ok === true && result.status === 'feedback', `feedback is delivered: ${JSON.stringify(result).slice(0, 200)}`)
+    if (result.ok) {
+      ok(result.sessionEnded === true && result.endedBy === 'user', 'the ended-by marker is preserved as data')
+      const feedback = result.feedback
+      ok(feedback.prompts.length === 64 && feedback.promptsTruncated, `the prompt count is bounded: ${feedback.prompts.length}`)
+      ok(feedback.artifactFailures.length === 16 && feedback.artifactFailuresTruncated, 'artifact failures are bounded')
+      ok(feedback.domSnapshotTruncated && Buffer.byteLength(feedback.domSnapshot) <= 256 * 1024, 'the dom snapshot is byte-bounded')
+      ok(feedback.prompts[0].attachments.length === 16, 'attachment refs per prompt are bounded')
+      ok(feedback.prompts[0].target?.type === 'layout-warnings', 'the target type is kept as data')
+      const projection = JSON.stringify(feedback)
+      ok(!projection.includes(attachmentTarget), 'no attachment filesystem path is exposed or read')
+      ok(!projection.includes('"path"') && !projection.includes('"mime"'), 'only id/name attachment refs are projected')
+      assertions += 1
+      assert.ok(projection.includes(PROMPT_TEXT_SENTINEL), 'prompt text is preserved as data')
+    }
+
+    ok((await session.end(ARTIFACT)).ok === true, 'the session can still be ended after feedback')
+    await session.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 8. user-ended stays closed; no automatic reopen
+  // -------------------------------------------------------------------------
+
+  {
+    const session = await controlSession('user-ended', { open: { status: 'user-ended' } })
+    const first = await session.open(ARTIFACT)
+    ok(first.ok === true && first.status === 'user-ended', `open reports user-ended: ${JSON.stringify(first)}`)
+    ok(session.state().userEnded === true && session.state().sessionOpen === false, 'the instance latches the user-ended state')
+
+    expectFailure(await session.open(ARTIFACT), 'session-user-ended')
+    const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
+    ok(argv.filter((line) => line[0] === 'open').length === 1, `no reopen was attempted: ${JSON.stringify(argv)}`)
+    ok((await session.stop()).ok === true, 'stop still works after a user end')
+
+    const userEndedByPoll = await controlSession('user-ended-poll', {
+      poll: { status: 'feedback', prompts: [{ uid: 'u', tag: 'note', text: 'bye', selector: '#a' }], session_ended: true, ended_by: 'user' },
+    })
+    ok((await userEndedByPoll.poll(ARTIFACT)).ok === true, 'the session-ended feedback is delivered')
+    ok(userEndedByPoll.state().userEnded === true, 'a user end observed through poll also latches closed')
+    expectFailure(await userEndedByPoll.open(ARTIFACT), 'session-user-ended')
+    await userEndedByPoll.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 9. a foreign server on the port is never adopted, preempted, or killed
+  // -------------------------------------------------------------------------
+
+  {
+    const foreign = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ ok: true, app: 'something-else', version: '9.9.9' }))
+    })
+    await new Promise<void>((resolveListen) => foreign.listen(0, '127.0.0.1', resolveListen))
+    const address = foreign.address()
+    assert.ok(address !== null && typeof address === 'object')
+    const foreignPort = address.port
+
+    const session = await controlSession('foreign', {}, { port: foreignPort })
+    expectFailure(await session.open(ARTIFACT), 'port-occupied')
+    ok(foreign.listening, 'the foreign listener is untouched')
+    const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
+    ok(argv.length === 0, `no command was issued against a foreign port: ${JSON.stringify(argv)}`)
+    const stopped = await session.stop()
+    ok(stopped.ok === true && stopped.status === 'not-running', 'stop never touches a server it does not own')
+    ok(foreign.listening, 'stop left the foreign listener running')
+    await new Promise<void>((resolveClose) => foreign.close(() => resolveClose()))
+  }
+
+  {
+    // A pre-existing lavish-axi server of the very same pinned version is still
+    // not ours: the adapter must neither adopt nor shut it down.
+    const port = await allocateUnusedLoopbackPort()
+    const preState = await freshStateDir('preexisting')
+    await writeControl(preState, {})
+    const preexisting = spawn(process.execPath, [join(fakePackageRoot, 'dist', 'cli.mjs'), 'server', '--port', String(port)], {
+      cwd: artifactRoot,
+      env: buildChildEnvironment(preState, port),
+      detached: true,
+      stdio: 'ignore',
+    })
+    ok(await waitForHealth(port), 'the pre-existing same-version server is healthy before the probe')
+
+    const session = await controlSession('preexisting-session', {}, { port })
+    expectFailure(await session.open(ARTIFACT), 'port-occupied')
+    ok(preexisting.pid !== undefined && isProcessAlive(preexisting.pid), 'the pre-existing server was not adopted or killed')
+    const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
+    ok(argv.length === 0, `no command was issued to the pre-existing server: ${JSON.stringify(argv)}`)
+
+    const stopped = await session.stop()
+    ok(stopped.ok === true && stopped.status === 'not-running', 'stop reports nothing owned rather than shutting a foreign server down')
+    if (preexisting.pid !== undefined) ok(isProcessAlive(preexisting.pid), 'the pre-existing server survived stop')
+
+    if (preexisting.pid !== undefined) {
+      try {
+        process.kill(-preexisting.pid, 'SIGTERM')
+      } catch {
+        preexisting.kill('SIGTERM')
+      }
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 300))
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 10. per-instance isolation: two instances, two state dirs, two ports
+  // -------------------------------------------------------------------------
+
+  {
+    const firstState = await freshStateDir('pair-a')
+    const secondState = await freshStateDir('pair-b')
+    const [first, second] = await Promise.all([sessionFor(firstState), sessionFor(secondState)])
+    ok(first.state().port !== second.state().port, 'each instance allocates its own port')
+    ok(first.state().stateDir !== second.state().stateDir, 'each instance owns its own state dir')
+    const [firstOpen, secondOpen] = await Promise.all([first.open(ARTIFACT), second.open(ARTIFACT)])
+    ok(firstOpen.ok === true && secondOpen.ok === true, 'two instances serve concurrently')
+    await Promise.all([first.stop(), second.stop()])
+    const [firstPid, secondPid] = await Promise.all([readPid(firstState, 'server.pid'), readPid(secondState, 'server.pid')])
+    ok(firstPid !== null && secondPid !== null && firstPid !== secondPid, 'the two instances owned different server processes')
+    for (const pid of [firstPid, secondPid]) {
+      if (pid !== null) ok(!isProcessAlive(pid), 'every owned server was reaped')
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 11. the adapter never writes to stdout/stderr and never mutates the artifact
+  // -------------------------------------------------------------------------
+
+  {
+    const session = await controlSession('quiet', {
+      poll: { status: 'feedback', prompts: [{ uid: 'u', tag: 'note', text: PROMPT_TEXT_SENTINEL, selector: '#a' }] },
+    })
+    const before = await stat(ARTIFACT)
+    const bodyBefore = await readFile(ARTIFACT, 'utf8')
+
+    let written = 0
+    const stdoutWrite = process.stdout.write.bind(process.stdout)
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    const counter = (): boolean => {
+      written += 1
+      return true
+    }
+    ;(process.stdout as unknown as { write: unknown }).write = counter
+    ;(process.stderr as unknown as { write: unknown }).write = counter
+    try {
+      await session.open(ARTIFACT)
+      const feedback = await session.poll(ARTIFACT)
+      ok(feedback.ok === true, 'the quiet probe still receives feedback')
+      expectFailure(await session.poll(ARTIFACT, { timeoutMs: 0 }), 'invalid-options')
+      await session.end(ARTIFACT)
+      await session.stop()
+    } finally {
+      ;(process.stdout as unknown as { write: unknown }).write = stdoutWrite
+      ;(process.stderr as unknown as { write: unknown }).write = stderrWrite
+    }
+    ok(written === 0, `the adapter wrote ${written} chunks to stdout/stderr; it must log nothing`)
+
+    const after = await stat(ARTIFACT)
+    const bodyAfter = await readFile(ARTIFACT, 'utf8')
+    ok(bodyAfter === bodyBefore, 'the artifact contents are untouched')
+    ok(after.mtimeMs === before.mtimeMs, 'the artifact mtime is untouched')
+    ok(after.size === before.size, 'the artifact size is untouched')
+  }
+
+  // -------------------------------------------------------------------------
+  // 12. opt-in: real installed CLI protocol probe
+  // -------------------------------------------------------------------------
+
+  if (process.env.GOTRY_LAVISH_LIVE !== '1') {
+    console.log('SKIP: the real lavish-axi probe is opt-in; set GOTRY_LAVISH_LIVE=1 (public registry install into an mkdtemp prefix, no global install)')
+  } else {
+    await realCliProbe()
+  }
+
+  console.log(`LAVISH LOCAL ADAPTER TESTS OK (${assertions} assertions)`)
+} finally {
+  await rm(workRoot, { recursive: true, force: true })
+}
+
+async function realCliProbe(): Promise<void> {
+  const installRoot = await mkdtemp(join(tmpdir(), 'gotry-lavish-live-'))
+  let ownedStateDir: string | null = null
+  try {
+    await writeFile(join(installRoot, 'package.json'), `${JSON.stringify({ name: 'gotry-lavish-probe', private: true, version: '0.0.0' })}\n`)
+    console.log(`=== live probe: npm install lavish-axi@${LAVISH_AXI_VERSION} into ${installRoot} ===`)
+    const install = spawnSync('npm', ['install', '--no-save', '--no-audit', '--no-fund', '--ignore-scripts', `lavish-axi@${LAVISH_AXI_VERSION}`], {
+      cwd: installRoot,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH ?? '', HOME: installRoot },
+    })
+    console.log('argv: npm install --no-save --no-audit --no-fund --ignore-scripts lavish-axi@' + LAVISH_AXI_VERSION)
+    console.log(`exit: ${install.status}`)
+    assert.equal(install.status, 0, `npm install failed: ${install.stderr}`)
+
+    const packageRoot = join(installRoot, 'node_modules', 'lavish-axi')
+    const cli = await readTrustedCli(packageRoot)
+    console.log(`resolved entry: ${cli.entry}`)
+    console.log(`resolved version: ${cli.version}`)
+    assertions += 2
+
+    const liveArtifacts = join(installRoot, 'artifacts')
+    await mkdir(liveArtifacts, { recursive: true })
+    const artifact = join(liveArtifacts, 'synthetic-trip-card.html')
+    await writeFile(artifact, '<!doctype html><html><body><div style="background:#fff;color:#111;height:120px">synthetic card</div></body></html>\n')
+
+    const session = await LavishLocalSession.create({
+      cliPackageRoot: packageRoot,
+      cwd: liveArtifacts,
+      allowedRoot: liveArtifacts,
+    })
+    const { port, stateDir } = session.state()
+    ownedStateDir = stateDir
+    console.log(`owned loopback port: ${port}`)
+    console.log(`owned state dir: ${stateDir}`)
+
+    const beforeStop = spawnSync(process.execPath, [cli.entry, 'stop', '--port', String(port)], {
+      encoding: 'utf8',
+      cwd: liveArtifacts,
+      env: buildChildEnvironment(stateDir, port),
+    })
+    console.log(`argv: lavish-axi stop --port ${port} -> exit ${beforeStop.status} stdout: ${beforeStop.stdout.trim()}`)
+    ok(beforeStop.status === 0, 'the real stop command is well-defined with nothing running')
+
+    const opened = await session.open(artifact)
+    ok(opened.ok === true, `live open succeeds: ${JSON.stringify(opened)}`)
+    if (opened.ok) {
+      ok(opened.status === 'opened', `live open status is opened: ${opened.status}`)
+      ok(opened.url.startsWith(`http://127.0.0.1:${port}/session/`), 'the live session url is loopback on the owned port')
+      console.log(`argv: open <artifact> --no-open -> exit 0, status=${opened.status}, url=${opened.url.replace(/\/session\/[0-9a-f]{16}/, '/session/[redacted]')}`)
+    }
+
+    const polled = await session.poll(artifact, { timeoutMs: 2_500 })
+    ok(polled.ok === true, `live poll succeeds: ${JSON.stringify(polled)}`)
+    if (polled.ok) {
+      ok(polled.status === 'waiting', `live poll status is waiting: ${polled.status}`)
+      console.log(`argv: poll <artifact> --timeout-ms 2500 -> exit 0, status=${polled.status}`)
+    }
+
+    const ended = await session.end(artifact)
+    ok(ended.ok === true && ended.status === 'ended', `live end succeeds: ${JSON.stringify(ended)}`)
+    console.log('argv: end <artifact> -> exit 0, status=ended')
+
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_000))
+    const afterEnd = spawnSync(process.execPath, [cli.entry, 'stop', '--port', String(port)], {
+      encoding: 'utf8',
+      cwd: liveArtifacts,
+      env: buildChildEnvironment(stateDir, port),
+    })
+    console.log(`argv: lavish-axi stop --port ${port} (after end) -> exit ${afterEnd.status} stdout: ${afterEnd.stdout.trim()}`)
+    ok(afterEnd.status === 0, 'the real stop command stays well-defined after a session ends')
+
+    const stopped = await session.stop()
+    ok(stopped.ok === true, `live stop succeeds: ${JSON.stringify(stopped)}`)
+    console.log(`stop -> status=${stopped.ok ? stopped.status : 'error'}`)
+    ok(stopped.ok && (stopped.status === 'stopped' || stopped.status === 'not-running'), 'live stop is idempotent')
+
+    const health = spawnSync(process.execPath, ['-e', `fetch('http://127.0.0.1:${port}/health').then(() => process.exit(0), () => process.exit(3))`], { encoding: 'utf8' })
+    ok(health.status === 3, 'the owned port is free after stop')
+    console.log('post-stop health probe: no listener (expected)')
+
+    // The server self-exits once the last session ends with nothing connected, so
+    // the stop above never had to signal it. A second instance on the same owned
+    // state dir and port gets a live server, then reaps it while it is running.
+    const liveSession = await LavishLocalSession.create({
+      cliPackageRoot: packageRoot,
+      cwd: liveArtifacts,
+      allowedRoot: liveArtifacts,
+      stateDir,
+      port,
+    })
+    const reopened = await liveSession.open(artifact)
+    ok(reopened.ok === true && reopened.status === 'opened', `a fresh server opens a new session: ${JSON.stringify(reopened)}`)
+    const liveReap = await liveSession.stop()
+    ok(liveReap.ok === true && liveReap.status === 'stopped', `a live owned server is signalled and reaped: ${JSON.stringify(liveReap)}`)
+    console.log(`open (fresh server) -> stop while live -> status=${liveReap.ok ? liveReap.status : 'error'}`)
+    const healthAfterReap = spawnSync(process.execPath, ['-e', `fetch('http://127.0.0.1:${port}/health').then(() => process.exit(0), () => process.exit(3))`], { encoding: 'utf8' })
+    ok(healthAfterReap.status === 3, 'the owned port is free after reaping a live server')
+    console.log('post-reap health probe: no listener (expected)')
+    console.log('NOTE: real browser feedback (feedback payloads, --agent-reply echo, browser_disconnected grace) is NOT exercised here; it stays a #438 TODO for a real browser session.')
+  } finally {
+    if (ownedStateDir) await rm(ownedStateDir, { recursive: true, force: true })
+    await rm(installRoot, { recursive: true, force: true })
+  }
+}

--- a/ts/scripts/lavish-local-tests.ts
+++ b/ts/scripts/lavish-local-tests.ts
@@ -33,6 +33,9 @@ import {
   type LavishLocalFailure,
 } from '../capabilities/lavish-local.ts'
 
+const MAX_PROMPT_FIELD_CHARS_TEST = 16 * 1024
+const MAX_PROMPT_FIELD_BYTES_TEST = 16 * 1024
+
 const TOON_ENTRY = createRequire(import.meta.url).resolve('@toon-format/toon')
 const workRoot = await mkdtemp(join(tmpdir(), 'gotry-lavish-local-tests-'))
 
@@ -676,6 +679,213 @@ try {
 
     ok((await session.end(ARTIFACT)).ok === true, 'the session can still be ended after feedback')
     await session.stop()
+  }
+
+  // -------------------------------------------------------------------------
+  // 7b. prompt vs text separation: freeform + annotation shapes from real
+  //     upstream lavish-axi@0.1.67 (see normalizePrompt at dist/cli.mjs ~8112
+  //     and acceptedPrompts filter at ~7720: `tag === "message" && prompt.prompt`).
+  //     Tag is the lower-cased element tagName (context() at ~5359: real
+  //     annotations are h1 / div / p, not the literal "text").
+  // -------------------------------------------------------------------------
+
+  {
+    const REAL_USER_REQUEST = 'Synthetic acceptance feedback: add a visible section titled Agent update 1 with the text Browser feedback accepted. Keep all dates and facts unchanged.'
+    const realBrowserFreeform = await controlSession('real-browser-freeform', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          { uid: '', tag: 'message', selector: '', text: 'Freeform message', prompt: REAL_USER_REQUEST, attachments: [] },
+        ],
+      },
+    })
+    const freeformResult = await realBrowserFreeform.poll(ARTIFACT)
+    ok(freeformResult.ok === true, 'the real-browser freeform fixture delivers feedback')
+    if (freeformResult.ok) {
+      const prompts = freeformResult.feedback.prompts
+      ok(prompts.length === 1, 'one freeform prompt is projected')
+      const only = prompts[0]
+      ok(only !== undefined, 'the freeform prompt is present')
+      if (only !== undefined) {
+        ok(only.tag === 'message', 'the freeform tag is preserved')
+        ok(only.text === 'Freeform message', `text is the upstream placeholder, not the request: ${only.text}`)
+        ok(only.textTruncated === false, 'the upstream placeholder text is not flagged as truncated')
+        ok(only.prompt === REAL_USER_REQUEST, `prompt is the actual user instruction, not silently substituted with text: ${only.prompt.slice(0, 80)}...`)
+        ok(only.promptTruncated === false, 'a request that fits within the byte bound is not flagged as truncated')
+        ok(only.selector === '' && only.target === undefined, 'freeform has no selector or target')
+      }
+      ok(freeformResult.feedback.promptsMalformed === 0, 'a well-formed freeform prompt is not counted as malformed')
+    }
+    await realBrowserFreeform.stop()
+
+    const realAnnotation = await controlSession('real-annotation', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          {
+            uid: 'a-1',
+            tag: 'h1',
+            selector: 'h1.day-3',
+            text: 'Day 3 — Kyoto half-day walking tour (08:00 – 14:30)',
+            prompt: 'Re-time this to start no earlier than 10:00.',
+            attachments: [],
+          },
+        ],
+      },
+    })
+    const annotationResult = await realAnnotation.poll(ARTIFACT)
+    ok(annotationResult.ok === true, 'the annotation fixture delivers feedback')
+    if (annotationResult.ok) {
+      const prompts = annotationResult.feedback.prompts
+      ok(prompts.length === 1, 'one annotation prompt is projected')
+      const only = prompts[0]
+      ok(only !== undefined, 'the annotation prompt is present')
+      if (only !== undefined) {
+        ok(only.tag === 'h1', 'the annotation tag is the lower-cased element tagName')
+        ok(only.selector === 'h1.day-3', 'the originating selector is preserved')
+        ok(only.text === 'Day 3 — Kyoto half-day walking tour (08:00 – 14:30)', 'the selected snippet stays in text')
+        ok(only.prompt === 'Re-time this to start no earlier than 10:00.', 'the user comment stays in prompt')
+        ok(only.target === undefined, 'a plain HTML annotation has no target (table/mermaid only)')
+        ok(only.text !== only.prompt, 'text and prompt are not the same string for an annotation')
+      }
+      ok(annotationResult.feedback.promptsMalformed === 0, 'a well-formed annotation prompt is not counted as malformed')
+    }
+    await realAnnotation.stop()
+
+    const counterexampleRepro = await controlSession('root-counterexample', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          { uid: '', tag: 'message', selector: '', text: 'Freeform message', attachments: [] },
+        ],
+      },
+    })
+    const reproResult = await counterexampleRepro.poll(ARTIFACT)
+    ok(reproResult.ok === true, 'the root counterexample fixture still delivers feedback (no global failure)')
+    if (reproResult.ok) {
+      const prompts = reproResult.feedback.prompts
+      ok(prompts.length === 1, 'the missing-prompt freeform prompt is not silently dropped')
+      const only = prompts[0]
+      ok(only !== undefined && only.prompt === '', `a missing prompt is exposed as the empty string, not as text: ${only?.prompt}`)
+      ok(only !== undefined && only.promptTruncated === false, 'a missing prompt is not falsely flagged as truncated')
+      ok(only !== undefined && only.text === 'Freeform message', 'the placeholder text is preserved')
+      ok(reproResult.feedback.promptsMalformed === 1, `the missing-prompt freeform is counted as malformed: ${reproResult.feedback.promptsMalformed}`)
+    }
+    await counterexampleRepro.stop()
+
+    const nonStringPrompt = await controlSession('non-string-prompt', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          { uid: 'u', tag: 'message', selector: '', text: 'Freeform message', prompt: 7 as unknown as string },
+          { uid: 'v', tag: 'h1', selector: 'h1.day-3', text: 'snippet', prompt: { bogus: true } as unknown as string },
+          { uid: 'w', tag: 'message', selector: '', text: 'Freeform message', prompt: null as unknown as string },
+        ],
+      },
+    })
+    const nonStringResult = await nonStringPrompt.poll(ARTIFACT)
+    ok(nonStringResult.ok === true, 'non-string prompt fields do not poison the whole poll')
+    if (nonStringResult.ok) {
+      ok(nonStringResult.feedback.promptsMalformed === 3, `every non-string prompt is counted as malformed regardless of tag: ${nonStringResult.feedback.promptsMalformed}`)
+      for (const projected of nonStringResult.feedback.prompts) {
+        ok(projected.prompt === '' && projected.promptTruncated === false, `non-string prompt projected as empty and not falsely truncated: ${JSON.stringify(projected)}`)
+      }
+    }
+    await nonStringPrompt.stop()
+
+    const emptyWithAttachment = await controlSession('empty-with-attachment', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          { uid: 'ea', tag: 'message', selector: '', text: 'Freeform message', prompt: '', attachments: [{ id: 'att-x', name: 'screenshot.png' }] },
+        ],
+      },
+    })
+    const emptyAttachResult = await emptyWithAttachment.poll(ARTIFACT)
+    ok(emptyAttachResult.ok === true, 'an empty-prompt request with attachments still delivers feedback')
+    if (emptyAttachResult.ok) {
+      ok(emptyAttachResult.feedback.promptsMalformed === 0, 'an empty-string prompt is NOT counted as malformed')
+      const only = emptyAttachResult.feedback.prompts[0]
+      ok(only !== undefined && only.prompt === '', 'the empty prompt is preserved as data')
+      ok(only !== undefined && only.promptTruncated === false, 'an empty prompt is not falsely flagged as truncated')
+      ok(only !== undefined && only.attachments.length === 1 && only.attachments[0]?.id === 'att-x', 'the attachment survives alongside an empty prompt')
+    }
+    await emptyWithAttachment.stop()
+
+    const emptyNoAttachment = await controlSession('empty-no-attachment', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          { uid: 'en', tag: 'h1', selector: 'h1.day-3', text: 'Day 3', prompt: '', attachments: [] },
+        ],
+      },
+    })
+    const emptyNoAttachResult = await emptyNoAttachment.poll(ARTIFACT)
+    ok(emptyNoAttachResult.ok === true, 'an empty-prompt annotation still delivers feedback')
+    if (emptyNoAttachResult.ok) {
+      ok(emptyNoAttachResult.feedback.promptsMalformed === 0, 'an empty-string prompt with no attachments is still NOT counted as malformed')
+      const only = emptyNoAttachResult.feedback.prompts[0]
+      ok(only !== undefined && only.prompt === '' && only.text === 'Day 3', 'the empty prompt does NOT fall back to the context text')
+      ok(only !== undefined && only.promptTruncated === false, 'an empty prompt is not falsely flagged as truncated')
+    }
+    await emptyNoAttachment.stop()
+
+    const malformedAnyTag = await controlSession('malformed-any-tag', {
+      poll: {
+        status: 'feedback',
+        prompts: [
+          { uid: 'l', tag: 'layout-warnings', selector: '', text: 'warning batch' },
+          { uid: 'n', tag: 'note', selector: '#x', text: 'note body' },
+          { uid: 'p', tag: 'div', selector: 'p', text: 'paragraph' },
+        ],
+      },
+    })
+    const malformedAnyResult = await malformedAnyTag.poll(ARTIFACT)
+    ok(malformedAnyResult.ok === true, 'missing-prompt fixtures on any tag deliver feedback')
+    if (malformedAnyResult.ok) {
+      ok(malformedAnyResult.feedback.promptsMalformed === 3, `missing prompt is counted as malformed on every tag, not just freeform/annotation: ${malformedAnyResult.feedback.promptsMalformed}`)
+      for (const projected of malformedAnyResult.feedback.prompts) {
+        ok(projected.prompt === '' && projected.promptTruncated === false, `missing-prompt is projected as empty without false truncation flags: ${JSON.stringify(projected)}`)
+        ok(projected.text.length > 0, `context text survives so consumers can audit the drop: ${projected.text}`)
+      }
+    }
+    await malformedAnyTag.stop()
+
+    const oversizedChar = 'A'.repeat(MAX_PROMPT_FIELD_CHARS_TEST + 200)
+    const charOverflow = await controlSession('prompt-char-overflow', {
+      poll: { status: 'feedback', prompts: [{ uid: 'c', tag: 'message', selector: '', text: 'Freeform message', prompt: oversizedChar }] },
+    })
+    const charResult = await charOverflow.poll(ARTIFACT)
+    ok(charResult.ok === true, 'an over-char-bound prompt still delivers feedback')
+    if (charResult.ok) {
+      const only = charResult.feedback.prompts[0]
+      ok(only !== undefined, 'the prompt is projected')
+      if (only !== undefined) {
+        ok(only.prompt.length === MAX_PROMPT_FIELD_CHARS_TEST, `the prompt is char-clipped: ${only.prompt.length}`)
+        ok(only.promptTruncated === true, 'the truncation flag is set explicitly')
+      }
+      ok(charResult.feedback.promptsMalformed === 0, 'over-char-bound prompts are truncated, not counted as malformed')
+    }
+    await charOverflow.stop()
+
+    const oversizedByte = '\u{1F600}'.repeat(MAX_PROMPT_FIELD_BYTES_TEST + 100)
+    const byteOverflow = await controlSession('prompt-byte-overflow', {
+      poll: { status: 'feedback', prompts: [{ uid: 'b', tag: 'message', selector: '', text: 'Freeform message', prompt: oversizedByte }] },
+    })
+    const byteResult = await byteOverflow.poll(ARTIFACT)
+    ok(byteResult.ok === true, 'an over-byte-bound prompt still delivers feedback')
+    if (byteResult.ok) {
+      const only = byteResult.feedback.prompts[0]
+      ok(only !== undefined, 'the prompt is projected')
+      if (only !== undefined) {
+        const projectedBytes = Buffer.byteLength(only.prompt, 'utf8')
+        ok(projectedBytes <= MAX_PROMPT_FIELD_BYTES_TEST, `the prompt is byte-clipped to the bound: ${projectedBytes}`)
+        ok(only.promptTruncated === true, 'the byte truncation flag is set explicitly')
+        ok(!only.prompt.endsWith('�'), 'no split multi-byte sequence survives in the truncated prompt')
+      }
+      ok(byteResult.feedback.promptsMalformed === 0, 'over-byte-bound prompts are truncated, not counted as malformed')
+    }
+    await byteOverflow.stop()
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Refs #443 (parent #438). This is a **bounded adapter slice**, not the whole of #443. The PR is now on `fbc5a51` after rebasing onto `main @ b351452` (#449) and a focused review fix for the real-browser prompt drop.

## What changed on top of `41552dd` (PR review, real browser counterexample)

Root drove the real `lavish-axi@0.1.67` browser against the harness on `41552dd` and observed that a freeform "Send to Agent" submission came back as `prompts[0].text = "Freeform message"` with the user instruction dropped (see `ART/root443-browser-feedback-counterexample.json`). The upstream chat filter is
`acceptedPrompts.filter((p) => p.tag === "message" && p.prompt)` (`dist/cli.mjs` ~7720) and `context()` sets `tag = (el.tagName || "").toLowerCase()` (~5359), so the previous `projectFeedback()` was conflating selected-element context with the user request and losing it.

The `fbc5a51` commit fixes that without expanding the owned scope:

- `LavishPrompt` now carries both `text` (selected-element context — bounded, `textTruncated` flag) and `prompt` (the user instruction — bounded, `promptTruncated` flag). Char and byte bounds; multi-byte UTF-8 truncation never splits a codepoint.
- `LavishUntrustedFeedback.promptsMalformed` counts records whose `prompt` was missing or non-string at the upstream boundary, on **every** tag (freeform `message`, annotation `h1` / `div` / …, layout-warnings, custom). The drop is auditable; the rest of the record (`uid`, `tag`, `selector`, `text`, attachments) still survives so consumers can see what they lost.
- An empty-string `prompt` (legitimate "no text, attachments only") is preserved as data and is **not** counted as malformed — the adapter does not fall back to context text.
- Annotation tags in the fixture are real HTML element names (`h1`) sourced from upstream `context()` at ~5359, not a literal `"text"`.
- Non-vacuous check: temporarily disabling the malformed counter makes the root counterexample assertion fail with `expected: 1, got: 0`.

Section 7b of `ts/scripts/lavish-local-tests.ts` covers: freeform positive (`message` + `Freeform message` placeholder + real instruction); annotation positive (`h1` selector + snippet + comment); the root counterexample repro (no `prompt` field); non-string prompt fields (number, object, null) on every tag; empty `prompt` with and without attachments; over-char and over-byte truncation with UTF-8 safe cuts; and the once-only / non-zero-exit / reply-bounds gates from `41552dd` are kept. Bilingual design pair `docs/design/lavish-local.{md,zh-CN.md}` documents the prompt/text split and the empty-vs-missing semantics.

## Remaining core TODO (still not in this PR; root owns)

1. **Product registration** — wire the adapter into `ts/src/index.ts`, tool + client surfaces, card registration. Deliberately untouched here because #442 owns the intersecting files.
2. **Full regression + six state surfaces** — wire this suite into `scripts/run-all-tests.sh` and sync the six state faces of `architecture.md` §11 in the same commit.
3. **Real browser feedback E2E on `fbc5a51`** — root's review cycle (`browser → poll → source update → visible refresh → reply → user end`) needs to be re-run on the new SHA. The offline suite is synthetic-only.
4. **Root `node_modules` does not contain `@toon-format/toon`** — the root lock is validated (`npm ci --dry-run` exit 0) but the existing root install was deliberately left untouched. A root `npm ci` is needed before any root-level call path imports it.

Until 1–3 land, the product must not claim a working Lavish review loop.

## Verified CLI facts (read from the installed package, not from prose)

`lavish-axi@0.1.67`, MIT, `engines.node >= 22`, published `bin` → `dist/cli.mjs`. `open` returns `opened`/`user-ended`; `poll` returns `waiting`/`feedback`/`ended`/`browser_disconnected`; a `waiting` poll consumes nothing while a `feedback` delivery is the consumption; `stop` is well-defined with nothing running; the server self-exits once the last session ends with nothing connected. `update` is the SDK's own self-upgrade and is never invoked here, nor are `setup hooks`, `setup plugin`, `share`, or `export`.

## Evidence (SHA `fbc5a51`, rebased onto `main @ b351452`)

| gate | command | result |
| --- | --- | --- |
| typecheck | `cd ts && npx tsc --noEmit` | exit 0 |
| focused suite | `cd ts && npx tsx scripts/lavish-local-tests.ts` | exit 0, **268 assertions** (was 209 on `41552dd`; +59 cover section 7b prompt/text split) |
| docs parity | `node scripts/check-docs-i18n.mjs` | 59 pairs OK |
| ts lock strict | `cd ts && npm ci` | exit 0 |
| root lock strict | `npm ci --dry-run` | exit 0 |

The opt-in real CLI probe (`GOTRY_LAVISH_LIVE=1`) was last exercised on `41552dd` with exit 0 / 225 assertions and is not re-run here — the `fbc5a51` change is purely a projection tightening and the lifecycle behaviour it covered is unchanged. Root will run the browser-driven E2E on `fbc5a51` as part of #443.

**No network claims beyond the pinned `npm install --no-save --ignore-scripts lavish-axi@0.1.67` already documented on `41552dd`.**

## Not in this PR

Product wiring, `ts/src/index.ts`, client surfaces, the six state surfaces, `run-all-tests.sh`, and DSH card registration are untouched (owned by #442 / root). Lavish itself is **not** added to the product dependency tree — only the decoder is, consistently across both manifests and all three locks. Unsupported feedback shapes (whiteboard/excalidraw targets, attachments) stay bounded and opaque rather than modelled.