### PR TITLE
test(booking-copilot): teardown directIngressRoot fixture (ref #461)

### DIFF
--- a/ts/scripts/booking-copilot-runtime-proof-tests.ts
+++ b/ts/scripts/booking-copilot-runtime-proof-tests.ts
@@ -358,12 +358,22 @@ const directIngressRoot = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-missing-t
 const directIngressLedger = ensureLedger(directIngressRoot)
 const directIngressRuntime = new BookingCopilotTaskRuntime(directIngressLedger)
 const directIngressBefore = directIngressLedger.countEvents()
-assert.throws(() => directIngressRuntime.startTask({
-  schemaVersion: 'booking.surface', kind: 'user.turn.ingress', requestKey: 'ingress-no-task', surfaceHint: 'tenant',
-  workspace: { schemaVersion: 'booking.surface', revision: 0, locale: 'en-US', currency: 'AED', searchDraft: {}, results: { status: 'idle' }, visibleHotels: [], loadedOffers: [], shortlistedOfferRefs: [] },
-  request: { text: 'find hotels in Dubai' },
-} as never), /ingress_binding_required/)
-assert.equal(directIngressLedger.countEvents(), directIngressBefore, 'browser ingress has no direct runtime ledger side effects')
+try {
+  assert.throws(() => directIngressRuntime.startTask({
+    schemaVersion: 'booking.surface', kind: 'user.turn.ingress', requestKey: 'ingress-no-task', surfaceHint: 'tenant',
+    workspace: { schemaVersion: 'booking.surface', revision: 0, locale: 'en-US', currency: 'AED', searchDraft: {}, results: { status: 'idle' }, visibleHotels: [], loadedOffers: [], shortlistedOfferRefs: [] },
+    request: { text: 'find hotels in Dubai' },
+  } as never), /ingress_binding_required/)
+  assert.equal(directIngressLedger.countEvents(), directIngressBefore, 'browser ingress has no direct runtime ledger side effects')
+} finally {
+  try { directIngressLedger.close() } catch (closeError) {
+    try { rmSync(directIngressRoot, { recursive: true, force: true }) } catch (rmError) {
+      throw new AggregateError([closeError, rmError], 'directIngress fixture teardown failed')
+    }
+    throw closeError
+  }
+  rmSync(directIngressRoot, { recursive: true, force: true })
+}
 const selectedIngressRoot = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-selected-ingress-'))
 const selectedIngressLedger = ensureLedger(selectedIngressRoot)
 const selectedIngressRuntime = new BookingCopilotTaskRuntime(selectedIngressLedger, { contextRefFactory: () => 'ctx-selected-ingress' })


### PR DESCRIPTION
## 摘要

为 `ts/scripts/booking-copilot-runtime-proof-tests.ts` 的 `directIngressRoot` 夹具增加 ledger 关闭与临时目录删除。正常路径和断言失败路径均执行清理；关闭失败时仍尝试删除，两个清理错误同时发生时通过 `AggregateError` 保留。

合并源 SHA：`f20170eb9e545726951d25b20a445d2b49a58ac3`。合并目标 SHA：`7f3674243801f3f9059609bfba85574928f0e60e`。仅一个测试文件，新增 16 行、删除 6 行。

## 合并后跟进

根评审复现：断言与清理同时失败时，原始断言错误会被覆盖。增量修复会另开 PR。本 PR 保留 Merged 状态，分支后续的 `872aeb7` 不属于此合并内容。此前 worker 在合并后写入的 Draft／新 head 描述不准确，本说明已更正。

审计与复现：https://github.com/Danceiny/gotry/pull/464#issuecomment-5651175074

## 验证范围

原作者报告类型检查、运行时证明及单独断言失败清理通过。根评审独立七组合探针在合并源发现三种诊断信息丢失，总退出码为 `1`；它们是新增后续修复的验收条件。

E2E：N/A，仅内部测试夹具生命周期；不代表真实预订 UAT。
