### PR TITLE
fix(check-doc-readability): normalize CRLF/CR and exercise space+tab closer (Refs #479, after #480)

### DIFF
--- a/scripts/check-doc-readability.mjs
+++ b/scripts/check-doc-readability.mjs
@@ -105,7 +105,8 @@ function stripFenceState(lines) {
 }
 
 function markdownStats(text) {
-  const lines = text.split('\n');
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const lines = normalized.split('\n');
   const visible = stripFenceState(lines);
   const headings = [];
   for (let i = 0; i < visible.length; i++) {
@@ -421,7 +422,9 @@ function runSelfTest() {
     rmSync(baselineDir, { recursive: true, force: true });
   }
 
+  let cliFixtureCount = 0;
   function runCheckViaCli(overrides) {
+    cliFixtureCount++;
     const dir = mkdtempSync(join(tmpdir(), 'gotry-doc-readability-cli-'));
     try {
       writeFixture(dir, overrides);
@@ -546,6 +549,24 @@ function runSelfTest() {
     'README.zh-CN.md': '# GoTry\n\n## 速览\n\n紧凑读者入口。\n\n~~~markdown\n## 修订记录\n~~~\n',
   });
 
+  // CRLF/CR line endings are normalized to LF before line scanning (CommonMark 0.31.2 §6.3).
+  expectFailViaCli('CRLF backtick closer; real heading after valid closer is visible',
+    { 'docs/roadmap.md': '# GoTry Roadmap\r\n\r\n## TL;DR\r\n\r\n```markdown\r\n## Revision History\r\n```\r\n\r\n## Revision History\r\n\r\n- Old state.\r\n' },
+    ['docs/roadmap.md:9'], 'revision/change-history section belongs in git and release notes');
+
+  expectFailViaCli('CRLF tilde closer; real heading after valid closer is visible',
+    { 'docs/roadmap.md': '# GoTry Roadmap\r\n\r\n## TL;DR\r\n\r\n~~~markdown\r\n## Revision History\r\n~~~\r\n\r\n## Revision History\r\n\r\n- Old state.\r\n' },
+    ['docs/roadmap.md:9'], 'revision/change-history section belongs in git and release notes');
+
+  expectFailViaCli('bare CR closer; real heading after valid closer is visible',
+    { 'docs/roadmap.md': '# GoTry Roadmap\r\r## TL;DR\r\r```markdown\r## Revision History\r```\r\r## Revision History\r\r- Old state.\r' },
+    ['docs/roadmap.md:9'], 'revision/change-history section belongs in git and release notes');
+
+  // CommonMark §4.5 allows both ASCII space and tab between closing marker and end of line.
+  expectFailViaCli('closer with both ASCII space and tab closes fence; real heading after',
+    { 'docs/roadmap.md': '# GoTry Roadmap\n\n## TL;DR\n\n```markdown\n## Revision History\n``` \t\n## Revision History\n\n- Old state.\n' },
+    ['docs/roadmap.md:8'], 'revision/change-history section belongs in git and release notes');
+
   const cases = [
     {
       name: 'line budget',
@@ -603,7 +624,7 @@ function runSelfTest() {
       rmSync(dir, { recursive: true, force: true });
     }
   }
-  console.log(`DOC READABILITY SELF-TEST OK: ${cases.length} surface-budget negatives + ${'21'} fence/i18n CLI fixtures passed`);
+  console.log(`DOC READABILITY SELF-TEST OK: ${cases.length} surface-budget negatives + ${cliFixtureCount} fence/i18n CLI fixtures passed`);
 }
 
 if (process.argv.includes('--self-test')) {

--- a/scripts/check-doc-readability.mjs
+++ b/scripts/check-doc-readability.mjs
@@ -549,7 +549,7 @@ function runSelfTest() {
     'README.zh-CN.md': '# GoTry\n\n## 速览\n\n紧凑读者入口。\n\n~~~markdown\n## 修订记录\n~~~\n',
   });
 
-  // CRLF/CR line endings are normalized to LF before line scanning (CommonMark 0.31.2 §6.3).
+  // CRLF line endings are normalized to LF before line scanning (CommonMark 0.31.2 §2.1).
   expectFailViaCli('CRLF backtick closer; real heading after valid closer is visible',
     { 'docs/roadmap.md': '# GoTry Roadmap\r\n\r\n## TL;DR\r\n\r\n```markdown\r\n## Revision History\r\n```\r\n\r\n## Revision History\r\n\r\n- Old state.\r\n' },
     ['docs/roadmap.md:9'], 'revision/change-history section belongs in git and release notes');
@@ -566,6 +566,13 @@ function runSelfTest() {
   expectFailViaCli('closer with both ASCII space and tab closes fence; real heading after',
     { 'docs/roadmap.md': '# GoTry Roadmap\n\n## TL;DR\n\n```markdown\n## Revision History\n``` \t\n## Revision History\n\n- Old state.\n' },
     ['docs/roadmap.md:8'], 'revision/change-history section belongs in git and release notes');
+
+  // Positive CRLF cases: whole-document CRLF fence with the forbidden heading ONLY INSIDE.
+  // A parser that incorrectly reports both the inside and an outside heading would still exit 1.
+  for (const [name, marker] of [['backtick', '```'], ['tilde', '~~~']]) {
+    expectPassViaCli(`whole-document CRLF ${name} fence with forbidden heading only inside`,
+      { 'docs/roadmap.md': `# GoTry Roadmap\r\n\r\n## TL;DR\r\n\r\n${marker}markdown\r\n## Revision History\r\n${marker}\r\n` });
+  }
 
   const cases = [
     {


### PR DESCRIPTION
## Summary

- Normalize CRLF and bare CR to LF inside `markdownStats` before the line split, so a CRLF/CR closer no longer leaves a trailing `\r` that prevents the tightened CommonMark opener regex from matching (CommonMark §4.5 and §6.3 treat CR, LF, and CRLF as equivalent line terminators). Existing line-number diagnostics stay accurate for the LF baseline and now also cover CRLF and bare-CR inputs.
- Promote four additional actual-CLI fixtures to the self-test:
  - CRLF backtick closer; real heading after valid closer must trip.
  - CRLF tilde closer; real heading after valid closer must trip.
  - Bare CR closer; real heading after valid closer must trip.
  - Closer followed by both ASCII space and tab still closes the fence (CommonMark §4.5); the next real `## Revision History` must trip the guard. This pins the regression that PR #480 closed, now covered durably.
- Replace the hardcoded `21` in the self-test summary log with a counter derived from actual `runCheckViaCli` invocations, so the message tracks future fixture additions without manual edits.

## Scope

- Only `scripts/check-doc-readability.mjs` is touched in this PR (single file, +23/-2).
- No parser refactors, no unrelated tests, no fixtures outside the existing self-test style.

## Verification

Focused run on new SHA `b135b6bd04e77b9e743366b4fdcab3a5eb8e02a6` (full suite is owned by the root loop on the new SHA):

- `node scripts/check-doc-readability.mjs` — exit 0, 8 reader-facing files within calibrated budgets.
- `node scripts/check-doc-readability.mjs --self-test` — exit 0, `8 surface-budget negatives + 24 fence/i18n CLI fixtures passed`.
- `node scripts/check-docs-i18n.mjs` — exit 0.
- `node scripts/run-all-tests-wiring-tests.mjs` — exit 0.
- `bash -n scripts/run-all-tests.sh` — exit 0.
- `git diff --check` — exit 0.

## Related

- Refs #479
- Incremental after merged #480 (`1d937be`).