### PR TITLE
fix(booking-copilot): enforce rejection-before-correction result order

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -1625,6 +1625,76 @@ assert.deepEqual(
   'corrected occupancy preserves both non-empty rooms and child criteria',
 )
 
+// Event-order regression (PR461 review F2): an INVALID_ARGS rejection that
+// arrives after the accepted correction succeeded has not been observed by
+// the model at decision time; the planning authority must fail closed.
+let lateInvalidResultRuns = 0
+const lateInvalidResultPort: DshPlannerRunPort = {
+  async run() {
+    lateInvalidResultRuns += 1
+    return {
+      finalResponse: '',
+      events: [
+        toolCall('booking_search_hotels', JSON.stringify({
+          decision: { kind: 'operation', action: { ...searchRun, kind: 'search.patch', actionId: 'action-dsh-order-late-invalid', reason: 'Late invalid call.', input: { patch: { occupancy: { rooms: [{ adults: 2, childAges: [6] }, { childAges: [4] }] } } } } },
+        }), 'call-order-late-invalid'),
+        toolCall('booking_search_hotels', JSON.stringify({
+          decision: { kind: 'operation', action: { ...searchRun, kind: 'search.patch', actionId: 'action-dsh-order-late-valid', reason: 'Late valid call.', input: { patch: { occupancy: { rooms: [{ adults: 2, childAges: [6] }, { adults: 1, childAges: [4] }] } } } } },
+        }), 'call-order-late-valid'),
+        toolResult('call-order-late-valid'),
+        toolResult('call-order-late-invalid', true, 'INVALID_ARGS'),
+      ],
+    }
+  },
+  async close() {},
+}
+const lateInvalidResult = await createDshEmbeddedBookingPlanner({ runPort: lateInvalidResultPort })
+await assert.rejects(
+  lateInvalidResult.plannerFactory(task).next({
+    task,
+    turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: 'dsh-turn-order-late', workspace, request: { text: 'Find hotels' } },
+  }),
+  /planner_typed_decision_after_candidate/,
+  'rejection feedback that lands after the accepted correction must fail closed',
+)
+assert.equal(lateInvalidResultRuns, 1, 'late rejection result fails closed within a single provider run')
+await lateInvalidResult.close()
+
+// Event-order regression (PR461 review F2): the correction call itself is
+// emitted before the model receives the INVALID_ARGS rejection for the
+// earlier invalid call; the planning authority must refuse to honour it.
+let preFeedbackCorrectionRuns = 0
+const preFeedbackCorrectionPort: DshPlannerRunPort = {
+  async run() {
+    preFeedbackCorrectionRuns += 1
+    return {
+      finalResponse: '',
+      events: [
+        toolCall('booking_search_hotels', JSON.stringify({
+          decision: { kind: 'operation', action: { ...searchRun, kind: 'search.patch', actionId: 'action-dsh-order-pre-invalid', reason: 'Pre-feedback invalid call.', input: { patch: { occupancy: { rooms: [{ adults: 2, childAges: [6] }, { childAges: [4] }] } } } } },
+        }), 'call-order-pre-invalid'),
+        toolCall('booking_search_hotels', JSON.stringify({
+          decision: { kind: 'operation', action: { ...searchRun, kind: 'search.patch', actionId: 'action-dsh-order-pre-valid', reason: 'Pre-feedback valid call.', input: { patch: { occupancy: { rooms: [{ adults: 2, childAges: [6] }, { adults: 1, childAges: [4] }] } } } } },
+        }), 'call-order-pre-valid'),
+        toolResult('call-order-pre-invalid', true, 'INVALID_ARGS'),
+        toolResult('call-order-pre-valid'),
+      ],
+    }
+  },
+  async close() {},
+}
+const preFeedbackCorrection = await createDshEmbeddedBookingPlanner({ runPort: preFeedbackCorrectionPort })
+await assert.rejects(
+  preFeedbackCorrection.plannerFactory(task).next({
+    task,
+    turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: 'dsh-turn-order-pre', workspace, request: { text: 'Find hotels' } },
+  }),
+  /planner_typed_decision_after_candidate/,
+  'correction emitted before its INVALID_ARGS feedback must fail closed',
+)
+assert.equal(preFeedbackCorrectionRuns, 1, 'pre-feedback correction fails closed within a single provider run')
+await preFeedbackCorrection.close()
+
 // A prose-only first response receives the same bounded correction treatment
 // as a malformed typed call; a valid second typed call is returned immediately.
 let proseRecoveryRuns = 0
@@ -1686,5 +1756,5 @@ await assert.rejects(
 )
 assert.equal(providerRuns, 1, 'provider failures are not silently swallowed or retried')
 
-await Promise.all([adapter.close(), textChannel.close(), fencedTextChannel.close(), stringifiedAction.close(), invalidThenValid.close(), invalidWithoutSchemaRejection.close(), unauthorised.close(), unauthorisedTyped.close(), multipleTypedSuccesses.close(), missingToolResult.close(), mismatchedToolResult.close(), fragmentRef.close(), truncatedRecovery.close(), sanitizedRef.close(), unsafeRef.close(), uiOffers.close(), forbidden.close(), terminalAdapter.close(), indexKeyedRooms.close(), occupancyRepair.close(), proseRecovery.close(), malformed.close(), providerError.close(), reservedText.close(), finalTextAfterTransientAttempt.close(), attemptFailureWithoutTerminalEvent.close()])
+await Promise.all([adapter.close(), textChannel.close(), fencedTextChannel.close(), stringifiedAction.close(), invalidThenValid.close(), invalidWithoutSchemaRejection.close(), unauthorised.close(), unauthorisedTyped.close(), multipleTypedSuccesses.close(), missingToolResult.close(), mismatchedToolResult.close(), fragmentRef.close(), truncatedRecovery.close(), sanitizedRef.close(), unsafeRef.close(), uiOffers.close(), forbidden.close(), terminalAdapter.close(), indexKeyedRooms.close(), occupancyRepair.close(), lateInvalidResult.close(), preFeedbackCorrection.close(), proseRecovery.close(), malformed.close(), providerError.close(), reservedText.close(), finalTextAfterTransientAttempt.close(), attemptFailureWithoutTerminalEvent.close()])
 console.log('BOOKING COPILOT DSH PLANNER PROOF: task session/typed tool decisions/no Book/prose non-executable/no portal token OK')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -557,6 +557,7 @@ function scanDshToolDecisionEvents(events: readonly unknown[], task: BookingCopi
   if (calls.some((call) => call.index > accepted.index)) throw new Error('planner_typed_decision_after_candidate')
   if (rejected.some((call) => call.index > accepted.index)) throw new Error('planner_typed_decision_after_candidate')
   if (calls.some((call) => call.index < accepted.index && call.result?.kind !== 'schema-rejection')) throw new Error('planner_unresolved_tool_call_before_candidate')
+  if (rejected.some((call) => call.result!.index >= accepted.index)) throw new Error('planner_typed_decision_after_candidate')
   return [accepted.decision!]
 }
 


### PR DESCRIPTION
## TODO

1. 对最终集成 SHA 执行完整本地回归并核对两个相关修复，当前保留 Draft。
2. 与父 PR #461 的 typed journey goal／停靠点修复协调集成，再刷新父 PR 的真实 UAT 证据。

本 PR 修复 [PR #461 审阅中的 F2](https://github.com/Danceiny/gotry/pull/461#pullrequestreview-5188133251)：以前，纠正调用可以先于前一个 `INVALID_ARGS` 反馈出现，仍被接纳。现在要求每个容忍的 schema rejection result 均早于 accepted call；两种反例被拒绝，正常串行纠正继续允许。复用现有错误码，无新增接口。

增量只有两个文件：`dsh-planner.ts` 一行检查，以及 planner proof 中两条反例和单次 run 断言（合计 +72／−1）。现有双语文档已经规定先拒绝后纠正，行为修复与该合同对齐。

Claude Code 交付 SHA：`cd30d3a2daba94915d237d6fcc59f13931380c4c`；父分支基线：`5783531497faba30ce646c9c04b389699b400241`。此 PR 的 base 为父 PR 分支 `fix/issue-3580-planner-provider-errors`，只呈现增量。

Claude Code 报告 `tsc --noEmit`、planner proof、真实本地 DSH 子进程 core proof、docs i18n 和定向排序 probe 均退出 0。架构师将补充独立执行及最终集成门槛；在此之前，不把执行者报告视为验收。

E2E：执行者的本地 DSH／SSE fixture 证据待架构师复核；真实供应商／业务 UAT **TODO**，继续在父 PR #461／#142 跟踪。这项修复不授权 Book、支付或发布。

架构师源分支复核：上述 SHA 的定向五项及完整本地回归均退出 0，[全量记录](https://github.com/Danceiny/gotry/pull/462#issuecomment-5649317638)。E2E 包含本地 DSH 和安装包路径；最终集成／真实 UAT 仍为 TODO。
