### PR TITLE
test(lavish): include offline adapter checks in full regression

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -576,6 +576,10 @@ echo
 echo "=== 67. issue #436 持久健康面→注册工具 routing 建议 E2E(跨进程 fixture 探针子进程走真实 evaluateProbeResults+recordChannelEvent 写 channel-health.jsonl→真实注册工具 gotry_flyai_search/gotry_session_search 结果 \`routing\` 字段断言:持久 down 排除(本进程该通道会话态为空)/非会话通道同样生效/会话 down 优先于持久 'ok' 恢复/会话 hit 清除后有效持久 ok 恢复/独立根不串根/过期·未来·缺·坏时间戳均不压制且坏行不得在 latest-wins 前顶掉更早有效 down/同根追加可重复;夹具按产品真实操作标签登记并记录实际请求标签防错位;隔离临时 stateRoot+有界子进程,全离线无网络无真实供应商) ==="
 (cd ts && npx tsx scripts/issue436-persisted-routing-e2e.ts) || FAIL=1
 
+echo
+echo "=== 67b. Issue #443 本地 Lavish Editor 会话适配器(offline:trust/path 白名单/argv 形状/字节与超时上界/状态机/进程组 reap/生命周期规则;GOTRY_LAVISH_LIVE=0 强锁,合成 lavish-axi 包树,零网络零真浏览器,ambient opt-in 也不得安装/调用外部 CLI) ==="
+(cd ts && GOTRY_LAVISH_LIVE=0 npx tsx scripts/lavish-local-tests.ts) || FAIL=1
+
 if [ "$FAIL" -ne 0 ]; then
   echo "REGRESSION FAILED"
   exit 1


### PR DESCRIPTION
The full regression now always runs the existing offline Lavish adapter suite. Its invocation explicitly sets `GOTRY_LAVISH_LIVE=0`, so an inherited live opt-in cannot install or run an external CLI; failures feed the existing regression result.

Local validation on `5c4c2b740ffc52fcd1dcf3e7f3af3a39dfdf0e90`: full regression exit 0, including 268 adapter assertions; shell syntax and independently executed positive/negative invocation checks exit 0. Full log SHA256: `83738795e239a416212804cfb5f28556293ff87b5312cb58b320d3b153a65505`.

Refs #443. Fixture failure-path cleanup is tracked separately in #454.
