### PR TITLE
test(booking-copilot): preserve assertion failures during fixture cleanup

### DIFF
--- a/ts/scripts/booking-copilot-runtime-proof-tests.ts
+++ b/ts/scripts/booking-copilot-runtime-proof-tests.ts
@@ -358,6 +358,7 @@ const directIngressRoot = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-missing-t
 const directIngressLedger = ensureLedger(directIngressRoot)
 const directIngressRuntime = new BookingCopilotTaskRuntime(directIngressLedger)
 const directIngressBefore = directIngressLedger.countEvents()
+let directIngressOriginalError: unknown
 try {
   assert.throws(() => directIngressRuntime.startTask({
     schemaVersion: 'booking.surface', kind: 'user.turn.ingress', requestKey: 'ingress-no-task', surfaceHint: 'tenant',
@@ -365,15 +366,20 @@ try {
     request: { text: 'find hotels in Dubai' },
   } as never), /ingress_binding_required/)
   assert.equal(directIngressLedger.countEvents(), directIngressBefore, 'browser ingress has no direct runtime ledger side effects')
+} catch (error) {
+  directIngressOriginalError = error
 } finally {
   try { directIngressLedger.close() } catch (closeError) {
     try { rmSync(directIngressRoot, { recursive: true, force: true }) } catch (rmError) {
-      throw new AggregateError([closeError, rmError], 'directIngress fixture teardown failed')
+      throw new AggregateError([closeError, rmError, directIngressOriginalError].filter((e): e is Error => e !== undefined), 'directIngress fixture teardown failed')
     }
-    throw closeError
+    throw new AggregateError([closeError, directIngressOriginalError].filter((e): e is Error => e !== undefined), 'directIngress fixture teardown failed')
   }
-  rmSync(directIngressRoot, { recursive: true, force: true })
+  try { rmSync(directIngressRoot, { recursive: true, force: true }) } catch (rmError) {
+    throw new AggregateError([rmError, directIngressOriginalError].filter((e): e is Error => e !== undefined), 'directIngress fixture teardown failed')
+  }
 }
+if (directIngressOriginalError !== undefined) throw directIngressOriginalError
 const selectedIngressRoot = mkdtempSync(join(tmpdir(), 'gotry-booking-v2-selected-ingress-'))
 const selectedIngressLedger = ensureLedger(selectedIngressRoot)
 const selectedIngressRuntime = new BookingCopilotTaskRuntime(selectedIngressLedger, { contextRefFactory: () => 'ctx-selected-ingress' })


### PR DESCRIPTION
When a runtime-proof assertion and fixture cleanup both fail, cleanup previously hid the original assertion error. This change retains every error while still attempting both ledger close and temporary-directory removal.

Only the existing `directIngressRoot` fixture changes; both original assertions remain intact. Follow-up to the [post-merge finding on #464](https://github.com/Danceiny/gotry/pull/464#issuecomment-5651175074).

中文：保留断言与清理同时失败时的原始错误，同时继续关闭连接、删除临时目录。仅修改已有夹具。

Validation at `4e9e68b05c1235deae031d2d8e8d40ac2f719ade` was independently executed by the root reviewer on Node 24.20.0: strict `npm ci` in root and `ts/`, typecheck, the original runtime proof, seven failure combinations, i18n and diff checks all exit 0. The worktree remained clean. The three combined assertion/cleanup cases fail at the previous source and pass here.

E2E: N/A — internal test fixture lifecycle only; real ledger and filesystem effects were exercised. This does not establish live booking UAT or milestone admission.
