### PR TITLE
fix(booking-copilot): align first-turn planner envelope

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -255,6 +255,11 @@ assert.ok(!profilePatch.includes('2026-09-10') && !profilePatch.includes('2026-0
 assert.ok(!/under criteria/i.test(profilePatch), 'planner persona does not revive the stale under-criteria routing wording')
 assert.match(profilePatch, /Shape-only example/i, 'planner persona marks the example as shape-only')
 assert.match(profilePatch, /do not copy literal/i, 'planner persona tells the model not to copy placeholder sample values')
+const shapeExampleLine = profilePatch.split('\n').find((line) => line.trimStart().startsWith('{"decision":'))
+assert.ok(shapeExampleLine, 'planner persona example uses the model-facing decision envelope')
+const shapeExample = JSON.parse(shapeExampleLine!.trim().replace('<rev from payload>', '0')) as { decision?: { kind?: string; action?: unknown } }
+assert.deepEqual(Object.keys(shapeExample), ['decision'], 'planner persona example has exactly the declared top-level envelope')
+assert.deepEqual(Object.keys(shapeExample.decision ?? {}), ['kind', 'action'], 'planner persona example nests the typed operation under decision')
 assert.match(profilePatch, /"stay":\{"checkIn":"<computed YYYY-MM-DD from the host-local time anchor>","checkOut":"<computed YYYY-MM-DD from nights\/check-in>"\}/, 'shape example keeps the stay object shape')
 assert.match(profilePatch, /"starRating":\{"strength":"must","value":\{"min":3,"max":3\}\}/, 'shape example keeps the starRating criterion shape')
 assert.match(profilePatch, /"occupancy":\{"rooms":\[\{"adults":2,"childAges":\[\]\}\]\}/, 'shape example includes a well-formed occupancy block')

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -206,7 +206,7 @@ export function buildDshEmbeddedBookingPatch(pluginPath: string): string {
       (三星=3星: min 3 max 3); dates under stay as concrete YYYY-MM-DD resolved from the time anchor.\n\
       Shape-only example of a correctly shaped search.patch tool call; do not copy literal\n\
       placeholder values, dates, destination, contextRef, revision, actionId, or reason from it:\n\
-      {"kind":"operation","action":{"schemaVersion":"booking.surface","kind":"search.patch","actionId":"<unique-id>","contextRef":"<ctx from payload>","expectedRevision":<rev from payload>,"factRefs":[],"reason":"<one line>","input":{"patch":${JSON.stringify(PLANNER_EXAMPLE_PATCH)}}}}\n\
+      {"decision":{"kind":"operation","action":{"schemaVersion":"booking.surface","kind":"search.patch","actionId":"<unique-id>","contextRef":"<ctx from payload>","expectedRevision":<rev from payload>,"factRefs":[],"reason":"<one line>","input":{"patch":${JSON.stringify(PLANNER_EXAMPLE_PATCH)}}}}}\n\
     workspaceContext: false\n\
     skills:\n\
       enabled: false\n\


### PR DESCRIPTION
TODO

Fixes the Booking Copilot first-turn planner example so the model-facing shape matches the registered tool schema: `{ decision: ... }`.

Evidence:
- `cd ts && npx tsx scripts/booking-copilot-dsh-planner-proof-tests.ts` (exit 0)
- `git diff --check` for the two changed files (exit 0)

Remaining acceptance:
1. Deploy this candidate together with current `origin/main` to exclusive UAT.
2. Execute the real first user turn through HotelByte BFF and observe an applied typed operation.
3. Run the proportionate full gate after live behavior is proven.

Refs hotelbyte-com/hotel-fe#3580.