### PR TITLE
fix(booking-copilot): reject numeric revision mismatch before canonical-schema (Refs #473, history #475)

### DIFF
--- a/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
+++ b/ts/scripts/booking-copilot-dsh-planner-proof-tests.ts
@@ -800,6 +800,33 @@ const mixedAuthorityCases: ReadonlyArray<{
     accept: false,
     errorPattern: /planner_revision_mismatch/,
   },
+  {
+    name: 'revision mismatch plus empty actionId',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, actionId: '', expectedRevision: 99 },
+    accept: false,
+    errorPattern: /planner_revision_mismatch/,
+  },
+  {
+    name: 'revision mismatch plus nonstring factRef',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, factRefs: [0], expectedRevision: 99 },
+    accept: false,
+    errorPattern: /planner_revision_mismatch/,
+  },
+  {
+    name: 'revision mismatch plus invalid input',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, expectedRevision: 99, input: { bogus: 1 } },
+    accept: false,
+    errorPattern: /planner_revision_mismatch/,
+  },
+  {
+    name: 'wrong-typed revision repair control',
+    tool: 'booking_search_hotels',
+    badAction: { ...searchRun, expectedRevision: '99', factRefs: ['draft:destination=Dubai'] },
+    accept: true,
+  },
 ]
 for (const [index, c] of mixedAuthorityCases.entries()) {
   const mixedAuthorityPlanner = await createDshEmbeddedBookingPlanner({

--- a/ts/src/booking-surface/dsh-planner.ts
+++ b/ts/src/booking-surface/dsh-planner.ts
@@ -440,6 +440,18 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
       throw new Error('planner_surface_action_unsupported')
     }
   }
+  // The runtime owns the revision: the planner can only echo what the prompt
+  // showed it. Reject a mismatch instead of rewriting model-authored authority;
+  // the client-side concurrency guard also lives at the context/journal binding.
+  // Inspect expectedRevision safely — only a typed number can establish the
+  // mismatch; a wrong-typed or missing revision falls through to schema
+  // validation as a repairable shape error so an unrelated schema failure
+  // (empty actionId / nonstring factRef / closed-input violation) cannot hide
+  // a known numeric revision mismatch behind INVALID_ARGS + later-canonical
+  // shape repair.
+  if (typeof decision.action.expectedRevision === 'number' && decision.action.expectedRevision !== task.revision) {
+    throw new Error('planner_revision_mismatch')
+  }
   const validation = validateBookingReadAction(decision.action)
   if (!validation.ok) {
     invalidDecisionLog('action_schema_invalid', {
@@ -449,14 +461,6 @@ function parseToolDecision(event: unknown, task: BookingCopilotTaskState): Booki
       errorCount: validation.errors.length,
     })
     throw new Error('planner_invalid_action')
-  }
-  // The runtime owns the revision: the planner can only echo what the prompt
-  // showed it. Reject a mismatch instead of rewriting model-authored authority;
-  // the client-side concurrency guard also lives at the context/journal binding.
-  // Inspect expectedRevision safely — only a typed number can establish the
-  // mismatch; a wrong-typed revision was already rejected by schema validation.
-  if (typeof decision.action.expectedRevision === 'number' && decision.action.expectedRevision !== task.revision) {
-    throw new Error('planner_revision_mismatch')
   }
   const action = decision.action as unknown as BookingReadAction
   assertPlannerSafeRefs(decision.action)


### PR DESCRIPTION
TODO: retain the integration hold while #142 real inventory and recovery acceptance is outstanding.

Reject a known numeric revision mismatch before unrelated action-schema failures, so an empty action ID or non-string fact reference cannot make that conflict repairable. Missing or wrong-typed revisions still follow the existing schema-correction path. Four cases extend the existing planner proof table; only two files change.

Root validation at `6ae5f3f566afe79cc3cac41d2eaca349ab604bb6`: ten local checks including full regression exit 0; the ten-case independent adversarial probe exits 0. Full regression ran 2026-09-13 07:19:29–07:31:07 UTC. Both the source and independent review worktrees are clean. Independent Sol static review found no code blocker. [Public root review](https://github.com/Danceiny/gotry/pull/476#pullrequestreview-5190055549).

E2E: real local DSH subprocess and isolated ledger/HTTP fixtures. Real supplier UAT remains #142. References #473; follow-up to merged #475. Documentation consolidation is tracked separately in #474.
