### PR TITLE
fix(booking-copilot): reject authority before canonical-schema and reserved-namespace carriers (#473)

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -715,6 +715,130 @@ await assert.rejects(
 )
 await reservedFactRefRejectedThenValid.close()
 
+// Issue #473 mixed-authority regression: an INVALID_ARGS + later-valid pair
+// must not launder an authority violation that co-travels with a reference
+// syntax error. Pure shape errors stay repairable; authority rejections
+// remain fail-closed regardless of paired INVALID_ARGS + later canonical.
+const mixedAuthorityCases: ReadonlyArray<{
+  name: string
+  tool: 'booking_search_hotels' | 'booking_refine_results'
+  badAction: Record<string, unknown>
+  accept: true
+} | {
+  name: string
+  tool: 'booking_search_hotels' | 'booking_refine_results'
+  badAction: Record<string, unknown>
+  accept: false
+  errorPattern: RegExp
+}> = [
+  {
+    name: 'shape-only repair control',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, factRefs: ['draft:destination=Dubai'] },
+    accept: true,
+  },
+  {
+    name: 'capability mismatch plus unsafe factRef',
+    tool: 'booking_search_hotels',
+    badAction: { ...hotelSelect, factRefs: ['draft:destination=Dubai'] },
+    accept: false,
+    errorPattern: /planner_capability_action_mismatch/,
+  },
+  {
+    name: 'surface unsupported plus unsafe factRef',
+    tool: 'booking_refine_results',
+    badAction: { ...hotelSelect, factRefs: ['draft:destination=Dubai'] },
+    accept: false,
+    errorPattern: /planner_surface_action_unsupported/,
+  },
+  {
+    name: 'revision mismatch plus unsafe factRef',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, expectedRevision: 99, factRefs: ['draft:destination=Dubai'] },
+    accept: false,
+    errorPattern: /planner_revision_mismatch/,
+  },
+  {
+    name: 'reserved factRef plus unsafe actionId',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, actionId: 'bad/action', factRefs: ['modelref:reserved-by-runtime'] },
+    accept: false,
+    errorPattern: /planner_invalid_action:reserved_fact_ref/,
+  },
+  {
+    name: 'context mismatch plus unsafe factRef control',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, contextRef: 'ctx-other', factRefs: ['draft:destination=Dubai'] },
+    accept: false,
+    errorPattern: /planner_context_mismatch/,
+  },
+  {
+    name: 'reserved factRef plus empty actionId',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, actionId: '', factRefs: ['modelref:reserved-by-runtime'] },
+    accept: false,
+    errorPattern: /planner_invalid_action:reserved_fact_ref/,
+  },
+  {
+    name: 'surface unsupported plus nonstring factRef',
+    tool: 'booking_refine_results',
+    badAction: { ...hotelSelect, factRefs: [0] },
+    accept: false,
+    errorPattern: /planner_surface_action_unsupported/,
+  },
+  {
+    name: 'capability mismatch plus unsafe actionId counterpart',
+    tool: 'booking_search_hotels',
+    badAction: { ...hotelSelect, actionId: 'bad/id' },
+    accept: false,
+    errorPattern: /planner_capability_action_mismatch/,
+  },
+  {
+    name: 'revision mismatch plus unsafe actionId counterpart',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, actionId: 'bad/id', expectedRevision: 99 },
+    accept: false,
+    errorPattern: /planner_revision_mismatch/,
+  },
+]
+for (const [index, c] of mixedAuthorityCases.entries()) {
+  const mixedAuthorityPlanner = await createDshEmbeddedBookingPlanner({
+    runPort: {
+      async run() {
+        return {
+          finalResponse: '',
+          events: [
+            toolCall(c.tool, JSON.stringify({ decision: { kind: 'operation', action: c.badAction } }), `mixed-authority-${index}-bad`),
+            toolResult(`mixed-authority-${index}-bad`, true, 'INVALID_ARGS'),
+            ...successfulToolEvents('booking_search_hotels', JSON.stringify({ decision: { kind: 'operation', action: searchRun } }), `mixed-authority-${index}-good`),
+          ],
+        }
+      },
+      async close() {},
+    },
+  })
+  try {
+    if (c.accept) {
+      const decisions = await mixedAuthorityPlanner.plannerFactory(task).next({
+        task,
+        turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: `dsh-mixed-authority-${index}`, workspace, request: { text: 'Find hotels' } },
+      })
+      assert.deepEqual(decisions, [{ kind: 'operation', action: searchRun }], `${c.name} accepts the later canonical call after shape repair`)
+    } else {
+      await assert.rejects(
+        mixedAuthorityPlanner.plannerFactory(task).next({
+          task,
+          turn: { schemaVersion: 'booking.surface', kind: 'user.turn', taskId: task.taskId, turnId: `dsh-mixed-authority-${index}`, workspace, request: { text: 'Find hotels' } },
+        }),
+        c.errorPattern,
+        c.name,
+      )
+    }
+  } finally {
+    await mixedAuthorityPlanner.close()
+  }
+}
+
 const sanitizedRefPort: DshPlannerRunPort = {
   async run() {
     return {

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -349,7 +349,22 @@ const PLANNER_SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:._-]*$/
 
 // Action identifiers and fact references are ledger keys, not prose. They
 // must arrive canonical; the reserved modelref namespace is never accepted
-// from a model-authored action.
+// from a model-authored action. The reserved-namespace rejection is a hard
+// authority error, so canonical-schema or sibling syntax failures must not
+// hide it behind a repairable shape error.
+function assertReservedModelRefNamespace(action: Record<string, unknown>): void {
+  const factRefs = action.factRefs
+  if (Array.isArray(factRefs)) {
+    for (const ref of factRefs) {
+      if (typeof ref === 'string' && ref.startsWith('modelref:')) {
+        throw new Error('planner_invalid_action:reserved_fact_ref')
+      }
+    }
+  }
+}
+
+// Pure syntax errors below stay shape-only and remain repairable when
+// paired with a same-run INVALID_ARGS tool/result.
 function assertPlannerSafeRefs(action: Record<string, unknown>): void {
   const actionId = action.actionId
   if (typeof actionId !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(actionId)) {
@@ -358,9 +373,6 @@ function assertPlannerSafeRefs(action: Record<string, unknown>): void {
   const factRefs = action.factRefs
   if (Array.isArray(factRefs)) {
     for (const ref of factRefs) {
-      if (typeof ref === 'string' && ref.startsWith('modelref:')) {
-        throw new Error('planner_invalid_action:reserved_fact_ref')
-      }
       if (typeof ref !== 'string' || !PLANNER_SAFE_REF_PATTERN.test(ref) || ref.length > 512) {
         throw new Error('planner_invalid_action:unsafe_fact_ref')
       }
@@ -408,6 +420,26 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
     invalidDecisionLog('forbidden_action', { actionKind: diagnosticText(decision.action.kind) })
     throw new Error('planner_forbidden_action')
   }
+  // Reserved modelref namespace must reject before canonical-schema or sibling
+  // syntax failures can launder the violation through repairable shape errors.
+  assertReservedModelRefNamespace(decision.action)
+  // Authority checks (capability / allowedActions) must reject before any
+  // canonical-schema shape failure. They only fire when the typed kind
+  // discriminant is well-formed; a missing or malformed kind falls through
+  // to validateBookingReadAction as a shape error so a blind cast never
+  // turns an unknown kind into a capability violation.
+  if (typeof decision.action.kind === 'string' && (BOOKING_READ_ACTION_KINDS as readonly string[]).includes(decision.action.kind)) {
+    const actionKind = decision.action.kind as BookingReadAction['kind']
+    const capability = TOOL_TO_CAPABILITY.get(name as DshEmbeddedBookingToolName)
+    if (!capability || !actionsForEmbeddedCapability(capability).includes(actionKind)) {
+      invalidDecisionLog('capability_action_mismatch')
+      throw new Error('planner_capability_action_mismatch')
+    }
+    if (!task.allowedActions.includes(actionKind)) {
+      invalidDecisionLog('surface_action_unsupported', { allowedActionCount: task.allowedActions.length })
+      throw new Error('planner_surface_action_unsupported')
+    }
+  }
   const validation = validateBookingReadAction(decision.action)
   if (!validation.ok) {
     invalidDecisionLog('action_schema_invalid', {
@@ -418,22 +450,17 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
     })
     throw new Error('planner_invalid_action')
   }
-  assertPlannerSafeRefs(decision.action)
-  const action = decision.action as unknown as BookingReadAction
-  const capability = TOOL_TO_CAPABILITY.get(name as DshEmbeddedBookingToolName)
-  if (!capability || !actionsForEmbeddedCapability(capability).includes(action.kind)) {
-    invalidDecisionLog('capability_action_mismatch')
-    throw new Error('planner_capability_action_mismatch')
-  }
-  if (!task.allowedActions.includes(action.kind)) {
-    invalidDecisionLog('surface_action_unsupported', { allowedActionCount: task.allowedActions.length })
-    throw new Error('planner_surface_action_unsupported')
-  }
-  if (action.contextRef !== task.contextRef) throw new Error('planner_context_mismatch')
   // The runtime owns the revision: the planner can only echo what the prompt
   // showed it. Reject a mismatch instead of rewriting model-authored authority;
   // the client-side concurrency guard also lives at the context/journal binding.
-  if (action.expectedRevision !== task.revision) throw new Error('planner_revision_mismatch')
+  // Inspect expectedRevision safely — only a typed number can establish the
+  // mismatch; a wrong-typed revision was already rejected by schema validation.
+  if (typeof decision.action.expectedRevision === 'number' && decision.action.expectedRevision !== task.revision) {
+    throw new Error('planner_revision_mismatch')
+  }
+  const action = decision.action as unknown as BookingReadAction
+  assertPlannerSafeRefs(decision.action)
+  if (action.contextRef !== task.contextRef) throw new Error('planner_context_mismatch')
   if (action.relaxationApprovalRef) throw new Error('planner_approval_ref_forbidden')
   return { kind: 'operation', action }
 }


### PR DESCRIPTION
## Summary

- Reject the reserved modelref namespace and the capability / allowedActions authority checks **before** `validateBookingReadAction` so canonical-schema validation or sibling syntax failures cannot launder the violation through a repairable shape error.
- Keep the unsafe `actionId` / `factRef` syntax checks inside `assertPlannerSafeRefs` as shape-only, repairable when paired with a same-run `INVALID_ARGS`.
- Inspect `kind` / `expectedRevision` safely (typeof guard) — a missing or wrong-typed discriminant falls through to schema validation as a shape error rather than being mis-labelled as a capability violation.

## Acceptance

All four root mixed cases plus the two new carriers and the unsafe-actionId counterparts now reject for the underlying authority violation, while the canonical / shape-only repair controls still pass.

| case | result |
| --- | --- |
| shape-only repair control | accepted after same-run repair |
| capability mismatch + unsafe factRef | `planner_capability_action_mismatch` |
| surface unsupported + unsafe factRef | `planner_surface_action_unsupported` |
| revision mismatch + unsafe factRef | `planner_revision_mismatch` |
| reserved factRef + unsafe actionId | `planner_invalid_action:reserved_fact_ref` |
| context mismatch + unsafe factRef control | `planner_context_mismatch` |
| reserved factRef + empty actionId | `planner_invalid_action:reserved_fact_ref` |
| surface unsupported + nonstring factRef | `planner_surface_action_unsupported` |
| capability mismatch + unsafe actionId counterpart | `planner_capability_action_mismatch` |
| revision mismatch + unsafe actionId counterpart | `planner_revision_mismatch` |

## Test plan

Re-runnable with Node 24 + strict-peer-deps npm ci already in place:

- `cd ts && npx tsc --noEmit`
- `cd ts && npx tsx scripts/booking-copilot-dsh-planner-proof-tests.ts`
- `cd ts && npx tsx scripts/booking-copilot-dsh-plugin-proof-tests.ts`
- `cd ts && npx tsx scripts/booking-copilot-runtime-proof-tests.ts`
- `cd ts && npx tsx scripts/booking-copilot-dsh-core-proof-tests.ts`
- `cd ts && npx tsx <root extended probe>` against the final SHA

References #473 (Not-Fixes until root full review closes). Related #472 / #142. The Booking Copilot no-merge hold stays in place.

## Top TODO for root full review

- Re-run the six focused gates on the final exact SHA (89da99a).
- Re-run the root extended probe (8 cases) and confirm exit 0 + matched error codes.
- Confirm diff stays exactly the two owned files; no docs / no `dsh-plugin.js` / no deps / no `package.json` / no lockfile changes.
- Confirm i18n mechanical check still green (`node scripts/check-docs-i18n.mjs`).
- Confirm full local regression passes on the final SHA before marking this Draft PR ready for merge.
