### PR TITLE
test(lavish): reap pre-existing fixtures on assertion failure

### DIFF
--- a/ts/scripts/lavish-local-tests.ts
+++ b/ts/scripts/lavish-local-tests.ts
@@ -19,6 +19,7 @@ import { createRequire } from 'node:module'
 import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { connect } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -254,6 +255,179 @@ async function waitForHealth(port: number): Promise<boolean> {
   return false
 }
 
+// ---------------------------------------------------------------------------
+// directly-spawned foreign-server fixture registry (issue #454)
+//
+// Section 9 spawns a same-version lavish-axi server outside the adapter to
+// prove the foreign listener is never adopted or killed. The test harness
+// owns that exact fixture (PID + PGID + loopback port) for the lifetime of
+// the probe. Reaping signals the recorded PGID — not the leader PID — so
+// descendants that survive the leader are still bound to the harness-owned
+// group. Only the recorded fixture group is ever signalled; no broad pkill,
+// no command-name search.
+// ---------------------------------------------------------------------------
+
+interface OwnedFixture {
+  readonly pgid: number
+  readonly port: number
+  readonly label: string
+}
+
+const ownedFixtures = new Set<OwnedFixture>()
+const deferredCleanupErrors: Error[] = []
+
+function trackFixture(pid: number, port: number, label: string): OwnedFixture {
+  const entry: OwnedFixture = { pgid: pid, port, label }
+  ownedFixtures.add(entry)
+  return entry
+}
+
+type Probe = { state: 'present' | 'absent' } | { state: 'error'; detail: string }
+type SignalResult = { state: 'delivered' | 'absent' } | { state: 'error'; detail: string }
+
+interface ReapResult {
+  readonly groupGone: boolean
+  readonly portClosed: boolean
+  readonly escalatedKill: boolean
+  readonly issues: string[]
+}
+
+function probeGroup(pgid: number): Probe {
+  try {
+    process.kill(-pgid, 0)
+    return { state: 'present' }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    return code === 'ESRCH'
+      ? { state: 'absent' }
+      : { state: 'error', detail: `group probe failed: ${code ?? String(error)}` }
+  }
+}
+
+function signalGroup(pgid: number, signal: NodeJS.Signals): SignalResult {
+  try {
+    process.kill(-pgid, signal)
+    return { state: 'delivered' }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    return code === 'ESRCH'
+      ? { state: 'absent' }
+      : { state: 'error', detail: `${signal} failed: ${code ?? String(error)}` }
+  }
+}
+
+async function waitForGroupGone(pgid: number, timeoutMs: number): Promise<{ gone: boolean; issue?: string }> {
+  const deadline = Date.now() + timeoutMs
+  while (true) {
+    const probe = probeGroup(pgid)
+    if (probe.state === 'absent') return { gone: true }
+    if (probe.state === 'error') return { gone: false, issue: probe.detail }
+    if (Date.now() >= deadline) return { gone: false }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 50))
+  }
+}
+
+async function waitForPortClosed(port: number, timeoutMs: number): Promise<{ closed: boolean; issue?: string }> {
+  const deadline = Date.now() + timeoutMs
+  while (true) {
+    const outcome = await new Promise<'open' | 'closed' | string>((resolve) => {
+      const socket = connect(port, '127.0.0.1')
+      let settled = false
+      const finish = (value: 'open' | 'closed' | string): void => {
+        if (settled) return
+        settled = true
+        socket.destroy()
+        resolve(value)
+      }
+      socket.once('connect', () => finish('open'))
+      socket.once('error', (error) => {
+        const code = (error as NodeJS.ErrnoException).code
+        finish(code === 'ECONNREFUSED' ? 'closed' : `port probe failed: ${code ?? String(error)}`)
+      })
+      socket.setTimeout(500, () => finish('port probe timed out'))
+    })
+    if (outcome === 'closed') return { closed: true }
+    if (outcome !== 'open') return { closed: false, issue: outcome }
+    if (Date.now() >= deadline) return { closed: false, issue: 'port remained open' }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 50))
+  }
+}
+
+async function reapOwnedFixture(
+  entry: OwnedFixture,
+  options: { graceMs?: number; killGraceMs?: number; portWaitMs?: number } = {},
+): Promise<ReapResult> {
+  const graceMs = options.graceMs ?? 2_000
+  const killGraceMs = options.killGraceMs ?? 2_000
+  const portWaitMs = options.portWaitMs ?? 2_000
+  const issues: string[] = []
+  let groupGone = false
+  let escalatedKill = false
+
+  const term = signalGroup(entry.pgid, 'SIGTERM')
+  if (term.state === 'absent') {
+    groupGone = true
+  } else if (term.state === 'error') {
+    issues.push(term.detail)
+  } else {
+    const waited = await waitForGroupGone(entry.pgid, graceMs)
+    groupGone = waited.gone
+    if (waited.issue) issues.push(waited.issue)
+  }
+
+  if (!groupGone && issues.length === 0) {
+    const kill = signalGroup(entry.pgid, 'SIGKILL')
+    escalatedKill = kill.state === 'delivered'
+    if (kill.state === 'absent') {
+      groupGone = true
+    } else if (kill.state === 'error') {
+      issues.push(kill.detail)
+    } else {
+      const waited = await waitForGroupGone(entry.pgid, killGraceMs)
+      groupGone = waited.gone
+      if (waited.issue) issues.push(waited.issue)
+      else if (!waited.gone) issues.push('process group survived SIGKILL')
+    }
+  }
+
+  const port = await waitForPortClosed(entry.port, portWaitMs)
+  if (port.issue) issues.push(port.issue)
+  return { groupGone, portClosed: port.closed, escalatedKill, issues }
+}
+
+function reapSucceeded(result: ReapResult): boolean {
+  return result.groupGone && result.portClosed && result.issues.length === 0
+}
+
+function describeReap(entry: OwnedFixture, result: ReapResult): string {
+  return `${entry.label} pgid=${entry.pgid} port=${entry.port} groupGone=${result.groupGone} portClosed=${result.portClosed} escalated=${result.escalatedKill} issues=${result.issues.join(',') || 'none'}`
+}
+
+async function reapAllOwnedFixtures(): Promise<Error[]> {
+  const errors: Error[] = []
+  for (const entry of [...ownedFixtures]) {
+    try {
+      const result = await reapOwnedFixture(entry)
+      if (reapSucceeded(result)) ownedFixtures.delete(entry)
+      else errors.push(new Error(`outer fixture cleanup failed: ${describeReap(entry, result)}`))
+    } catch (error) {
+      errors.push(new Error(`outer fixture cleanup threw for ${entry.label} pgid=${entry.pgid}: ${asError(error).message}`))
+    }
+  }
+  return errors
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function throwCollected(errors: Error[]): void {
+  if (errors.length === 0) return
+  if (errors.length === 1) throw errors[0]
+  throw new AggregateError(errors, errors.map((error) => error.message).join(' | '))
+}
+
+let suitePrimary: unknown = undefined
 try {
   // -------------------------------------------------------------------------
   // 1. trusted CLI resolution
@@ -939,7 +1113,11 @@ try {
 
   {
     // A pre-existing lavish-axi server of the very same pinned version is still
-    // not ours: the adapter must neither adopt nor shut it down.
+    // not ours: the adapter must neither adopt nor shut it down. The test
+    // harness owns that exact fixture in a try/finally so every code path —
+    // including a failing assertion — is reaped with bounded exit/PID/port
+    // evidence. Only SIGKILL escalation is permitted, and only against the
+    // harness-owned fixture group — never a broad pkill.
     const port = await allocateUnusedLoopbackPort()
     const preState = await freshStateDir('preexisting')
     await writeControl(preState, {})
@@ -949,25 +1127,36 @@ try {
       detached: true,
       stdio: 'ignore',
     })
-    ok(await waitForHealth(port), 'the pre-existing same-version server is healthy before the probe')
+    const fixturePid = preexisting.pid
+    if (fixturePid === undefined) {
+      throw new Error('failed to spawn pre-existing server: pid is undefined')
+    }
+    const fixture = trackFixture(fixturePid, port, 'preexisting')
+    try {
+      ok(await waitForHealth(port), 'the pre-existing same-version server is healthy before the probe')
 
-    const session = await controlSession('preexisting-session', {}, { port })
-    expectFailure(await session.open(ARTIFACT), 'port-occupied')
-    ok(preexisting.pid !== undefined && isProcessAlive(preexisting.pid), 'the pre-existing server was not adopted or killed')
-    const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
-    ok(argv.length === 0, `no command was issued to the pre-existing server: ${JSON.stringify(argv)}`)
+      const session = await controlSession('preexisting-session', {}, { port })
+      expectFailure(await session.open(ARTIFACT), 'port-occupied')
+      ok(isProcessAlive(fixturePid), 'the pre-existing server was not adopted or killed')
+      const argv = await readJsonl(join(session.state().stateDir, 'argv.jsonl'))
+      ok(argv.length === 0, `no command was issued to the pre-existing server: ${JSON.stringify(argv)}`)
 
-    const stopped = await session.stop()
-    ok(stopped.ok === true && stopped.status === 'not-running', 'stop reports nothing owned rather than shutting a foreign server down')
-    if (preexisting.pid !== undefined) ok(isProcessAlive(preexisting.pid), 'the pre-existing server survived stop')
-
-    if (preexisting.pid !== undefined) {
+      const stopped = await session.stop()
+      ok(stopped.ok === true && stopped.status === 'not-running', 'stop reports nothing owned rather than shutting a foreign server down')
+      ok(isProcessAlive(fixturePid), 'the pre-existing server survived stop')
+    } finally {
       try {
-        process.kill(-preexisting.pid, 'SIGTERM')
-      } catch {
-        preexisting.kill('SIGTERM')
+        const result = await reapOwnedFixture(fixture)
+        if (reapSucceeded(result)) {
+          ownedFixtures.delete(fixture)
+        } else {
+          // Retain the entry for one outer retry and retain this failed attempt
+          // as evidence even if that retry succeeds.
+          deferredCleanupErrors.push(new Error(`fixture cleanup failed: ${describeReap(fixture, result)}`))
+        }
+      } catch (error) {
+        deferredCleanupErrors.push(new Error(`fixture cleanup threw for ${fixture.label} pgid=${fixture.pgid}: ${asError(error).message}`))
       }
-      await new Promise((resolveDelay) => setTimeout(resolveDelay, 300))
     }
   }
 
@@ -1040,10 +1229,22 @@ try {
   } else {
     await realCliProbe()
   }
-
-  console.log(`LAVISH LOCAL ADAPTER TESTS OK (${assertions} assertions)`)
+} catch (err) {
+  suitePrimary = err
 } finally {
-  await rm(workRoot, { recursive: true, force: true })
+  const errors = suitePrimary === undefined ? [...deferredCleanupErrors] : [asError(suitePrimary), ...deferredCleanupErrors]
+  try {
+    errors.push(...await reapAllOwnedFixtures())
+  } catch (error) {
+    errors.push(asError(error))
+  }
+  try {
+    await rm(workRoot, { recursive: true, force: true })
+  } catch (error) {
+    errors.push(asError(error))
+  }
+  if (errors.length === 0) console.log(`LAVISH LOCAL ADAPTER TESTS OK (${assertions} assertions)`)
+  throwCollected(errors)
 }
 
 async function realCliProbe(): Promise<void> {


### PR DESCRIPTION
## 概要

修复 #454:在 Lavish 本地适配器测试脚本(`ts/scripts/lavish-local-tests.ts`)中,断言失败路径上保留了一个由测试自己启动、占用端口的预存在伪 server 进程组,未被回收。本 PR 仅把**这条由夹具自身拥有的预存在 server**在断言失败 / 清理失败 / 临时目录删除失败的所有路径上连同进程组统一回收,产品代码与运行时表面无任何变更。

## 范围(单文件,1 / N)

| 项 | 值 |
| --- | --- |
| 源 SHA | `9fb3c342a13cdedf20ea31b67a7b78172e115ecd` |
| 父提交(基线) | `7774ad0b2c69da360d2d22cf8e6fca0ab33254ef` (`origin/main`) |
| 分支 | `test/issue454-lavish-fixture-cleanup` |
| 改动文件 | `ts/scripts/lavish-local-tests.ts` |
| 文件 SHA256 | `878549fa464b0dd8b0b64fdc452ce11eed2b7a2a1e81ad558581f4d61dff07cb` |
| Diff | `220 insertions(+), 19 deletions(-)` |

父提交之后的全部 diff 范围仅这一个文件;`git diff --name-only origin/main...HEAD` 也只有这一行。

## 设计要点

- **进程组所有权收窄**:夹具自启时用 `trackFixture()` 记录 `{ pgid: pid, port, label }`,清理只针对该条目;未引入任何 `pkill`、`killall`、`fuser`、按命令名杀进程或全局进程搜索(`scripts/lavish-local-tests.ts:279, 297, 309`)。
- **严格 socket / process 探针**:进程缺失只承认 `ESRCH`(`probeGroup` / `signalGroup`),端口关闭只承认 `ECONNREFUSED`(`waitForPortClosed`);其他错误一律视为失败,不做静默吞错。
- **SIGKILL 诚实上报**:`escalatedKill` 仅在 SIGKILL 投递成功时置位,SIGKILL 后进程组仍在则记录 `process group survived SIGKILL`。
- **同版本预存在 server 仍为 foreign**:`open()` 必须返回 `port-occupied`,不向其发送任何 argv,`stop()` 返回 `not-running`;夹具存活状态直到 harness 显式清理为止。
- **错误聚合不掩盖**:section-local `finally` 仅在 `reapSucceeded(result)` 为真时删除条目,否则保留在 `ownedFixtures` 让外层重试,并把本次失败记录到 `deferredCleanupErrors`;主流程错误、清理错误、`rm(workRoot)` 错误在 `throwCollected(errors)` 之前统一聚合,失败时**绝不**输出 `LAVISH LOCAL ADAPTER TESTS OK` 成功横幅。

## 证据(本地,源 SHA 绑定)

来自 `/Users/danceiny/work/gotry/.omx/artifacts/continue-20260912T160102/root454-captured-source-validation.json` 的 4 道本地门:

| Gate | 命令 | Exit | 起 | 止 | Log SHA256 |
| --- | --- | --- | --- | --- | --- |
| type | `npx tsc --noEmit` (cwd `ts/`) | 0 | 2026-09-12T18:05:51.285Z | 2026-09-12T18:05:55.803Z | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
| offline | `npx tsx scripts/lavish-local-tests.ts` (cwd `ts/`) | 0 | 2026-09-12T18:05:55.824Z | 2026-09-12T18:06:03.011Z | `e2b1c4c57d4d48a99f9706c8bd06f13c6344b9cf79a6625eca25ac50c5faecd7` |
| diff | `git diff --check HEAD^ HEAD` | 0 | 2026-09-12T18:06:03.028Z | 2026-09-12T18:06:03.037Z | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
| full | `bash scripts/run-all-tests.sh` | 0 | 2026-09-12T18:06:03.054Z | 2026-09-12T18:14:43.682Z | `ba7903cddacdf29de34327dfdc59b635172ec0acb8d44014ecdb508d7d865b9d` |

Offline 日志末行:`LAVISH LOCAL ADAPTER TESTS OK (268 assertions)`。

`scripts/run-all-tests.sh` 是该项目既定的全量回归门(AGENTS.md 中登记的 project gate),本次 source-stable full run 在新源码上 exit 0。

## 故障注入证据

`/Users/danceiny/work/gotry/.omx/artifacts/continue-20260912T160102/root454-actual-suite-proof.json` 中两条 child 进程 exit-1 用例均直接跑最终源码:

| Case | Child Exit | PGID/PID Absent | Port Refused | No Success Banner | Log SHA256 |
| --- | --- | --- | --- | --- | --- |
| `primary_only` | 1 | true | true | true | `b78b991db568d4c6d28279549711563519343e55e9a0dfb3878918b01b12a0c3` |
| `combined_errors` | 1 | true | true | true | `3462e7138b80e3a642d0a3b04b86e99b10e78e3769350f731f9aed6bd1d1209a` |

- `primary_only`:真实断言失败 + 真实 finally + 真实 reap,失败路径进程组与端口都被收回。
- `combined_errors`:真实断言失败后,故意注入 deferred cleanup + `rm(workRoot)` 双重失败,确认原始错误与清理错误聚合抛出,无成功横幅。

## 实现归属

- 实现由实际 Claude Code 撰写,期间使用 native fallback 做小幅收敛,源码与父提交对比即见。
- 由独立的 root verifier(`root454-final-verifier.mjs`, sha256 `7943c8fb62a6558fdeb8997ab31e9a3cdc633f3882b6e3754614ca559941dcf3`)以及本次故障注入 runner 单独复核。

## 产品 E2E

N/A。本次仅修改一个测试脚本文件,产品运行时未变;实际进程 / socket 清理行为已通过上述故障注入 child 进程执行。

## 范围说明

本 PR 仅解决 #454 的"断言失败下夹具未被回收"这一项。不主张整个 M4-M6 完成;其余 Lavish 范围的工作各自独立跟踪。

## 根证据

https://github.com/Danceiny/gotry/issues/454#issuecomment-5647634641

Refs #454
